### PR TITLE
[#4] Add MIT License to `@nxlv/python` Package

### DIFF
--- a/packages/nx-python/CHANGELOG.md
+++ b/packages/nx-python/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## [15.0.1] - 2023-01-10
+
+### Fixed
+
+- Added license to `@nxlv/python` package json.
+
 ## [15.0.0] - 2023-01-09
 
 ### BREAKING CHANGES

--- a/packages/nx-python/package.json
+++ b/packages/nx-python/package.json
@@ -1,10 +1,11 @@
 {
   "name": "@nxlv/python",
   "description": "Custom NX Plugin to support the Python language",
-  "version": "15.0.0",
+  "version": "15.0.1",
   "main": "src/index.js",
   "generators": "./generators.json",
   "executors": "./executors.json",
+  "license": "MIT",
   "repository": {
     "type": "git",
     "url": "git@github.com:lucasvieirasilva/nx-plugins.git"


### PR DESCRIPTION
This PR adds the MIT license to the `@nxlv/python` package.json file.