### PR TITLE
feat(nx-python): added support for git dependencies

### DIFF
--- a/packages/nx-python/src/executors/build/executor.ts
+++ b/packages/nx-python/src/executors/build/executor.ts
@@ -29,6 +29,8 @@ type Dependency = {
   markers?: string;
   optional: boolean;
   extras?: string[];
+  git?: string;
+  rev?: string;
 };
 
 type PoetryLockPackage = {
@@ -40,7 +42,9 @@ type PoetryLockPackage = {
     [key: string]: PyprojectTomlDependency;
   };
   source?: {
-    type: string;
+    type: 'git' | 'directory' | 'file' | 'url';
+    url?: string;
+    reference?: string;
   };
 };
 
@@ -158,12 +162,14 @@ function resolveLockedDependencies(
 }
 
 function parseToPyprojectDependency(dep: Dependency): PyprojectTomlDependency {
-  if (dep.markers || dep.optional || dep.extras) {
+  if (dep.markers || dep.optional || dep.extras || dep.git) {
     return {
       version: dep.version,
       markers: dep.markers,
       optional: dep.optional,
       extras: dep.extras,
+      git: dep.git,
+      rev: dep.rev,
     };
   } else {
     return dep.version;
@@ -196,24 +202,41 @@ function resolveDependencies(
     if (line.trim()) {
       const dep = {} as Dependency;
       const elements = line.split(';');
+
+      if (elements.length > 1) {
+        dep.markers = elements[1].trim();
+      }
+
       if (elements[0].includes('@')) {
         const atPosition = elements[0].indexOf('@');
         const packageName = elements[0].substring(0, atPosition).trim();
-        const localDepUrl = elements[0].substring(atPosition + 1).trim();
-        const rootFolder = relative(workspaceRoot, uri2path(localDepUrl));
-        const pyprojectToml = join(rootFolder, 'pyproject.toml');
-        const tomlData = parse(
-          readFileSync(pyprojectToml).toString('utf-8')
-        ) as PyprojectToml;
-        logger.info(
-          chalk`${tab}• Adding {blue.bold ${packageName}} local dependency`
-        );
-        includeDependencyPackage(
-          tomlData,
-          rootFolder,
-          buildFolderPath,
-          buildTomlData
-        );
+        const location = elements[0].substring(atPosition + 1).trim();
+
+        dep.name = packageName;
+        resolvePackageExtras(dep);
+
+        const lockedPkg = getLockedPackage(lockData, dep.name);
+
+        switch (lockedPkg.source.type) {
+          case 'directory':
+            includeDirectoryDependency(
+              location,
+              workspaceRoot,
+              tab,
+              packageName,
+              buildFolderPath,
+              buildTomlData
+            );
+            break;
+          case 'git':
+            includeGitDependency(tab, lockedPkg, dep, deps);
+            break;
+          default:
+            throw new Error(
+              `Unsupported source type: ${lockedPkg.source.type}`
+            );
+        }
+
         continue;
       }
 
@@ -224,18 +247,7 @@ function resolveDependencies(
       );
       resolvePackageExtras(dep);
 
-      if (elements.length > 1) {
-        dep.markers = elements[1].trim();
-      }
-
-      const lockedPkg = lockData.package.find(
-        (pkg) => pkg.name.toLowerCase() === dep.name.toLowerCase()
-      );
-      if (!lockedPkg) {
-        throw new Error(
-          chalk`Package {blue.bold ${dep.name}} not found in poetry.lock`
-        );
-      }
+      const lockedPkg = getLockedPackage(lockData, dep.name);
 
       dep.optional = lockedPkg.optional;
       deps.push(dep);
@@ -264,6 +276,62 @@ function resolveDependencies(
   }
 
   return deps;
+}
+
+function getLockedPackage(lockData: PoetryLock, packageName: string) {
+  const lockedPkg = lockData.package.find(
+    (pkg) => pkg.name.toLowerCase() === packageName.toLowerCase()
+  );
+  if (!lockedPkg) {
+    throw new Error(
+      chalk`Package {blue.bold ${packageName.toLowerCase()}} not found in poetry.lock`
+    );
+  }
+  return lockedPkg;
+}
+
+function includeGitDependency(
+  tab: string,
+  lockedPkg: PoetryLockPackage,
+  dep: Dependency,
+  deps: Dependency[]
+) {
+  dep.git = lockedPkg.source.url;
+  dep.optional = lockedPkg.optional;
+
+  if (lockedPkg.source.reference !== 'HEAD') {
+    dep.rev = lockedPkg.source.reference;
+  }
+
+  logger.info(
+    chalk`${tab}• Adding {blue.bold ${dep.name}==${dep.git}@${lockedPkg.source.reference}} dependency`
+  );
+
+  deps.push(dep);
+}
+
+function includeDirectoryDependency(
+  localDepUrl: string,
+  workspaceRoot: string,
+  tab: string,
+  packageName: string,
+  buildFolderPath: string,
+  buildTomlData: PyprojectToml
+) {
+  const rootFolder = relative(workspaceRoot, uri2path(localDepUrl));
+  const pyprojectToml = join(rootFolder, 'pyproject.toml');
+  const tomlData = parse(
+    readFileSync(pyprojectToml).toString('utf-8')
+  ) as PyprojectToml;
+  logger.info(
+    chalk`${tab}• Adding {blue.bold ${packageName}} local dependency`
+  );
+  includeDependencyPackage(
+    tomlData,
+    rootFolder,
+    buildFolderPath,
+    buildTomlData
+  );
 }
 
 function getProjectRequirementsTxt(

--- a/packages/nx-python/src/graph/dependency-graph.ts
+++ b/packages/nx-python/src/graph/dependency-graph.ts
@@ -20,6 +20,8 @@ export type PyprojectTomlDependency =
       optional?: boolean;
       extras?: string[];
       develop?: boolean;
+      git?: string;
+      rev?: string;
     };
 
 export type PyprojectTomlDependencies = {


### PR DESCRIPTION
Added support for git dependencies

## Current Behavior

Currently, only standard and `directory` package sources are supported by the `@nxlv/python` plugin.

## Expected Behavior

Build and bundle git dependencies correctly.

Terminal output 
```text
> nx run lib1:build


  Building project  lib1 ...

  Copying project files to a temporary folder
  Resolving dependencies...
    • Adding argon2-cffi-bindings==21.2.0  dependency
    • Adding argon2-cffi==21.3.0  dependency
    • Adding asgiref==3.6.0  dependency
    • Adding backports-zoneinfo==0.2.1  dependency
    • Adding cffi==1.15.1  dependency
    • Adding django==https://github.com/django/django.git@d54717118360e8679aa2bd0c5a1625f3e84712ba dependency
    • Adding numpy==1.24.1  dependency
    • Adding pycparser==2.21  dependency
    • Adding sqlparse==0.4.3  dependency
    • Adding tzdata==2022.7  dependency
  Generating sdist and wheel artifacts
Running command: poetry build at /var/folders/bw/g7dt139130s8vnyw5941r5hc0000gn/T/nx-python/build/244a4443-f965-440a-8162-d02328d9670e folder

Building pymonorepo-lib1 (1.0.0)
  - Building sdist
  - Built pymonorepo_lib1-1.0.0.tar.gz
  - Building wheel
  - Built pymonorepo_lib1-1.0.0-py3-none-any.whl
  Artifacts generated at packages/lib1/dist folder

 ————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————

 >  NX   Successfully ran target build for project lib1 (2s)
```

## Related Issue(s)

- Fixes #20
