### PR TITLE
feat(nx-python): follow all groups with dep graph

### DIFF
--- a/packages/nx-python/src/graph/dependency-graph.spec.ts
+++ b/packages/nx-python/src/graph/dependency-graph.spec.ts
@@ -118,6 +118,190 @@ describe('nx-python dependency graph', () => {
     });
   });
 
+  it('should link dev dependencies in the graph', async () => {
+    fsMock({
+      'apps/app1/pyproject.toml': dedent`
+      [tool.poetry]
+      name = "app1"
+      version = "1.0.0"
+        [tool.poetry.group.dev.dependencies]
+        python = "^3.8"
+        dep1 = { path = "../../libs/dep1" }
+      `,
+
+      'libs/dep1/pyproject.toml': dedent`
+      [tool.poetry]
+      name = "dep1"
+      version = "1.0.0"
+        [tool.poetry.dependencies]
+        python = "^3.8"
+      `,
+    });
+
+    const mockBuilder = new ProjectGraphBuilder(null);
+
+    mockBuilder.addNode({
+      name: 'app1',
+      type: 'app',
+      data: {
+        root: 'apps/app1',
+        files: [],
+      },
+    });
+
+    mockBuilder.addNode({
+      name: 'dep1',
+      type: 'lib',
+      data: {
+        root: 'libs/dep1',
+        files: [],
+      },
+    });
+
+    const result = processProjectGraph(mockBuilder.graph, {
+      fileMap: {},
+      filesToProcess: {},
+      workspace: {
+        projects: {
+          app1: {
+            root: 'apps/app1',
+            targets: {},
+          },
+          dep1: {
+            root: 'libs/dep1',
+            targets: {},
+          },
+        },
+        version: 2,
+        npmScope: 'test',
+      },
+    });
+
+    expect(result).toStrictEqual({
+      dependencies: {
+        app1: [
+          {
+            source: 'app1',
+            target: 'dep1',
+            type: 'implicit',
+          },
+        ],
+        dep1: [],
+      },
+      externalNodes: {},
+      nodes: {
+        app1: {
+          name: 'app1',
+          type: 'app',
+          data: {
+            root: 'apps/app1',
+            files: [],
+          },
+        },
+        dep1: {
+          name: 'dep1',
+          type: 'lib',
+          data: {
+            root: 'libs/dep1',
+            files: [],
+          },
+        },
+      },
+    });
+  });
+
+  it('should link arbitrary groups dependencies in the graph', async () => {
+    fsMock({
+      'apps/app1/pyproject.toml': dedent`
+      [tool.poetry]
+      name = "app1"
+      version = "1.0.0"
+        [tool.poetry.group.example_group.dependencies]
+        python = "^3.8"
+        dep1 = { path = "../../libs/dep1" }
+      `,
+
+      'libs/dep1/pyproject.toml': dedent`
+      [tool.poetry]
+      name = "dep1"
+      version = "1.0.0"
+        [tool.poetry.dependencies]
+        python = "^3.8"
+      `,
+    });
+
+    const mockBuilder = new ProjectGraphBuilder(null);
+
+    mockBuilder.addNode({
+      name: 'app1',
+      type: 'app',
+      data: {
+        root: 'apps/app1',
+        files: [],
+      },
+    });
+
+    mockBuilder.addNode({
+      name: 'dep1',
+      type: 'lib',
+      data: {
+        root: 'libs/dep1',
+        files: [],
+      },
+    });
+
+    const result = processProjectGraph(mockBuilder.graph, {
+      fileMap: {},
+      filesToProcess: {},
+      workspace: {
+        projects: {
+          app1: {
+            root: 'apps/app1',
+            targets: {},
+          },
+          dep1: {
+            root: 'libs/dep1',
+            targets: {},
+          },
+        },
+        version: 2,
+        npmScope: 'test',
+      },
+    });
+
+    expect(result).toStrictEqual({
+      dependencies: {
+        app1: [
+          {
+            source: 'app1',
+            target: 'dep1',
+            type: 'implicit',
+          },
+        ],
+        dep1: [],
+      },
+      externalNodes: {},
+      nodes: {
+        app1: {
+          name: 'app1',
+          type: 'app',
+          data: {
+            root: 'apps/app1',
+            files: [],
+          },
+        },
+        dep1: {
+          name: 'dep1',
+          type: 'lib',
+          data: {
+            root: 'libs/dep1',
+            files: [],
+          },
+        },
+      },
+    });
+  });
+
   it('should progress the dependency graph for an empty project', async () => {
     const result = processProjectGraph(null, {
       fileMap: {},


### PR DESCRIPTION
Ensures that the dependency graph follows all arbitrary pip dependency groups.

## Current Behavior

Currently the dependency graph only respects the main depdencies and the dev dependency group. This expands it to support any arbitrary groups like poetry supports. e.g. `tool.poetry.group.example_group.dependencies`

## Expected Behavior

Any dependencies added to custom groups appear in the dependency graph.

## Related Issue(s)

None

