### PR TITLE
feat(nx-python): adds support for custom dependency sources

### DIFF
--- a/packages/nx-python/README.md
+++ b/packages/nx-python/README.md
@@ -350,6 +350,33 @@ To identify if the package is publishable, the executor checks `project.json` fi
 
 If the `publish` option is set to `false` and the `--bundleLocalDependencies=false` option is used, the executor will bundle the package.
 
+###### Custom source specification
+
+In addition when adding dependencies in this way its also possible to configure a custom source for a package. This works similar to the `publish` option in that its specified on the target dependencies build options. To use this set the `customSourceName` and `customSourceUrl` to valid values for the source to retrieve the package from for each package stored on a custom Pypi.
+
+`project.json` example:
+
+```json
+{
+  ...
+  "targets": {
+    ...
+    "build": {
+      "executor": "@nxlv/python:build",
+      "outputs": ["apps/myapp/dist"],
+      "options": {
+        "outputPath": "apps/myapp/dist",
+        "publish": false,
+        "customSourceName": "example",
+        "customSourceUrl": "http://example.com/"
+      }
+    },
+  }
+}
+```
+
+Alternatively its also possible to configured it within the `nx.json` as `targetDefaults` across the whole repository.
+
 #### flake8
 
 The `@nxlv/python:flake8` handles the `flake8` linting tasks and reporting generator.

--- a/packages/nx-python/src/executors/build/executor.ts
+++ b/packages/nx-python/src/executors/build/executor.ts
@@ -131,7 +131,7 @@ export default async function executor(
 }
 
 function parseToPyprojectDependency(dep: Dependency): PyprojectTomlDependency {
-  if (dep.markers || dep.optional || dep.extras || dep.git) {
+  if (dep.markers || dep.optional || dep.extras || dep.git || dep.source) {
     return {
       version: dep.version,
       markers: dep.markers,
@@ -139,6 +139,7 @@ function parseToPyprojectDependency(dep: Dependency): PyprojectTomlDependency {
       extras: dep.extras,
       git: dep.git,
       rev: dep.rev,
+      source: dep.source,
     };
   } else {
     return dep.version;

--- a/packages/nx-python/src/executors/build/resolvers/types.ts
+++ b/packages/nx-python/src/executors/build/resolvers/types.ts
@@ -8,6 +8,7 @@ export type Dependency = {
   extras?: string[];
   git?: string;
   rev?: string;
+  source?: string;
 };
 
 export type PoetryLockPackage = {

--- a/packages/nx-python/src/executors/build/schema.d.ts
+++ b/packages/nx-python/src/executors/build/schema.d.ts
@@ -6,4 +6,7 @@ export interface BuildExecutorSchema {
   devDependencies: boolean;
   lockedVersions: boolean;
   bundleLocalDependencies: boolean;
+  customSourceName?: string;
+  customSourceUrl?: string;
+  publish?: boolean;
 }

--- a/packages/nx-python/src/executors/build/schema.json
+++ b/packages/nx-python/src/executors/build/schema.json
@@ -41,6 +41,15 @@
       "type": "boolean",
       "description": "Bundle local dependencies",
       "default": true
+    },
+    "customSourceName": {
+      "type": "string",
+      "description": "Name for the custom source URL",
+      "default": "private"
+    },
+    "customSourceUrl": {
+      "type": "string",
+      "description": "URL for the custom source"
     }
   },
   "required": ["outputPath"]

--- a/packages/nx-python/src/graph/dependency-graph.ts
+++ b/packages/nx-python/src/graph/dependency-graph.ts
@@ -22,6 +22,7 @@ export type PyprojectTomlDependency =
       develop?: boolean;
       git?: string;
       rev?: string;
+      source?: string;
     };
 
 export type PyprojectTomlDependencies = {
@@ -31,6 +32,11 @@ export type PyprojectTomlDependencies = {
 export type Dependency = {
   name: string;
   category: string;
+};
+
+export type PyprojectTomlSource = {
+  name: string;
+  url: string;
 };
 
 export type PyprojectToml = {
@@ -55,6 +61,7 @@ export type PyprojectToml = {
           [key: string]: string;
         };
       };
+      source?: PyprojectTomlSource[];
     };
   };
 };


### PR DESCRIPTION
<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior

Custom sources are not supported all packages will be specified as if they are in the default pypi configured on a consumers machine.

## Expected Behavior

Custom sources can be specified and are injected into the build `pyproject.toml` as required by the `customSourceName` and `customSourceUrl` values specified within the build target options of a given project.

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #40 
