### PR TITLE
fix(nx-python): replace rmSync to fs-extra removeSync and add fs-extra as a dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
         "command-exists": "^1.2.9",
         "cross-spawn": "^7.0.3",
         "file-uri-to-path": "^2.0.0",
+        "fs-extra": "^11.1.0",
         "tslib": "^2.3.0",
         "uuid": "^9.0.0"
       },
@@ -38,6 +39,7 @@
         "@swc/cli": "~0.1.61",
         "@swc/core": "^1.3.26",
         "@types/cross-spawn": "^6.0.2",
+        "@types/fs-extra": "^11.0.1",
         "@types/jest": "28.1.1",
         "@types/node": "18.13.0",
         "@typescript-eslint/eslint-plugin": "^5.52.0",
@@ -2197,20 +2199,6 @@
         "node": ">=v14"
       }
     },
-    "node_modules/@commitlint/read/node_modules/fs-extra": {
-      "version": "11.1.0",
-      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.1.0.tgz",
-      "integrity": "sha512-0rcTq621PD5jM/e0a3EJoGC/1TC5ZBCERW82LQuwfGnCa1V8w7dpYH1yNu+SLb6E5dkeCBzKEyLGlFrnr+dUyw==",
-      "dev": true,
-      "dependencies": {
-        "graceful-fs": "^4.2.0",
-        "jsonfile": "^6.0.1",
-        "universalify": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=14.14"
-      }
-    },
     "node_modules/@commitlint/resolve-extends": {
       "version": "17.4.4",
       "resolved": "https://registry.npmjs.org/@commitlint/resolve-extends/-/resolve-extends-17.4.4.tgz",
@@ -3176,20 +3164,6 @@
         "tslib": "^2.3.0"
       }
     },
-    "node_modules/@nrwl/js/node_modules/fs-extra": {
-      "version": "11.1.0",
-      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.1.0.tgz",
-      "integrity": "sha512-0rcTq621PD5jM/e0a3EJoGC/1TC5ZBCERW82LQuwfGnCa1V8w7dpYH1yNu+SLb6E5dkeCBzKEyLGlFrnr+dUyw==",
-      "dev": true,
-      "dependencies": {
-        "graceful-fs": "^4.2.0",
-        "jsonfile": "^6.0.1",
-        "universalify": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=14.14"
-      }
-    },
     "node_modules/@nrwl/linter": {
       "version": "15.7.2",
       "resolved": "https://registry.npmjs.org/@nrwl/linter/-/linter-15.7.2.tgz",
@@ -3335,20 +3309,6 @@
         "dotenv": "~10.0.0",
         "fs-extra": "^11.1.0",
         "tslib": "^2.3.0"
-      }
-    },
-    "node_modules/@nrwl/nx-plugin/node_modules/fs-extra": {
-      "version": "11.1.0",
-      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.1.0.tgz",
-      "integrity": "sha512-0rcTq621PD5jM/e0a3EJoGC/1TC5ZBCERW82LQuwfGnCa1V8w7dpYH1yNu+SLb6E5dkeCBzKEyLGlFrnr+dUyw==",
-      "dev": true,
-      "dependencies": {
-        "graceful-fs": "^4.2.0",
-        "jsonfile": "^6.0.1",
-        "universalify": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=14.14"
       }
     },
     "node_modules/@nrwl/nx-win32-arm64-msvc": {
@@ -3649,20 +3609,6 @@
         "node": ">=14.17"
       }
     },
-    "node_modules/@semantic-release/changelog/node_modules/fs-extra": {
-      "version": "11.1.0",
-      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.1.0.tgz",
-      "integrity": "sha512-0rcTq621PD5jM/e0a3EJoGC/1TC5ZBCERW82LQuwfGnCa1V8w7dpYH1yNu+SLb6E5dkeCBzKEyLGlFrnr+dUyw==",
-      "dev": true,
-      "dependencies": {
-        "graceful-fs": "^4.2.0",
-        "jsonfile": "^6.0.1",
-        "universalify": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=14.14"
-      }
-    },
     "node_modules/@semantic-release/commit-analyzer": {
       "version": "9.0.2",
       "resolved": "https://registry.npmjs.org/@semantic-release/commit-analyzer/-/commit-analyzer-9.0.2.tgz",
@@ -3789,20 +3735,6 @@
         "node": ">=14.17"
       }
     },
-    "node_modules/@semantic-release/github/node_modules/fs-extra": {
-      "version": "11.1.0",
-      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.1.0.tgz",
-      "integrity": "sha512-0rcTq621PD5jM/e0a3EJoGC/1TC5ZBCERW82LQuwfGnCa1V8w7dpYH1yNu+SLb6E5dkeCBzKEyLGlFrnr+dUyw==",
-      "dev": true,
-      "dependencies": {
-        "graceful-fs": "^4.2.0",
-        "jsonfile": "^6.0.1",
-        "universalify": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=14.14"
-      }
-    },
     "node_modules/@semantic-release/npm": {
       "version": "9.0.1",
       "resolved": "https://registry.npmjs.org/@semantic-release/npm/-/npm-9.0.1.tgz",
@@ -3837,6 +3769,20 @@
       "dev": true,
       "engines": {
         "node": ">=14.17"
+      }
+    },
+    "node_modules/@semantic-release/npm/node_modules/fs-extra": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.1.0.tgz",
+      "integrity": "sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ==",
+      "dev": true,
+      "dependencies": {
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^6.0.1",
+        "universalify": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/@semantic-release/npm/node_modules/read-pkg": {
@@ -4430,6 +4376,16 @@
         "@types/node": "*"
       }
     },
+    "node_modules/@types/fs-extra": {
+      "version": "11.0.1",
+      "resolved": "https://registry.npmjs.org/@types/fs-extra/-/fs-extra-11.0.1.tgz",
+      "integrity": "sha512-MxObHvNl4A69ofaTRU8DFqvgzzv8s9yRtaPPm5gud9HDNvpB3GPQFvNuTWAI59B9huVGV5jXYJwbCsmBsOGYWA==",
+      "dev": true,
+      "dependencies": {
+        "@types/jsonfile": "*",
+        "@types/node": "*"
+      }
+    },
     "node_modules/@types/graceful-fs": {
       "version": "4.1.6",
       "resolved": "https://registry.npmjs.org/@types/graceful-fs/-/graceful-fs-4.1.6.tgz",
@@ -4575,6 +4531,15 @@
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.11.tgz",
       "integrity": "sha512-wOuvG1SN4Us4rez+tylwwwCV1psiNVOkJeM3AUWUNWg/jDQY2+HE/444y5gc+jBmRqASOm2Oeh5c1axHobwRKQ==",
       "dev": true
+    },
+    "node_modules/@types/jsonfile": {
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/@types/jsonfile/-/jsonfile-6.1.1.tgz",
+      "integrity": "sha512-GSgiRCVeapDN+3pqA35IkQwasaCh/0YFH5dEF6S88iDvEn901DjOeH3/QPY+XYP1DFzDZPvIvfeEgk+7br5png==",
+      "dev": true,
+      "dependencies": {
+        "@types/node": "*"
+      }
     },
     "node_modules/@types/keyv": {
       "version": "3.1.4",
@@ -8377,17 +8342,16 @@
       "dev": true
     },
     "node_modules/fs-extra": {
-      "version": "10.1.0",
-      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.1.0.tgz",
-      "integrity": "sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ==",
-      "dev": true,
+      "version": "11.1.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.1.0.tgz",
+      "integrity": "sha512-0rcTq621PD5jM/e0a3EJoGC/1TC5ZBCERW82LQuwfGnCa1V8w7dpYH1yNu+SLb6E5dkeCBzKEyLGlFrnr+dUyw==",
       "dependencies": {
         "graceful-fs": "^4.2.0",
         "jsonfile": "^6.0.1",
         "universalify": "^2.0.0"
       },
       "engines": {
-        "node": ">=12"
+        "node": ">=14.14"
       }
     },
     "node_modules/fs.realpath": {
@@ -8770,8 +8734,7 @@
     "node_modules/graceful-fs": {
       "version": "4.2.10",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.10.tgz",
-      "integrity": "sha512-9ByhssR2fPVsNZj478qUUbKfmL0+t5BDVyjShtyZZLiK7ZDAArFFfopyOTj0M05wE2tJPisA4iTnnXl2YoPvOA==",
-      "dev": true
+      "integrity": "sha512-9ByhssR2fPVsNZj478qUUbKfmL0+t5BDVyjShtyZZLiK7ZDAArFFfopyOTj0M05wE2tJPisA4iTnnXl2YoPvOA=="
     },
     "node_modules/grapheme-splitter": {
       "version": "1.0.4",
@@ -10848,7 +10811,6 @@
       "version": "6.1.0",
       "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz",
       "integrity": "sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==",
-      "dev": true,
       "dependencies": {
         "universalify": "^2.0.0"
       },
@@ -14804,20 +14766,6 @@
         }
       }
     },
-    "node_modules/nx/node_modules/fs-extra": {
-      "version": "11.1.0",
-      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.1.0.tgz",
-      "integrity": "sha512-0rcTq621PD5jM/e0a3EJoGC/1TC5ZBCERW82LQuwfGnCa1V8w7dpYH1yNu+SLb6E5dkeCBzKEyLGlFrnr+dUyw==",
-      "dev": true,
-      "dependencies": {
-        "graceful-fs": "^4.2.0",
-        "jsonfile": "^6.0.1",
-        "universalify": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=14.14"
-      }
-    },
     "node_modules/nx/node_modules/lines-and-columns": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-2.0.3.tgz",
@@ -18257,7 +18205,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.0.tgz",
       "integrity": "sha512-hAZsKq7Yy11Zu1DE0OzWjw7nnLZmJZYTDZZyEFHZdUhV8FkH5MCfoU1XMaxXovpyW5nq5scPqq0ZDP9Zyl04oQ==",
-      "dev": true,
       "engines": {
         "node": ">= 10.0.0"
       }
@@ -20195,19 +20142,6 @@
         "fs-extra": "^11.0.0",
         "git-raw-commits": "^2.0.0",
         "minimist": "^1.2.6"
-      },
-      "dependencies": {
-        "fs-extra": {
-          "version": "11.1.0",
-          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.1.0.tgz",
-          "integrity": "sha512-0rcTq621PD5jM/e0a3EJoGC/1TC5ZBCERW82LQuwfGnCa1V8w7dpYH1yNu+SLb6E5dkeCBzKEyLGlFrnr+dUyw==",
-          "dev": true,
-          "requires": {
-            "graceful-fs": "^4.2.0",
-            "jsonfile": "^6.0.1",
-            "universalify": "^2.0.0"
-          }
-        }
       }
     },
     "@commitlint/resolve-extends": {
@@ -20977,19 +20911,6 @@
         "source-map-support": "0.5.19",
         "tree-kill": "1.2.2",
         "tslib": "^2.3.0"
-      },
-      "dependencies": {
-        "fs-extra": {
-          "version": "11.1.0",
-          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.1.0.tgz",
-          "integrity": "sha512-0rcTq621PD5jM/e0a3EJoGC/1TC5ZBCERW82LQuwfGnCa1V8w7dpYH1yNu+SLb6E5dkeCBzKEyLGlFrnr+dUyw==",
-          "dev": true,
-          "requires": {
-            "graceful-fs": "^4.2.0",
-            "jsonfile": "^6.0.1",
-            "universalify": "^2.0.0"
-          }
-        }
       }
     },
     "@nrwl/linter": {
@@ -21066,19 +20987,6 @@
         "dotenv": "~10.0.0",
         "fs-extra": "^11.1.0",
         "tslib": "^2.3.0"
-      },
-      "dependencies": {
-        "fs-extra": {
-          "version": "11.1.0",
-          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.1.0.tgz",
-          "integrity": "sha512-0rcTq621PD5jM/e0a3EJoGC/1TC5ZBCERW82LQuwfGnCa1V8w7dpYH1yNu+SLb6E5dkeCBzKEyLGlFrnr+dUyw==",
-          "dev": true,
-          "requires": {
-            "graceful-fs": "^4.2.0",
-            "jsonfile": "^6.0.1",
-            "universalify": "^2.0.0"
-          }
-        }
       }
     },
     "@nrwl/nx-win32-arm64-msvc": {
@@ -21294,17 +21202,6 @@
           "resolved": "https://registry.npmjs.org/@semantic-release/error/-/error-3.0.0.tgz",
           "integrity": "sha512-5hiM4Un+tpl4cKw3lV4UgzJj+SmfNIDCLLw0TepzQxz9ZGV5ixnqkzIVF+3tp0ZHgcMKE+VNGHJjEeyFG2dcSw==",
           "dev": true
-        },
-        "fs-extra": {
-          "version": "11.1.0",
-          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.1.0.tgz",
-          "integrity": "sha512-0rcTq621PD5jM/e0a3EJoGC/1TC5ZBCERW82LQuwfGnCa1V8w7dpYH1yNu+SLb6E5dkeCBzKEyLGlFrnr+dUyw==",
-          "dev": true,
-          "requires": {
-            "graceful-fs": "^4.2.0",
-            "jsonfile": "^6.0.1",
-            "universalify": "^2.0.0"
-          }
         }
       }
     },
@@ -21404,17 +21301,6 @@
           "resolved": "https://registry.npmjs.org/@semantic-release/error/-/error-3.0.0.tgz",
           "integrity": "sha512-5hiM4Un+tpl4cKw3lV4UgzJj+SmfNIDCLLw0TepzQxz9ZGV5ixnqkzIVF+3tp0ZHgcMKE+VNGHJjEeyFG2dcSw==",
           "dev": true
-        },
-        "fs-extra": {
-          "version": "11.1.0",
-          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.1.0.tgz",
-          "integrity": "sha512-0rcTq621PD5jM/e0a3EJoGC/1TC5ZBCERW82LQuwfGnCa1V8w7dpYH1yNu+SLb6E5dkeCBzKEyLGlFrnr+dUyw==",
-          "dev": true,
-          "requires": {
-            "graceful-fs": "^4.2.0",
-            "jsonfile": "^6.0.1",
-            "universalify": "^2.0.0"
-          }
         }
       }
     },
@@ -21444,6 +21330,17 @@
           "resolved": "https://registry.npmjs.org/@semantic-release/error/-/error-3.0.0.tgz",
           "integrity": "sha512-5hiM4Un+tpl4cKw3lV4UgzJj+SmfNIDCLLw0TepzQxz9ZGV5ixnqkzIVF+3tp0ZHgcMKE+VNGHJjEeyFG2dcSw==",
           "dev": true
+        },
+        "fs-extra": {
+          "version": "10.1.0",
+          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.1.0.tgz",
+          "integrity": "sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ==",
+          "dev": true,
+          "requires": {
+            "graceful-fs": "^4.2.0",
+            "jsonfile": "^6.0.1",
+            "universalify": "^2.0.0"
+          }
         },
         "read-pkg": {
           "version": "5.2.0",
@@ -21854,6 +21751,16 @@
         "@types/node": "*"
       }
     },
+    "@types/fs-extra": {
+      "version": "11.0.1",
+      "resolved": "https://registry.npmjs.org/@types/fs-extra/-/fs-extra-11.0.1.tgz",
+      "integrity": "sha512-MxObHvNl4A69ofaTRU8DFqvgzzv8s9yRtaPPm5gud9HDNvpB3GPQFvNuTWAI59B9huVGV5jXYJwbCsmBsOGYWA==",
+      "dev": true,
+      "requires": {
+        "@types/jsonfile": "*",
+        "@types/node": "*"
+      }
+    },
     "@types/graceful-fs": {
       "version": "4.1.6",
       "resolved": "https://registry.npmjs.org/@types/graceful-fs/-/graceful-fs-4.1.6.tgz",
@@ -21980,6 +21887,15 @@
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.11.tgz",
       "integrity": "sha512-wOuvG1SN4Us4rez+tylwwwCV1psiNVOkJeM3AUWUNWg/jDQY2+HE/444y5gc+jBmRqASOm2Oeh5c1axHobwRKQ==",
       "dev": true
+    },
+    "@types/jsonfile": {
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/@types/jsonfile/-/jsonfile-6.1.1.tgz",
+      "integrity": "sha512-GSgiRCVeapDN+3pqA35IkQwasaCh/0YFH5dEF6S88iDvEn901DjOeH3/QPY+XYP1DFzDZPvIvfeEgk+7br5png==",
+      "dev": true,
+      "requires": {
+        "@types/node": "*"
+      }
     },
     "@types/keyv": {
       "version": "3.1.4",
@@ -24807,10 +24723,9 @@
       "dev": true
     },
     "fs-extra": {
-      "version": "10.1.0",
-      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.1.0.tgz",
-      "integrity": "sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ==",
-      "dev": true,
+      "version": "11.1.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.1.0.tgz",
+      "integrity": "sha512-0rcTq621PD5jM/e0a3EJoGC/1TC5ZBCERW82LQuwfGnCa1V8w7dpYH1yNu+SLb6E5dkeCBzKEyLGlFrnr+dUyw==",
       "requires": {
         "graceful-fs": "^4.2.0",
         "jsonfile": "^6.0.1",
@@ -25129,8 +25044,7 @@
     "graceful-fs": {
       "version": "4.2.10",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.10.tgz",
-      "integrity": "sha512-9ByhssR2fPVsNZj478qUUbKfmL0+t5BDVyjShtyZZLiK7ZDAArFFfopyOTj0M05wE2tJPisA4iTnnXl2YoPvOA==",
-      "dev": true
+      "integrity": "sha512-9ByhssR2fPVsNZj478qUUbKfmL0+t5BDVyjShtyZZLiK7ZDAArFFfopyOTj0M05wE2tJPisA4iTnnXl2YoPvOA=="
     },
     "grapheme-splitter": {
       "version": "1.0.4",
@@ -26731,7 +26645,6 @@
       "version": "6.1.0",
       "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz",
       "integrity": "sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==",
-      "dev": true,
       "requires": {
         "graceful-fs": "^4.1.6",
         "universalify": "^2.0.0"
@@ -29585,17 +29498,6 @@
         "yargs-parser": "21.1.1"
       },
       "dependencies": {
-        "fs-extra": {
-          "version": "11.1.0",
-          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.1.0.tgz",
-          "integrity": "sha512-0rcTq621PD5jM/e0a3EJoGC/1TC5ZBCERW82LQuwfGnCa1V8w7dpYH1yNu+SLb6E5dkeCBzKEyLGlFrnr+dUyw==",
-          "dev": true,
-          "requires": {
-            "graceful-fs": "^4.2.0",
-            "jsonfile": "^6.0.1",
-            "universalify": "^2.0.0"
-          }
-        },
         "lines-and-columns": {
           "version": "2.0.3",
           "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-2.0.3.tgz",
@@ -32105,8 +32007,7 @@
     "universalify": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.0.tgz",
-      "integrity": "sha512-hAZsKq7Yy11Zu1DE0OzWjw7nnLZmJZYTDZZyEFHZdUhV8FkH5MCfoU1XMaxXovpyW5nq5scPqq0ZDP9Zyl04oQ==",
-      "dev": true
+      "integrity": "sha512-hAZsKq7Yy11Zu1DE0OzWjw7nnLZmJZYTDZZyEFHZdUhV8FkH5MCfoU1XMaxXovpyW5nq5scPqq0ZDP9Zyl04oQ=="
     },
     "update-browserslist-db": {
       "version": "1.0.10",

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "@swc/cli": "~0.1.61",
     "@swc/core": "^1.3.26",
     "@types/cross-spawn": "^6.0.2",
+    "@types/fs-extra": "^11.0.1",
     "@types/jest": "28.1.1",
     "@types/node": "18.13.0",
     "@typescript-eslint/eslint-plugin": "^5.52.0",
@@ -57,6 +58,7 @@
     "command-exists": "^1.2.9",
     "cross-spawn": "^7.0.3",
     "file-uri-to-path": "^2.0.0",
+    "fs-extra": "^11.1.0",
     "tslib": "^2.3.0",
     "uuid": "^9.0.0"
   },

--- a/packages/nx-python/src/executors/build/executor.ts
+++ b/packages/nx-python/src/executors/build/executor.ts
@@ -6,7 +6,7 @@ import {
   readFileSync,
   writeFileSync,
   mkdirSync,
-  rmSync,
+  removeSync,
 } from 'fs-extra';
 import { join } from 'path';
 import {
@@ -60,9 +60,7 @@ export default async function executor(
       if (!options.ignorePaths.includes(file)) {
         const source = join(root, file);
         const target = join(buildFolderPath, file);
-        copySync(source, target, {
-          recursive: true,
-        });
+        copySync(source, target);
       }
     });
 
@@ -102,13 +100,13 @@ export default async function executor(
     writeFileSync(buildPyProjectToml, stringify(buildTomlData));
     const distFolder = join(buildFolderPath, 'dist');
 
-    rmSync(distFolder, { recursive: true, force: true });
+    removeSync(distFolder);
 
     logger.info(chalk`  Generating sdist and wheel artifacts`);
     const buildArgs = ['build'];
     runPoetry(buildArgs, { cwd: buildFolderPath });
 
-    rmSync(options.outputPath, { recursive: true, force: true });
+    removeSync(options.outputPath);
     mkdirSync(options.outputPath, { recursive: true });
     logger.info(
       chalk`  Artifacts generated at {bold ${options.outputPath}} folder`
@@ -116,7 +114,7 @@ export default async function executor(
     copySync(distFolder, options.outputPath);
 
     if (!options.keepBuildFolder) {
-      rmSync(buildFolderPath, { recursive: true, force: true });
+      removeSync(buildFolderPath);
     }
 
     return {

--- a/packages/nx-python/src/executors/build/resolvers/utils.ts
+++ b/packages/nx-python/src/executors/build/resolvers/utils.ts
@@ -12,7 +12,7 @@ export function includeDependencyPackage(
     const pkgFolder = join(root, pkg.include);
     const buildPackageFolder = join(buildFolderPath, pkg.include);
 
-    copySync(pkgFolder, buildPackageFolder, { recursive: true });
+    copySync(pkgFolder, buildPackageFolder);
 
     buildTomlData.tool.poetry.packages.push({
       include: pkg.include,

--- a/packages/nx-python/src/executors/sls-deploy/executor.ts
+++ b/packages/nx-python/src/executors/sls-deploy/executor.ts
@@ -4,7 +4,7 @@ import spawn from 'cross-spawn';
 import { Logger } from '../utils/logger';
 import { ExecutorSchema } from './schema';
 import path from 'path';
-import { existsSync, readdirSync, writeFileSync, rmSync } from 'fs-extra';
+import { existsSync, readdirSync, writeFileSync, removeSync } from 'fs-extra';
 
 const logger = new Logger();
 
@@ -61,6 +61,6 @@ export default async function executor(
       success: false,
     };
   } finally {
-    rmSync(requirementsTxt, { recursive: true, force: true });
+    removeSync(requirementsTxt);
   }
 }

--- a/packages/nx-python/src/executors/sls-package/executor.ts
+++ b/packages/nx-python/src/executors/sls-package/executor.ts
@@ -4,7 +4,7 @@ import spawn from 'cross-spawn';
 import { Logger } from '../utils/logger';
 import { ExecutorSchema } from './schema';
 import path from 'path';
-import { existsSync, readdirSync, writeFileSync, rmSync } from 'fs-extra';
+import { existsSync, readdirSync, writeFileSync, removeSync } from 'fs-extra';
 
 const logger = new Logger();
 
@@ -59,6 +59,6 @@ export default async function executor(
       success: false,
     };
   } finally {
-    rmSync(requirementsTxt, { recursive: true, force: true });
+    removeSync(requirementsTxt);
   }
 }


### PR DESCRIPTION
## Current Behavior

Currently, the `nx-python` project uses `fs-extra` without referencing it as a dependency, and pretty much the project uses a mix of `fs` and `fs-extra`, example: the `rmSync` should be replaced by `removeSync`.

## Expected Behavior

Added `fs-extra` as a dependency and replaced all `rmSync` with `removeSync`.

I've tested all the operations, and all look good.

## Related Issue(s)

Fixes #53
