### PR TITLE
fix(nx-python): fix the dependency graph when there are Python projects not managed by the `@nxlv/python`

### DIFF
--- a/packages/nx-python/src/graph/dependency-graph.spec.ts
+++ b/packages/nx-python/src/graph/dependency-graph.spec.ts
@@ -58,33 +58,35 @@ describe('nx-python dependency graph', () => {
       },
     });
 
+    const projects = {
+      app1: {
+        root: 'apps/app1',
+        targets: {},
+      },
+      dep1: {
+        root: 'libs/dep1',
+        targets: {},
+      },
+      dep2: {
+        root: 'libs/dep2',
+        targets: {},
+      },
+      dep3: {
+        root: 'libs/dep3',
+        targets: {},
+      },
+    };
+
     const result = processProjectGraph(mockBuilder.graph, {
       projectsConfigurations: {
-        projects: {},
+        projects,
         version: 2,
       },
       nxJsonConfiguration: {},
       fileMap: {},
       filesToProcess: {},
       workspace: {
-        projects: {
-          app1: {
-            root: 'apps/app1',
-            targets: {},
-          },
-          dep1: {
-            root: 'libs/dep1',
-            targets: {},
-          },
-          dep2: {
-            root: 'libs/dep2',
-            targets: {},
-          },
-          dep3: {
-            root: 'libs/dep3',
-            targets: {},
-          },
-        },
+        projects,
         version: 2,
         npmScope: 'test',
       },
@@ -162,25 +164,27 @@ describe('nx-python dependency graph', () => {
       },
     });
 
+    const projects = {
+      app1: {
+        root: 'apps/app1',
+        targets: {},
+      },
+      dep1: {
+        root: 'libs/dep1',
+        targets: {},
+      },
+    };
+
     const result = processProjectGraph(mockBuilder.graph, {
       projectsConfigurations: {
-        projects: {},
+        projects,
         version: 2,
       },
       nxJsonConfiguration: {},
       fileMap: {},
       filesToProcess: {},
       workspace: {
-        projects: {
-          app1: {
-            root: 'apps/app1',
-            targets: {},
-          },
-          dep1: {
-            root: 'libs/dep1',
-            targets: {},
-          },
-        },
+        projects,
         version: 2,
         npmScope: 'test',
       },
@@ -258,25 +262,27 @@ describe('nx-python dependency graph', () => {
       },
     });
 
+    const projects = {
+      app1: {
+        root: 'apps/app1',
+        targets: {},
+      },
+      dep1: {
+        root: 'libs/dep1',
+        targets: {},
+      },
+    };
+
     const result = processProjectGraph(mockBuilder.graph, {
       projectsConfigurations: {
-        projects: {},
+        projects,
         version: 2,
       },
       nxJsonConfiguration: {},
       fileMap: {},
       filesToProcess: {},
       workspace: {
-        projects: {
-          app1: {
-            root: 'apps/app1',
-            targets: {},
-          },
-          dep1: {
-            root: 'libs/dep1',
-            targets: {},
-          },
-        },
+        projects,
         version: 2,
         npmScope: 'test',
       },
@@ -334,6 +340,245 @@ describe('nx-python dependency graph', () => {
       dependencies: {},
       externalNodes: {},
       nodes: {},
+    });
+  });
+
+  it('should progress the dependency graph when there is an app that is not managed by @nxlv/python', async () => {
+    fsMock({
+      'apps/app1/pyproject.toml': dedent`
+      [tool.poetry]
+      name = "app1"
+      version = "1.0.0"
+        [tool.poetry.dependencies]
+        python = "^3.8"
+        dep1 = { path = "../../libs/dep1" }
+      `,
+      'apps/app2/pyproject.toml': dedent`
+      [tool.poetry]
+      name = "app1"
+      version = "1.0.0"
+        [tool.poetry.dependencies]
+        python = "^3.8"
+        dep3 = { path = "../../libs/dep3" }
+      `,
+      'libs/dep1/pyproject.toml': dedent`
+      [tool.poetry]
+      name = "dep1"
+      version = "1.0.0"
+        [tool.poetry.dependencies]
+        python = "^3.8"
+      `,
+      'libs/dep2/pyproject.toml': dedent`
+      [tool.poetry]
+      name = "dep2"
+      version = "1.0.0"
+        [tool.poetry.dependencies]
+        python = "^3.8"
+
+        [tool.poetry.group.dev.dependencies]
+        pytest = "6.2.4"
+      `,
+    });
+
+    const mockBuilder = new ProjectGraphBuilder(null);
+
+    mockBuilder.addNode({
+      name: 'app1',
+      type: 'app',
+      data: {
+        root: 'apps/app1',
+        files: [],
+      },
+    });
+
+    mockBuilder.addNode({
+      name: 'dep1',
+      type: 'lib',
+      data: {
+        root: 'libs/dep1',
+        files: [],
+      },
+    });
+
+    const projects = {
+      app1: {
+        root: 'apps/app1',
+        targets: {},
+      },
+      dep1: {
+        root: 'libs/dep1',
+        targets: {},
+      },
+      dep2: {
+        root: 'libs/dep2',
+        targets: {},
+      },
+      dep3: {
+        root: 'libs/dep3',
+        targets: {},
+      },
+    };
+
+    const result = processProjectGraph(mockBuilder.graph, {
+      projectsConfigurations: {
+        projects,
+        version: 2,
+      },
+      nxJsonConfiguration: {},
+      fileMap: {},
+      filesToProcess: {},
+      workspace: {
+        projects,
+        version: 2,
+        npmScope: 'test',
+      },
+    });
+
+    expect(result).toStrictEqual({
+      dependencies: {
+        app1: [
+          {
+            source: 'app1',
+            target: 'dep1',
+            type: 'implicit',
+          },
+        ],
+      },
+      externalNodes: {},
+      nodes: {
+        app1: {
+          name: 'app1',
+          type: 'app',
+          data: {
+            root: 'apps/app1',
+            files: [],
+          },
+        },
+        dep1: {
+          name: 'dep1',
+          type: 'lib',
+          data: {
+            root: 'libs/dep1',
+            files: [],
+          },
+        },
+      },
+    });
+  });
+
+  it('should progress the dependency graph when there is an app with an empty pyproject.toml', async () => {
+    fsMock({
+      'apps/app1/pyproject.toml': dedent`
+      [tool.poetry]
+      name = "app1"
+      version = "1.0.0"
+        [tool.poetry.dependencies]
+        python = "^3.8"
+        dep1 = { path = "../../libs/dep1" }
+      `,
+      'apps/app2/pyproject.toml': '',
+      'libs/dep1/pyproject.toml': dedent`
+      [tool.poetry]
+      name = "dep1"
+      version = "1.0.0"
+        [tool.poetry.dependencies]
+        python = "^3.8"
+      `,
+      'libs/dep2/pyproject.toml': dedent`
+      [tool.poetry]
+      name = "dep2"
+      version = "1.0.0"
+        [tool.poetry.dependencies]
+        python = "^3.8"
+
+        [tool.poetry.group.dev.dependencies]
+        pytest = "6.2.4"
+      `,
+    });
+
+    const mockBuilder = new ProjectGraphBuilder(null);
+
+    mockBuilder.addNode({
+      name: 'app1',
+      type: 'app',
+      data: {
+        root: 'apps/app1',
+        files: [],
+      },
+    });
+
+    mockBuilder.addNode({
+      name: 'dep1',
+      type: 'lib',
+      data: {
+        root: 'libs/dep1',
+        files: [],
+      },
+    });
+
+    const projects = {
+      app1: {
+        root: 'apps/app1',
+        targets: {},
+      },
+      dep1: {
+        root: 'libs/dep1',
+        targets: {},
+      },
+      dep2: {
+        root: 'libs/dep2',
+        targets: {},
+      },
+      dep3: {
+        root: 'libs/dep3',
+        targets: {},
+      },
+    };
+
+    const result = processProjectGraph(mockBuilder.graph, {
+      projectsConfigurations: {
+        projects,
+        version: 2,
+      },
+      nxJsonConfiguration: {},
+      fileMap: {},
+      filesToProcess: {},
+      workspace: {
+        projects,
+        version: 2,
+        npmScope: 'test',
+      },
+    });
+
+    expect(result).toStrictEqual({
+      dependencies: {
+        app1: [
+          {
+            source: 'app1',
+            target: 'dep1',
+            type: 'implicit',
+          },
+        ],
+      },
+      externalNodes: {},
+      nodes: {
+        app1: {
+          name: 'app1',
+          type: 'app',
+          data: {
+            root: 'apps/app1',
+            files: [],
+          },
+        },
+        dep1: {
+          name: 'dep1',
+          type: 'lib',
+          data: {
+            root: 'libs/dep1',
+            files: [],
+          },
+        },
+      },
     });
   });
 });

--- a/packages/nx-python/src/graph/dependency-graph.spec.ts
+++ b/packages/nx-python/src/graph/dependency-graph.spec.ts
@@ -1,4 +1,4 @@
-import { processProjectGraph } from './dependency-graph';
+import { processProjectGraph, getDependents } from './dependency-graph';
 import fsMock from 'mock-fs';
 import { ProjectGraphBuilder } from '@nrwl/devkit';
 import dedent from 'string-dedent';
@@ -8,9 +8,10 @@ describe('nx-python dependency graph', () => {
     fsMock.restore();
   });
 
-  it('should progress the dependency graph', async () => {
-    fsMock({
-      'apps/app1/pyproject.toml': dedent`
+  describe('dependency graph', () => {
+    it('should progress the dependency graph', async () => {
+      fsMock({
+        'apps/app1/pyproject.toml': dedent`
       [tool.poetry]
       name = "app1"
       version = "1.0.0"
@@ -19,14 +20,14 @@ describe('nx-python dependency graph', () => {
         dep1 = { path = "../../libs/dep1" }
       `,
 
-      'libs/dep1/pyproject.toml': dedent`
+        'libs/dep1/pyproject.toml': dedent`
       [tool.poetry]
       name = "dep1"
       version = "1.0.0"
         [tool.poetry.dependencies]
         python = "^3.8"
       `,
-      'libs/dep2/pyproject.toml': dedent`
+        'libs/dep2/pyproject.toml': dedent`
       [tool.poetry]
       name = "dep2"
       version = "1.0.0"
@@ -36,97 +37,97 @@ describe('nx-python dependency graph', () => {
         [tool.poetry.group.dev.dependencies]
         pytest = "6.2.4"
       `,
-    });
+      });
 
-    const mockBuilder = new ProjectGraphBuilder(null);
+      const mockBuilder = new ProjectGraphBuilder(null);
 
-    mockBuilder.addNode({
-      name: 'app1',
-      type: 'app',
-      data: {
-        root: 'apps/app1',
-        files: [],
-      },
-    });
+      mockBuilder.addNode({
+        name: 'app1',
+        type: 'app',
+        data: {
+          root: 'apps/app1',
+          files: [],
+        },
+      });
 
-    mockBuilder.addNode({
-      name: 'dep1',
-      type: 'lib',
-      data: {
-        root: 'libs/dep1',
-        files: [],
-      },
-    });
+      mockBuilder.addNode({
+        name: 'dep1',
+        type: 'lib',
+        data: {
+          root: 'libs/dep1',
+          files: [],
+        },
+      });
 
-    const projects = {
-      app1: {
-        root: 'apps/app1',
-        targets: {},
-      },
-      dep1: {
-        root: 'libs/dep1',
-        targets: {},
-      },
-      dep2: {
-        root: 'libs/dep2',
-        targets: {},
-      },
-      dep3: {
-        root: 'libs/dep3',
-        targets: {},
-      },
-    };
-
-    const result = processProjectGraph(mockBuilder.graph, {
-      projectsConfigurations: {
-        projects,
-        version: 2,
-      },
-      nxJsonConfiguration: {},
-      fileMap: {},
-      filesToProcess: {},
-      workspace: {
-        projects,
-        version: 2,
-        npmScope: 'test',
-      },
-    });
-
-    expect(result).toStrictEqual({
-      dependencies: {
-        app1: [
-          {
-            source: 'app1',
-            target: 'dep1',
-            type: 'implicit',
-          },
-        ],
-      },
-      externalNodes: {},
-      nodes: {
+      const projects = {
         app1: {
-          name: 'app1',
-          type: 'app',
-          data: {
-            root: 'apps/app1',
-            files: [],
-          },
+          root: 'apps/app1',
+          targets: {},
         },
         dep1: {
-          name: 'dep1',
-          type: 'lib',
-          data: {
-            root: 'libs/dep1',
-            files: [],
+          root: 'libs/dep1',
+          targets: {},
+        },
+        dep2: {
+          root: 'libs/dep2',
+          targets: {},
+        },
+        dep3: {
+          root: 'libs/dep3',
+          targets: {},
+        },
+      };
+
+      const result = processProjectGraph(mockBuilder.graph, {
+        projectsConfigurations: {
+          projects,
+          version: 2,
+        },
+        nxJsonConfiguration: {},
+        fileMap: {},
+        filesToProcess: {},
+        workspace: {
+          projects,
+          version: 2,
+          npmScope: 'test',
+        },
+      });
+
+      expect(result).toStrictEqual({
+        dependencies: {
+          app1: [
+            {
+              source: 'app1',
+              target: 'dep1',
+              type: 'implicit',
+            },
+          ],
+        },
+        externalNodes: {},
+        nodes: {
+          app1: {
+            name: 'app1',
+            type: 'app',
+            data: {
+              root: 'apps/app1',
+              files: [],
+            },
+          },
+          dep1: {
+            name: 'dep1',
+            type: 'lib',
+            data: {
+              root: 'libs/dep1',
+              files: [],
+            },
           },
         },
-      },
+      });
     });
-  });
 
-  it('should link dev dependencies in the graph', async () => {
-    fsMock({
-      'apps/app1/pyproject.toml': dedent`
+    it('should link dev dependencies in the graph', async () => {
+      fsMock({
+        'apps/app1/pyproject.toml': dedent`
       [tool.poetry]
       name = "app1"
       version = "1.0.0"
@@ -135,96 +136,96 @@ describe('nx-python dependency graph', () => {
         dep1 = { path = "../../libs/dep1" }
       `,
 
-      'libs/dep1/pyproject.toml': dedent`
+        'libs/dep1/pyproject.toml': dedent`
       [tool.poetry]
       name = "dep1"
       version = "1.0.0"
         [tool.poetry.dependencies]
         python = "^3.8"
       `,
-    });
+      });
 
-    const mockBuilder = new ProjectGraphBuilder(null);
+      const mockBuilder = new ProjectGraphBuilder(null);
 
-    mockBuilder.addNode({
-      name: 'app1',
-      type: 'app',
-      data: {
-        root: 'apps/app1',
-        files: [],
-      },
-    });
+      mockBuilder.addNode({
+        name: 'app1',
+        type: 'app',
+        data: {
+          root: 'apps/app1',
+          files: [],
+        },
+      });
 
-    mockBuilder.addNode({
-      name: 'dep1',
-      type: 'lib',
-      data: {
-        root: 'libs/dep1',
-        files: [],
-      },
-    });
+      mockBuilder.addNode({
+        name: 'dep1',
+        type: 'lib',
+        data: {
+          root: 'libs/dep1',
+          files: [],
+        },
+      });
 
-    const projects = {
-      app1: {
-        root: 'apps/app1',
-        targets: {},
-      },
-      dep1: {
-        root: 'libs/dep1',
-        targets: {},
-      },
-    };
-
-    const result = processProjectGraph(mockBuilder.graph, {
-      projectsConfigurations: {
-        projects,
-        version: 2,
-      },
-      nxJsonConfiguration: {},
-      fileMap: {},
-      filesToProcess: {},
-      workspace: {
-        projects,
-        version: 2,
-        npmScope: 'test',
-      },
-    });
-
-    expect(result).toStrictEqual({
-      dependencies: {
-        app1: [
-          {
-            source: 'app1',
-            target: 'dep1',
-            type: 'implicit',
-          },
-        ],
-      },
-      externalNodes: {},
-      nodes: {
+      const projects = {
         app1: {
-          name: 'app1',
-          type: 'app',
-          data: {
-            root: 'apps/app1',
-            files: [],
-          },
+          root: 'apps/app1',
+          targets: {},
         },
         dep1: {
-          name: 'dep1',
-          type: 'lib',
-          data: {
-            root: 'libs/dep1',
-            files: [],
+          root: 'libs/dep1',
+          targets: {},
+        },
+      };
+
+      const result = processProjectGraph(mockBuilder.graph, {
+        projectsConfigurations: {
+          projects,
+          version: 2,
+        },
+        nxJsonConfiguration: {},
+        fileMap: {},
+        filesToProcess: {},
+        workspace: {
+          projects,
+          version: 2,
+          npmScope: 'test',
+        },
+      });
+
+      expect(result).toStrictEqual({
+        dependencies: {
+          app1: [
+            {
+              source: 'app1',
+              target: 'dep1',
+              type: 'implicit',
+            },
+          ],
+        },
+        externalNodes: {},
+        nodes: {
+          app1: {
+            name: 'app1',
+            type: 'app',
+            data: {
+              root: 'apps/app1',
+              files: [],
+            },
+          },
+          dep1: {
+            name: 'dep1',
+            type: 'lib',
+            data: {
+              root: 'libs/dep1',
+              files: [],
+            },
           },
         },
-      },
+      });
     });
-  });
 
-  it('should link arbitrary groups dependencies in the graph', async () => {
-    fsMock({
-      'apps/app1/pyproject.toml': dedent`
+    it('should link arbitrary groups dependencies in the graph', async () => {
+      fsMock({
+        'apps/app1/pyproject.toml': dedent`
       [tool.poetry]
       name = "app1"
       version = "1.0.0"
@@ -233,119 +234,119 @@ describe('nx-python dependency graph', () => {
         dep1 = { path = "../../libs/dep1" }
       `,
 
-      'libs/dep1/pyproject.toml': dedent`
+        'libs/dep1/pyproject.toml': dedent`
       [tool.poetry]
       name = "dep1"
       version = "1.0.0"
         [tool.poetry.dependencies]
         python = "^3.8"
       `,
-    });
+      });
 
-    const mockBuilder = new ProjectGraphBuilder(null);
+      const mockBuilder = new ProjectGraphBuilder(null);
 
-    mockBuilder.addNode({
-      name: 'app1',
-      type: 'app',
-      data: {
-        root: 'apps/app1',
-        files: [],
-      },
-    });
+      mockBuilder.addNode({
+        name: 'app1',
+        type: 'app',
+        data: {
+          root: 'apps/app1',
+          files: [],
+        },
+      });
 
-    mockBuilder.addNode({
-      name: 'dep1',
-      type: 'lib',
-      data: {
-        root: 'libs/dep1',
-        files: [],
-      },
-    });
+      mockBuilder.addNode({
+        name: 'dep1',
+        type: 'lib',
+        data: {
+          root: 'libs/dep1',
+          files: [],
+        },
+      });
 
-    const projects = {
-      app1: {
-        root: 'apps/app1',
-        targets: {},
-      },
-      dep1: {
-        root: 'libs/dep1',
-        targets: {},
-      },
-    };
-
-    const result = processProjectGraph(mockBuilder.graph, {
-      projectsConfigurations: {
-        projects,
-        version: 2,
-      },
-      nxJsonConfiguration: {},
-      fileMap: {},
-      filesToProcess: {},
-      workspace: {
-        projects,
-        version: 2,
-        npmScope: 'test',
-      },
-    });
-
-    expect(result).toStrictEqual({
-      dependencies: {
-        app1: [
-          {
-            source: 'app1',
-            target: 'dep1',
-            type: 'implicit',
-          },
-        ],
-      },
-      externalNodes: {},
-      nodes: {
+      const projects = {
         app1: {
-          name: 'app1',
-          type: 'app',
-          data: {
-            root: 'apps/app1',
-            files: [],
-          },
+          root: 'apps/app1',
+          targets: {},
         },
         dep1: {
-          name: 'dep1',
-          type: 'lib',
-          data: {
-            root: 'libs/dep1',
-            files: [],
+          root: 'libs/dep1',
+          targets: {},
+        },
+      };
+
+      const result = processProjectGraph(mockBuilder.graph, {
+        projectsConfigurations: {
+          projects,
+          version: 2,
+        },
+        nxJsonConfiguration: {},
+        fileMap: {},
+        filesToProcess: {},
+        workspace: {
+          projects,
+          version: 2,
+          npmScope: 'test',
+        },
+      });
+
+      expect(result).toStrictEqual({
+        dependencies: {
+          app1: [
+            {
+              source: 'app1',
+              target: 'dep1',
+              type: 'implicit',
+            },
+          ],
+        },
+        externalNodes: {},
+        nodes: {
+          app1: {
+            name: 'app1',
+            type: 'app',
+            data: {
+              root: 'apps/app1',
+              files: [],
+            },
+          },
+          dep1: {
+            name: 'dep1',
+            type: 'lib',
+            data: {
+              root: 'libs/dep1',
+              files: [],
+            },
           },
         },
-      },
-    });
-  });
-
-  it('should progress the dependency graph for an empty project', async () => {
-    const result = processProjectGraph(null, {
-      projectsConfigurations: {
-        projects: {},
-        version: 2,
-      },
-      nxJsonConfiguration: {},
-      fileMap: {},
-      filesToProcess: {},
-      workspace: {
-        projects: {},
-        version: 2,
-        npmScope: 'test',
-      },
+      });
     });
 
-    expect(result).toStrictEqual({
-      dependencies: {},
-      externalNodes: {},
-      nodes: {},
-    });
-  });
+    it('should progress the dependency graph for an empty project', async () => {
+      const result = processProjectGraph(null, {
+        projectsConfigurations: {
+          projects: {},
+          version: 2,
+        },
+        nxJsonConfiguration: {},
+        fileMap: {},
+        filesToProcess: {},
+        workspace: {
+          projects: {},
+          version: 2,
+          npmScope: 'test',
+        },
+      });
 
-  it('should progress the dependency graph when there is an app that is not managed by @nxlv/python', async () => {
-    fsMock({
-      'apps/app1/pyproject.toml': dedent`
+      expect(result).toStrictEqual({
+        dependencies: {},
+        externalNodes: {},
+        nodes: {},
+      });
+    });
+
+    it('should progress the dependency graph when there is an app that is not managed by @nxlv/python', async () => {
+      fsMock({
+        'apps/app1/pyproject.toml': dedent`
       [tool.poetry]
       name = "app1"
       version = "1.0.0"
@@ -353,22 +354,22 @@ describe('nx-python dependency graph', () => {
         python = "^3.8"
         dep1 = { path = "../../libs/dep1" }
       `,
-      'apps/app2/pyproject.toml': dedent`
+        'apps/app2/pyproject.toml': dedent`
       [tool.poetry]
-      name = "app1"
+      name = "app2"
       version = "1.0.0"
         [tool.poetry.dependencies]
         python = "^3.8"
         dep3 = { path = "../../libs/dep3" }
       `,
-      'libs/dep1/pyproject.toml': dedent`
+        'libs/dep1/pyproject.toml': dedent`
       [tool.poetry]
       name = "dep1"
       version = "1.0.0"
         [tool.poetry.dependencies]
         python = "^3.8"
       `,
-      'libs/dep2/pyproject.toml': dedent`
+        'libs/dep2/pyproject.toml': dedent`
       [tool.poetry]
       name = "dep2"
       version = "1.0.0"
@@ -378,97 +379,114 @@ describe('nx-python dependency graph', () => {
         [tool.poetry.group.dev.dependencies]
         pytest = "6.2.4"
       `,
-    });
+      });
 
-    const mockBuilder = new ProjectGraphBuilder(null);
+      const mockBuilder = new ProjectGraphBuilder(null);
 
-    mockBuilder.addNode({
-      name: 'app1',
-      type: 'app',
-      data: {
-        root: 'apps/app1',
-        files: [],
-      },
-    });
+      mockBuilder.addNode({
+        name: 'app1',
+        type: 'app',
+        data: {
+          root: 'apps/app1',
+          files: [],
+        },
+      });
 
-    mockBuilder.addNode({
-      name: 'dep1',
-      type: 'lib',
-      data: {
-        root: 'libs/dep1',
-        files: [],
-      },
-    });
+      mockBuilder.addNode({
+        name: 'app2',
+        type: 'app',
+        data: {
+          root: 'apps/app2',
+          files: [],
+        },
+      });
 
-    const projects = {
-      app1: {
-        root: 'apps/app1',
-        targets: {},
-      },
-      dep1: {
-        root: 'libs/dep1',
-        targets: {},
-      },
-      dep2: {
-        root: 'libs/dep2',
-        targets: {},
-      },
-      dep3: {
-        root: 'libs/dep3',
-        targets: {},
-      },
-    };
+      mockBuilder.addNode({
+        name: 'dep1',
+        type: 'lib',
+        data: {
+          root: 'libs/dep1',
+          files: [],
+        },
+      });
 
-    const result = processProjectGraph(mockBuilder.graph, {
-      projectsConfigurations: {
-        projects,
-        version: 2,
-      },
-      nxJsonConfiguration: {},
-      fileMap: {},
-      filesToProcess: {},
-      workspace: {
-        projects,
-        version: 2,
-        npmScope: 'test',
-      },
-    });
-
-    expect(result).toStrictEqual({
-      dependencies: {
-        app1: [
-          {
-            source: 'app1',
-            target: 'dep1',
-            type: 'implicit',
-          },
-        ],
-      },
-      externalNodes: {},
-      nodes: {
+      const projects = {
         app1: {
-          name: 'app1',
-          type: 'app',
-          data: {
-            root: 'apps/app1',
-            files: [],
-          },
+          root: 'apps/app1',
+          targets: {},
+        },
+        app2: {
+          root: 'apps/app2',
+          targets: {},
         },
         dep1: {
-          name: 'dep1',
-          type: 'lib',
-          data: {
-            root: 'libs/dep1',
-            files: [],
+          root: 'libs/dep1',
+          targets: {},
+        },
+        dep2: {
+          root: 'libs/dep2',
+          targets: {},
+        },
+      };
+
+      const result = processProjectGraph(mockBuilder.graph, {
+        projectsConfigurations: {
+          projects,
+          version: 2,
+        },
+        nxJsonConfiguration: {},
+        fileMap: {},
+        filesToProcess: {},
+        workspace: {
+          projects,
+          version: 2,
+          npmScope: 'test',
+        },
+      });
+
+      expect(result).toStrictEqual({
+        dependencies: {
+          app1: [
+            {
+              source: 'app1',
+              target: 'dep1',
+              type: 'implicit',
+            },
+          ],
+        },
+        externalNodes: {},
+        nodes: {
+          app1: {
+            name: 'app1',
+            type: 'app',
+            data: {
+              root: 'apps/app1',
+              files: [],
+            },
+          },
+          app2: {
+            name: 'app2',
+            type: 'app',
+            data: {
+              root: 'apps/app2',
+              files: [],
+            },
+          },
+          dep1: {
+            name: 'dep1',
+            type: 'lib',
+            data: {
+              root: 'libs/dep1',
+              files: [],
+            },
           },
         },
-      },
+      });
     });
-  });
 
-  it('should progress the dependency graph when there is an app with an empty pyproject.toml', async () => {
-    fsMock({
-      'apps/app1/pyproject.toml': dedent`
+    it('should progress the dependency graph when there is an app with an empty pyproject.toml', async () => {
+      fsMock({
+        'apps/app1/pyproject.toml': dedent`
       [tool.poetry]
       name = "app1"
       version = "1.0.0"
@@ -476,15 +494,15 @@ describe('nx-python dependency graph', () => {
         python = "^3.8"
         dep1 = { path = "../../libs/dep1" }
       `,
-      'apps/app2/pyproject.toml': '',
-      'libs/dep1/pyproject.toml': dedent`
+        'apps/app2/pyproject.toml': '',
+        'libs/dep1/pyproject.toml': dedent`
       [tool.poetry]
       name = "dep1"
       version = "1.0.0"
         [tool.poetry.dependencies]
         python = "^3.8"
       `,
-      'libs/dep2/pyproject.toml': dedent`
+        'libs/dep2/pyproject.toml': dedent`
       [tool.poetry]
       name = "dep2"
       version = "1.0.0"
@@ -494,91 +512,192 @@ describe('nx-python dependency graph', () => {
         [tool.poetry.group.dev.dependencies]
         pytest = "6.2.4"
       `,
-    });
+      });
 
-    const mockBuilder = new ProjectGraphBuilder(null);
+      const mockBuilder = new ProjectGraphBuilder(null);
 
-    mockBuilder.addNode({
-      name: 'app1',
-      type: 'app',
-      data: {
-        root: 'apps/app1',
-        files: [],
-      },
-    });
+      mockBuilder.addNode({
+        name: 'app1',
+        type: 'app',
+        data: {
+          root: 'apps/app1',
+          files: [],
+        },
+      });
 
-    mockBuilder.addNode({
-      name: 'dep1',
-      type: 'lib',
-      data: {
-        root: 'libs/dep1',
-        files: [],
-      },
-    });
+      mockBuilder.addNode({
+        name: 'app2',
+        type: 'app',
+        data: {
+          root: 'apps/app2',
+          files: [],
+        },
+      });
 
-    const projects = {
-      app1: {
-        root: 'apps/app1',
-        targets: {},
-      },
-      dep1: {
-        root: 'libs/dep1',
-        targets: {},
-      },
-      dep2: {
-        root: 'libs/dep2',
-        targets: {},
-      },
-      dep3: {
-        root: 'libs/dep3',
-        targets: {},
-      },
-    };
+      mockBuilder.addNode({
+        name: 'dep1',
+        type: 'lib',
+        data: {
+          root: 'libs/dep1',
+          files: [],
+        },
+      });
 
-    const result = processProjectGraph(mockBuilder.graph, {
-      projectsConfigurations: {
-        projects,
-        version: 2,
-      },
-      nxJsonConfiguration: {},
-      fileMap: {},
-      filesToProcess: {},
-      workspace: {
-        projects,
-        version: 2,
-        npmScope: 'test',
-      },
-    });
-
-    expect(result).toStrictEqual({
-      dependencies: {
-        app1: [
-          {
-            source: 'app1',
-            target: 'dep1',
-            type: 'implicit',
-          },
-        ],
-      },
-      externalNodes: {},
-      nodes: {
+      const projects = {
         app1: {
-          name: 'app1',
-          type: 'app',
-          data: {
-            root: 'apps/app1',
-            files: [],
-          },
+          root: 'apps/app1',
+          targets: {},
+        },
+        app2: {
+          root: 'apps/app2',
+          targets: {},
         },
         dep1: {
-          name: 'dep1',
-          type: 'lib',
-          data: {
-            root: 'libs/dep1',
-            files: [],
+          root: 'libs/dep1',
+          targets: {},
+        },
+        dep2: {
+          root: 'libs/dep2',
+          targets: {},
+        },
+        dep3: {
+          root: 'libs/dep3',
+          targets: {},
+        },
+      };
+
+      const result = processProjectGraph(mockBuilder.graph, {
+        projectsConfigurations: {
+          projects,
+          version: 2,
+        },
+        nxJsonConfiguration: {},
+        fileMap: {},
+        filesToProcess: {},
+        workspace: {
+          projects,
+          version: 2,
+          npmScope: 'test',
+        },
+      });
+
+      expect(result).toStrictEqual({
+        dependencies: {
+          app1: [
+            {
+              source: 'app1',
+              target: 'dep1',
+              type: 'implicit',
+            },
+          ],
+        },
+        externalNodes: {},
+        nodes: {
+          app1: {
+            name: 'app1',
+            type: 'app',
+            data: {
+              root: 'apps/app1',
+              files: [],
+            },
+          },
+          app2: {
+            name: 'app2',
+            type: 'app',
+            data: {
+              root: 'apps/app2',
+              files: [],
+            },
+          },
+          dep1: {
+            name: 'dep1',
+            type: 'lib',
+            data: {
+              root: 'libs/dep1',
+              files: [],
+            },
           },
         },
-      },
+      });
+    });
+  });
+
+  describe('get dependents', () => {
+    it('should return the dependent projects', () => {
+      fsMock({
+        'apps/app1/pyproject.toml': dedent`
+      [tool.poetry]
+      name = "app1"
+      version = "1.0.0"
+        [tool.poetry.dependencies]
+        python = "^3.8"
+        dep1 = { path = "../../libs/dep1" }
+      `,
+        'libs/dep1/pyproject.toml': dedent`
+      [tool.poetry]
+      name = "dep1"
+      version = "1.0.0"
+        [tool.poetry.dependencies]
+        python = "^3.8"
+      `,
+      });
+
+      const projects = {
+        app1: {
+          root: 'apps/app1',
+          targets: {},
+        },
+        dep1: {
+          root: 'libs/dep1',
+          targets: {},
+        },
+      };
+
+      const result = getDependents(
+        'dep1',
+        {
+          projects,
+          version: 2,
+        },
+        '.'
+      );
+
+      expect(result).toStrictEqual(['app1']);
+    });
+
+    it('should return not throw an error when the pyproject is invalid or empty', () => {
+      fsMock({
+        'apps/app1/pyproject.toml': '',
+        'libs/dep1/pyproject.toml': dedent`
+      [tool.poetry]
+      name = "dep1"
+      version = "1.0.0"
+        [tool.poetry.dependencies]
+        python = "^3.8"
+      `,
+      });
+
+      const projects = {
+        app1: {
+          root: 'apps/app1',
+          targets: {},
+        },
+        dep1: {
+          root: 'libs/dep1',
+          targets: {},
+        },
+      };
+
+      const result = getDependents(
+        'dep1',
+        {
+          projects,
+          version: 2,
+        },
+        '.'
+      );
+
+      expect(result).toStrictEqual([]);
     });
   });
 });

--- a/packages/nx-python/src/graph/dependency-graph.ts
+++ b/packages/nx-python/src/graph/dependency-graph.ts
@@ -97,14 +97,14 @@ export const getDependencies = (
     const tomlData = getPyprojectData(pyprojectToml);
 
     resolveDependencies(
-      tomlData?.tool?.poetry?.dependencies,
+      tomlData.tool?.poetry?.dependencies,
       projectData,
       workspace,
       cwd,
       deps,
       'main'
     );
-    for (const group in tomlData?.tool?.poetry?.group || {}) {
+    for (const group in tomlData.tool?.poetry?.group || {}) {
       resolveDependencies(
         tomlData.tool.poetry.group[group].dependencies,
         projectData,
@@ -153,7 +153,7 @@ const checkProjectIsDependent = (
     const tomlData = getPyprojectData(pyprojectToml);
 
     let isDep = isProjectDependent(
-      tomlData?.tool?.poetry?.dependencies || {},
+      tomlData.tool?.poetry?.dependencies,
       projectData,
       root,
       cwd
@@ -161,7 +161,7 @@ const checkProjectIsDependent = (
 
     if (isDep) return true;
 
-    for (const group in tomlData?.tool?.poetry?.group || {}) {
+    for (const group in tomlData.tool?.poetry?.group || {}) {
       isDep = isProjectDependent(
         tomlData.tool.poetry.group[group].dependencies,
         projectData,


### PR DESCRIPTION
This PR fixes the dependency graph engine when there are Python projects not managed by the `@nxlv/python`

## Current Behavior

As described by @scottanderson42 in this comment https://github.com/lucasvieirasilva/nx-plugins/issues/101#issuecomment-1567423853, when there are other python projects in the same workspace that references local dependencies that are not managed by the `@nxlv/python` the dependency graph fails to calculate the dependencies, which results in a disconnection between the projects managed by `@nxlv/python`,  causing issues related to cache when dependencies are changed.

There is also an issue when the `pyproject.toml` is empty, in this case, the dependency graph also fails to calculate the dependencies.

## Expected Behavior

This PR should handle those scenarios and provide the dependency graph correctly for the projects managed by the `@nxlv/python`.

I've published a beta version for testing this issue: https://www.npmjs.com/package/@nxlv/python/v/15.9.1-beta.1

## Fixes

- #101 