### PR TITLE
feat(nx-python): add support for poetry remove --lock for poetry version >= 1.5.0

### DIFF
--- a/packages/nx-python/src/executors/utils/poetry.spec.ts
+++ b/packages/nx-python/src/executors/utils/poetry.spec.ts
@@ -8,7 +8,7 @@ jest.mock('command-exists', () => {
   };
 });
 
-import { checkPoetryExecutable, runPoetry } from './poetry';
+import { checkPoetryExecutable, runPoetry, getPoetryVersion } from './poetry';
 
 describe('Poetry Utils', () => {
   describe('Check Poetry Executable', () => {
@@ -113,5 +113,25 @@ describe('Poetry Utils', () => {
         stdio: 'inherit',
       });
     });
+  });
+
+  it('should get the poetry CLI version', async () => {
+    spawnSyncMock.mockReturnValueOnce({
+      status: 0,
+      stdout: Buffer.from('Poetry (version 1.5.0)'),
+    });
+
+    const version = await getPoetryVersion();
+
+    expect(version).toEqual('1.5.0');
+
+    spawnSyncMock.mockReturnValueOnce({
+      status: 0,
+      stdout: Buffer.from('\n\nSomething else\n\nPoetry (version 1.2.2)'),
+    });
+
+    const version2 = await getPoetryVersion();
+
+    expect(version2).toEqual('1.2.2');
   });
 });

--- a/packages/nx-python/src/executors/utils/poetry.spec.ts
+++ b/packages/nx-python/src/executors/utils/poetry.spec.ts
@@ -115,23 +115,34 @@ describe('Poetry Utils', () => {
     });
   });
 
-  it('should get the poetry CLI version', async () => {
-    spawnSyncMock.mockReturnValueOnce({
-      status: 0,
-      stdout: Buffer.from('Poetry (version 1.5.0)'),
+  describe('Get Poetry Version', () => {
+    it('should get the poetry CLI version', async () => {
+      spawnSyncMock.mockReturnValueOnce({
+        status: 0,
+        stdout: Buffer.from('Poetry (version 1.5.0)'),
+      });
+
+      const version = await getPoetryVersion();
+
+      expect(version).toEqual('1.5.0');
+
+      spawnSyncMock.mockReturnValueOnce({
+        status: 0,
+        stdout: Buffer.from('\n\nSomething else\n\nPoetry (version 1.2.2)'),
+      });
+
+      const version2 = await getPoetryVersion();
+
+      expect(version2).toEqual('1.2.2');
     });
 
-    const version = await getPoetryVersion();
+    it('should throw an error when the status is not 0', async () => {
+      spawnSyncMock.mockReturnValueOnce({
+        status: 1,
+        error: true,
+      });
 
-    expect(version).toEqual('1.5.0');
-
-    spawnSyncMock.mockReturnValueOnce({
-      status: 0,
-      stdout: Buffer.from('\n\nSomething else\n\nPoetry (version 1.2.2)'),
+      await expect(getPoetryVersion()).rejects.toThrowError();
     });
-
-    const version2 = await getPoetryVersion();
-
-    expect(version2).toEqual('1.2.2');
   });
 });

--- a/packages/nx-python/src/executors/utils/poetry.ts
+++ b/packages/nx-python/src/executors/utils/poetry.ts
@@ -20,6 +20,19 @@ export async function checkPoetryExecutable() {
   }
 }
 
+export async function getPoetryVersion() {
+  const result = spawn.sync(POETRY_EXECUTABLE, ['--version']);
+  if (result.error) {
+    throw new Error(
+      'Poetry is not installed. Please install Poetry before running this command.'
+    );
+  }
+  const versionRegex = /version (\d+\.\d+\.\d+)/;
+  const match = result.stdout.toString().trim().match(versionRegex);
+  const version = match && match[1];
+  return version;
+}
+
 export function addLocalProjectToPoetryProject(
   targetConfig: ProjectConfiguration,
   dependencyConfig: ProjectConfiguration,


### PR DESCRIPTION
This PR adds the `--lock` command as part of the `poetry remove` command for poetry CLI version `1.5.0` or greater.

The `--lock` option in the remove command was added in the poetry `1.5.0` release, so, to make this plugin compatible with older versions, I've created logic to validate the poetry version before using the `--lock` option.

## Current Behavior

Currently, the remove executor always executes `poetry remove <package>`, however, when the shared virtual environment is used all the operations in the poetry sub-projects need to have the `--lock` to avoid applying the changes.

The changes need to be applied when the `@nxlv/python` updates the pyproject in the root.

## Expected Behavior

If the poetry version is `1.5.0` or more and the project uses the shared virtual environment use the `--lock` option when the `remove` executor is called.

Otherwise, it should not use the `--lock` option.

## Related Issue(s)

#116 
