### PR TITLE
fix(nx-python): use poetry lock and poetry install when add/update/remove a package

### DIFF
--- a/packages/nx-python/src/dependency/update-dependency.ts
+++ b/packages/nx-python/src/dependency/update-dependency.ts
@@ -32,7 +32,8 @@ export function updateDependencyTree(context: ExecutorContext) {
         chalk`\nUpdating root {bold pyproject.toml} dependency {bold ${pkgName}}`
       );
 
-      runPoetry(['update', pkgName]);
+      runPoetry(['lock', '--no-update']);
+      runPoetry(['install']);
     }
   }
 }

--- a/packages/nx-python/src/executors/add/executor.spec.ts
+++ b/packages/nx-python/src/executors/add/executor.spec.ts
@@ -1054,12 +1054,16 @@ version = "1.0.0"
     expect(spawnSyncMock).toHaveBeenNthCalledWith(
       2,
       'poetry',
-      ['update', 'app'],
+      ['lock', '--no-update'],
       {
         shell: false,
         stdio: 'inherit',
       }
     );
+    expect(spawnSyncMock).toHaveBeenNthCalledWith(3, 'poetry', ['install'], {
+      shell: false,
+      stdio: 'inherit',
+    });
     expect(output.success).toBe(true);
   });
 });

--- a/packages/nx-python/src/executors/remove/executor.spec.ts
+++ b/packages/nx-python/src/executors/remove/executor.spec.ts
@@ -489,12 +489,16 @@ version = "1.0.0"
     expect(spawnSyncMock).toHaveBeenNthCalledWith(
       2,
       'poetry',
-      ['update', 'app'],
+      ['lock', '--no-update'],
       {
         shell: false,
         stdio: 'inherit',
       }
     );
+    expect(spawnSyncMock).toHaveBeenNthCalledWith(3, 'poetry', ['install'], {
+      shell: false,
+      stdio: 'inherit',
+    });
     expect(output.success).toBe(true);
   });
 
@@ -562,12 +566,16 @@ version = "1.0.0"
     expect(spawnSyncMock).toHaveBeenNthCalledWith(
       2,
       'poetry',
-      ['update', 'app'],
+      ['lock', '--no-update'],
       {
         shell: false,
         stdio: 'inherit',
       }
     );
+    expect(spawnSyncMock).toHaveBeenNthCalledWith(3, 'poetry', ['install'], {
+      shell: false,
+      stdio: 'inherit',
+    });
     expect(output.success).toBe(true);
   });
 });

--- a/packages/nx-python/src/executors/update/executor.spec.ts
+++ b/packages/nx-python/src/executors/update/executor.spec.ts
@@ -641,12 +641,16 @@ version = "1.0.0"
     expect(spawnSyncMock).toHaveBeenNthCalledWith(
       2,
       'poetry',
-      ['update', 'app'],
+      ['lock', '--no-update'],
       {
         shell: false,
         stdio: 'inherit',
       }
     );
+    expect(spawnSyncMock).toHaveBeenNthCalledWith(3, 'poetry', ['install'], {
+      shell: false,
+      stdio: 'inherit',
+    });
     expect(output.success).toBe(true);
   });
 
@@ -752,7 +756,7 @@ version = "1.0.0"
     const output = await executor(options, context);
     expect(checkPoetryExecutableMock).toHaveBeenCalled();
     expect(activateVenvMock).toHaveBeenCalledWith('.');
-    expect(spawnSyncMock).toHaveBeenCalledTimes(5);
+    expect(spawnSyncMock).toHaveBeenCalledTimes(6);
     expect(spawnSyncMock).toHaveBeenNthCalledWith(
       1,
       'poetry',
@@ -796,12 +800,16 @@ version = "1.0.0"
     expect(spawnSyncMock).toHaveBeenNthCalledWith(
       5,
       'poetry',
-      ['update', 'shared1'],
+      ['lock', '--no-update'],
       {
         shell: false,
         stdio: 'inherit',
       }
     );
+    expect(spawnSyncMock).toHaveBeenNthCalledWith(6, 'poetry', ['install'], {
+      shell: false,
+      stdio: 'inherit',
+    });
     expect(output.success).toBe(true);
   });
 });


### PR DESCRIPTION
## Current Behavior

When the workspace is configured to use a shared virtual environment and the `add`, `update`, and `remove` is executed the root lock is being updated using `poetry update [pkgName]`.

The `poetry update` perform more tasks than just updates.

## Expected Behavior

When the workspace is configured to use a shared virtual environment and the `add`, `update`, and `remove` is executed to update the root lock and the virtual environment is run `poetry lock --no-update` and `poetry install`.
