### PR TITLE
fix(nx-python): add tslib explicitly to the package.json using caret

### DIFF
--- a/packages/nx-python/package.json
+++ b/packages/nx-python/package.json
@@ -14,6 +14,9 @@
   "peerDependencies": {
     "@nx/devkit": "^16.0.0"
   },
+  "dependencies": {
+    "tslib": "^2.3.0"
+  },
   "nx-migrations": {
     "migrations": "./migrations.json"
   }


### PR DESCRIPTION
This PR changes the nx-python `package.json` to explicitly use `tslib` with caret.

## Current Behavior

Currently, when the project is built the `tslib` package is added with the static version of the repo's `package-lock.json`

## Expected Behavior

The `tslib` library now is added to the dist `package.json` using `^2.3.0`.

## Related Issue(s)

Fixes #173
