### PR TITLE
fix(nx-python): handle "from" for packages in pyproject.toml during the build process

### DIFF
--- a/packages/nx-python/src/executors/build/resolvers/utils.ts
+++ b/packages/nx-python/src/executors/build/resolvers/utils.ts
@@ -9,7 +9,7 @@ export function includeDependencyPackage(
   buildTomlData: PyprojectToml
 ) {
   for (const pkg of tomlData.tool.poetry.packages) {
-    const pkgFolder = join(root, pkg.include);
+    const pkgFolder = join(root, pkg.from ?? '', pkg.include);
     const buildPackageFolder = join(buildFolderPath, pkg.include);
 
     copySync(pkgFolder, buildPackageFolder);

--- a/packages/nx-python/src/graph/dependency-graph.ts
+++ b/packages/nx-python/src/graph/dependency-graph.ts
@@ -48,6 +48,7 @@ export type PyprojectToml = {
       version: string;
       packages?: Array<{
         include: string;
+        from?: string;
       }>;
       dependencies?: PyprojectTomlDependencies;
       group?: {


### PR DESCRIPTION
## Current Behavior
The build breaks when I depend on a local package with a `src` directory.

## Expected Behavior
If I correctly specify `from="src"` in the local package's `pyproject.toml`, the build should succeed. When using a typical flat package structure, it works fine. i.e. like this
```
../lib
├── pyproject.toml
└── awesome_package/
    └── __init__.py
```

## More Details

I have a package: `my_package`. A snippet of its `pyproject.toml` is here:
```toml
[tool.poetry.dependencies.awsome_package]
path = "../lib"
develop = true
```

The local package that's being referred to has a directory structure like this.
```
../lib
├── pyproject.toml
└── src/
     └── awesome_package/
        └── __init__.py
```

The local package also has this snippet in its `pyproject.toml`

```toml
[[tool.poetry.packages]]
include = "awesome_package"
from = "src"
```

I think it would be correct behavior for the `build` process, i.e. `nx build my_package` to find the `awesome_package` from the `../lib/src` directory.

## Miscellaneous
[src vs. flat layout details](https://packaging.python.org/en/latest/discussions/src-layout-vs-flat-layout/)