### PR TITLE
fix(nx-python): replace poetry update with poetry lock and poetry install when adding a new package

### DIFF
--- a/packages/nx-python/src/dependency/update-dependency.ts
+++ b/packages/nx-python/src/dependency/update-dependency.ts
@@ -65,8 +65,7 @@ export function updateDependents(
     console.log(chalk`\nUpdating project {bold ${dep}}`);
     const depConfig = workspace.projects[dep];
 
-    const pkgName = getProjectPackageName(context, projectName);
-    updateProject(pkgName, depConfig.root, updateLockOnly);
+    updateProject(depConfig.root, updateLockOnly);
 
     updateDependents(
       context,

--- a/packages/nx-python/src/executors/add/executor.spec.ts
+++ b/packages/nx-python/src/executors/add/executor.spec.ts
@@ -422,7 +422,7 @@ version = "1.0.0"
     const output = await executor(options, context);
     expect(checkPoetryExecutableMock).toHaveBeenCalled();
     expect(activateVenvMock).toHaveBeenCalledWith('.');
-    expect(spawn.sync).toHaveBeenCalledTimes(4);
+    expect(spawn.sync).toHaveBeenCalledTimes(7);
     expect(spawn.sync).toHaveBeenNthCalledWith(1, 'poetry', ['add', 'numpy'], {
       cwd: 'libs/shared1',
       shell: false,
@@ -431,33 +431,48 @@ version = "1.0.0"
     expect(spawn.sync).toHaveBeenNthCalledWith(
       2,
       'poetry',
-      ['update', 'shared1'],
+      ['lock', '--no-update'],
       {
         cwd: 'libs/lib1',
         shell: false,
         stdio: 'inherit',
       },
     );
+    expect(spawn.sync).toHaveBeenNthCalledWith(3, 'poetry', ['install'], {
+      cwd: 'libs/lib1',
+      shell: false,
+      stdio: 'inherit',
+    });
     expect(spawn.sync).toHaveBeenNthCalledWith(
-      3,
+      4,
       'poetry',
-      ['update', 'lib1'],
+      ['lock', '--no-update'],
       {
         cwd: 'apps/app',
         shell: false,
         stdio: 'inherit',
       },
     );
+    expect(spawn.sync).toHaveBeenNthCalledWith(5, 'poetry', ['install'], {
+      cwd: 'apps/app',
+      shell: false,
+      stdio: 'inherit',
+    });
     expect(spawn.sync).toHaveBeenNthCalledWith(
-      4,
+      6,
       'poetry',
-      ['update', 'lib1'],
+      ['lock', '--no-update'],
       {
         cwd: 'apps/app1',
         shell: false,
         stdio: 'inherit',
       },
     );
+    expect(spawn.sync).toHaveBeenNthCalledWith(7, 'poetry', ['install'], {
+      cwd: 'apps/app1',
+      shell: false,
+      stdio: 'inherit',
+    });
     expect(output.success).toBe(true);
   });
 
@@ -554,7 +569,7 @@ version = "1.0.0"
     const output = await executor(options, context);
     expect(checkPoetryExecutableMock).toHaveBeenCalled();
     expect(activateVenvMock).toHaveBeenCalledWith('.');
-    expect(spawn.sync).toHaveBeenCalledTimes(4);
+    expect(spawn.sync).toHaveBeenCalledTimes(7);
     expect(spawn.sync).toHaveBeenNthCalledWith(1, 'poetry', ['add', 'numpy'], {
       cwd: 'libs/shared1',
       shell: false,
@@ -563,33 +578,48 @@ version = "1.0.0"
     expect(spawn.sync).toHaveBeenNthCalledWith(
       2,
       'poetry',
-      ['update', 'shared1'],
+      ['lock', '--no-update'],
       {
         cwd: 'libs/lib1',
         shell: false,
         stdio: 'inherit',
       },
     );
+    expect(spawn.sync).toHaveBeenNthCalledWith(3, 'poetry', ['install'], {
+      cwd: 'libs/lib1',
+      shell: false,
+      stdio: 'inherit',
+    });
     expect(spawn.sync).toHaveBeenNthCalledWith(
-      3,
+      4,
       'poetry',
-      ['update', 'lib1'],
+      ['lock', '--no-update'],
       {
         cwd: 'apps/app',
         shell: false,
         stdio: 'inherit',
       },
     );
+    expect(spawn.sync).toHaveBeenNthCalledWith(5, 'poetry', ['install'], {
+      cwd: 'apps/app',
+      shell: false,
+      stdio: 'inherit',
+    });
     expect(spawn.sync).toHaveBeenNthCalledWith(
-      4,
+      6,
       'poetry',
-      ['update', 'lib1'],
+      ['lock', '--no-update'],
       {
         cwd: 'apps/app1',
         shell: false,
         stdio: 'inherit',
       },
     );
+    expect(spawn.sync).toHaveBeenNthCalledWith(7, 'poetry', ['install'], {
+      cwd: 'apps/app1',
+      shell: false,
+      stdio: 'inherit',
+    });
     expect(output.success).toBe(true);
   });
 
@@ -644,17 +674,22 @@ version = "1.0.0"
     const output = await executor(options, context);
     expect(checkPoetryExecutableMock).toHaveBeenCalled();
     expect(activateVenvMock).toHaveBeenCalledWith('.');
-    expect(spawn.sync).toHaveBeenCalledTimes(1);
+    expect(spawn.sync).toHaveBeenCalledTimes(2);
     expect(spawn.sync).toHaveBeenNthCalledWith(
       1,
       'poetry',
-      ['update', 'lib1'],
+      ['lock', '--no-update'],
       {
         cwd: 'apps/app',
         shell: false,
         stdio: 'inherit',
       },
     );
+    expect(spawn.sync).toHaveBeenNthCalledWith(2, 'poetry', ['install'], {
+      cwd: 'apps/app',
+      shell: false,
+      stdio: 'inherit',
+    });
     expect(output.success).toBe(true);
   });
 
@@ -710,17 +745,22 @@ version = "1.0.0"
     const output = await executor(options, context);
     expect(checkPoetryExecutableMock).toHaveBeenCalled();
     expect(activateVenvMock).toHaveBeenCalledWith('.');
-    expect(spawn.sync).toHaveBeenCalledTimes(1);
+    expect(spawn.sync).toHaveBeenCalledTimes(2);
     expect(spawn.sync).toHaveBeenNthCalledWith(
       1,
       'poetry',
-      ['update', 'lib1'],
+      ['lock', '--no-update'],
       {
         cwd: 'apps/app',
         shell: false,
         stdio: 'inherit',
       },
     );
+    expect(spawn.sync).toHaveBeenNthCalledWith(2, 'poetry', ['install'], {
+      cwd: 'apps/app',
+      shell: false,
+      stdio: 'inherit',
+    });
     expect(output.success).toBe(true);
   });
 
@@ -780,17 +820,22 @@ version = "1.0.0"
     const output = await executor(options, context);
     expect(checkPoetryExecutableMock).toHaveBeenCalled();
     expect(activateVenvMock).toHaveBeenCalledWith('.');
-    expect(spawn.sync).toHaveBeenCalledTimes(1);
+    expect(spawn.sync).toHaveBeenCalledTimes(2);
     expect(spawn.sync).toHaveBeenNthCalledWith(
       1,
       'poetry',
-      ['update', 'lib1'],
+      ['lock', '--no-update'],
       {
         cwd: 'apps/app',
         shell: false,
         stdio: 'inherit',
       },
     );
+    expect(spawn.sync).toHaveBeenNthCalledWith(2, 'poetry', ['install'], {
+      cwd: 'apps/app',
+      shell: false,
+      stdio: 'inherit',
+    });
     expect(output.success).toBe(true);
   });
 
@@ -851,17 +896,22 @@ version = "1.0.0"
     const output = await executor(options, context);
     expect(checkPoetryExecutableMock).toHaveBeenCalled();
     expect(activateVenvMock).toHaveBeenCalledWith('.');
-    expect(spawn.sync).toHaveBeenCalledTimes(1);
+    expect(spawn.sync).toHaveBeenCalledTimes(2);
     expect(spawn.sync).toHaveBeenNthCalledWith(
       1,
       'poetry',
-      ['update', 'lib1'],
+      ['lock', '--no-update'],
       {
         cwd: 'apps/app',
         shell: false,
         stdio: 'inherit',
       },
     );
+    expect(spawn.sync).toHaveBeenNthCalledWith(2, 'poetry', ['install'], {
+      cwd: 'apps/app',
+      shell: false,
+      stdio: 'inherit',
+    });
     expect(output.success).toBe(true);
   });
 
@@ -917,17 +967,22 @@ version = "1.0.0"
     expect(output.success).toBe(true);
     expect(checkPoetryExecutableMock).toHaveBeenCalled();
     expect(activateVenvMock).toHaveBeenCalledWith('.');
-    expect(spawn.sync).toHaveBeenCalledTimes(1);
+    expect(spawn.sync).toHaveBeenCalledTimes(2);
     expect(spawn.sync).toHaveBeenNthCalledWith(
       1,
       'poetry',
-      ['update', 'dgx-devops-lib1'],
+      ['lock', '--no-update'],
       {
         cwd: 'apps/app',
         shell: false,
         stdio: 'inherit',
       },
     );
+    expect(spawn.sync).toHaveBeenNthCalledWith(2, 'poetry', ['install'], {
+      cwd: 'apps/app',
+      shell: false,
+      stdio: 'inherit',
+    });
 
     const {
       tool: {

--- a/packages/nx-python/src/executors/add/executor.ts
+++ b/packages/nx-python/src/executors/add/executor.ts
@@ -84,12 +84,12 @@ function updateLocalProject(
     dependencyConfig.root,
   );
 
-  const dependencyPkgName = addLocalProjectToPoetryProject(
+  addLocalProjectToPoetryProject(
     projectConfig,
     dependencyConfig,
     dependencyPath,
     group,
     extras,
   );
-  updateProject(dependencyPkgName, projectConfig.root, updateLockOnly);
+  updateProject(projectConfig.root, updateLockOnly);
 }

--- a/packages/nx-python/src/executors/remove/executor.spec.ts
+++ b/packages/nx-python/src/executors/remove/executor.spec.ts
@@ -162,7 +162,7 @@ version = "1.0.0"
     const output = await executor(options, context);
     expect(checkPoetryExecutableMock).toHaveBeenCalled();
     expect(activateVenvMock).toHaveBeenCalledWith('.');
-    expect(spawn.sync).toHaveBeenCalledTimes(3);
+    expect(spawn.sync).toHaveBeenCalledTimes(5);
     expect(spawn.sync).toHaveBeenNthCalledWith(
       1,
       'poetry',
@@ -176,23 +176,33 @@ version = "1.0.0"
     expect(spawn.sync).toHaveBeenNthCalledWith(
       2,
       'poetry',
-      ['update', 'lib1'],
+      ['lock', '--no-update'],
       {
         cwd: 'apps/app',
         shell: false,
         stdio: 'inherit',
       },
     );
+    expect(spawn.sync).toHaveBeenNthCalledWith(3, 'poetry', ['install'], {
+      cwd: 'apps/app',
+      shell: false,
+      stdio: 'inherit',
+    });
     expect(spawn.sync).toHaveBeenNthCalledWith(
-      3,
+      4,
       'poetry',
-      ['update', 'lib1'],
+      ['lock', '--no-update'],
       {
         cwd: 'apps/app1',
         shell: false,
         stdio: 'inherit',
       },
     );
+    expect(spawn.sync).toHaveBeenNthCalledWith(5, 'poetry', ['install'], {
+      cwd: 'apps/app1',
+      shell: false,
+      stdio: 'inherit',
+    });
     expect(output.success).toBe(true);
   });
 
@@ -285,7 +295,7 @@ version = "1.0.0"
     const output = await executor(options, context);
     expect(checkPoetryExecutableMock).toHaveBeenCalled();
     expect(activateVenvMock).toHaveBeenCalledWith('.');
-    expect(spawn.sync).toHaveBeenCalledTimes(4);
+    expect(spawn.sync).toHaveBeenCalledTimes(7);
     expect(spawn.sync).toHaveBeenNthCalledWith(
       1,
       'poetry',
@@ -299,33 +309,48 @@ version = "1.0.0"
     expect(spawn.sync).toHaveBeenNthCalledWith(
       2,
       'poetry',
-      ['update', 'shared1'],
+      ['lock', '--no-update'],
       {
         cwd: 'libs/lib1',
         shell: false,
         stdio: 'inherit',
       },
     );
+    expect(spawn.sync).toHaveBeenNthCalledWith(3, 'poetry', ['install'], {
+      cwd: 'libs/lib1',
+      shell: false,
+      stdio: 'inherit',
+    });
     expect(spawn.sync).toHaveBeenNthCalledWith(
-      3,
+      4,
       'poetry',
-      ['update', 'lib1'],
+      ['lock', '--no-update'],
       {
         cwd: 'apps/app',
         shell: false,
         stdio: 'inherit',
       },
     );
+    expect(spawn.sync).toHaveBeenNthCalledWith(5, 'poetry', ['install'], {
+      cwd: 'apps/app',
+      shell: false,
+      stdio: 'inherit',
+    });
     expect(spawn.sync).toHaveBeenNthCalledWith(
-      4,
+      6,
       'poetry',
-      ['update', 'lib1'],
+      ['lock', '--no-update'],
       {
         cwd: 'apps/app1',
         shell: false,
         stdio: 'inherit',
       },
     );
+    expect(spawn.sync).toHaveBeenNthCalledWith(7, 'poetry', ['install'], {
+      cwd: 'apps/app1',
+      shell: false,
+      stdio: 'inherit',
+    });
     expect(output.success).toBe(true);
   });
 

--- a/packages/nx-python/src/executors/update/executor.spec.ts
+++ b/packages/nx-python/src/executors/update/executor.spec.ts
@@ -303,7 +303,7 @@ version = "1.0.0"
     const output = await executor(options, context);
     expect(checkPoetryExecutableMock).toHaveBeenCalled();
     expect(activateVenvMock).toHaveBeenCalledWith('.');
-    expect(spawn.sync).toHaveBeenCalledTimes(4);
+    expect(spawn.sync).toHaveBeenCalledTimes(7);
     expect(spawn.sync).toHaveBeenNthCalledWith(
       1,
       'poetry',
@@ -317,33 +317,48 @@ version = "1.0.0"
     expect(spawn.sync).toHaveBeenNthCalledWith(
       2,
       'poetry',
-      ['update', 'shared1'],
+      ['lock', '--no-update'],
       {
         cwd: 'apps/app',
         shell: false,
         stdio: 'inherit',
       },
     );
+    expect(spawn.sync).toHaveBeenNthCalledWith(3, 'poetry', ['install'], {
+      cwd: 'apps/app',
+      shell: false,
+      stdio: 'inherit',
+    });
     expect(spawn.sync).toHaveBeenNthCalledWith(
-      3,
+      4,
       'poetry',
-      ['update', 'shared1'],
+      ['lock', '--no-update'],
       {
         cwd: 'libs/lib1',
         shell: false,
         stdio: 'inherit',
       },
     );
+    expect(spawn.sync).toHaveBeenNthCalledWith(5, 'poetry', ['install'], {
+      cwd: 'libs/lib1',
+      shell: false,
+      stdio: 'inherit',
+    });
     expect(spawn.sync).toHaveBeenNthCalledWith(
-      4,
+      6,
       'poetry',
-      ['update', 'lib1'],
+      ['lock', '--no-update'],
       {
         cwd: 'apps/app1',
         shell: false,
         stdio: 'inherit',
       },
     );
+    expect(spawn.sync).toHaveBeenNthCalledWith(7, 'poetry', ['install'], {
+      cwd: 'apps/app1',
+      shell: false,
+      stdio: 'inherit',
+    });
     expect(output.success).toBe(true);
   });
 
@@ -398,17 +413,22 @@ version = "1.0.0"
     const output = await executor(options, context);
     expect(checkPoetryExecutableMock).toHaveBeenCalled();
     expect(activateVenvMock).toHaveBeenCalledWith('.');
-    expect(spawn.sync).toHaveBeenCalledTimes(1);
+    expect(spawn.sync).toHaveBeenCalledTimes(2);
     expect(spawn.sync).toHaveBeenNthCalledWith(
       1,
       'poetry',
-      ['update', 'lib1'],
+      ['lock', '--no-update'],
       {
         cwd: 'apps/app',
         shell: false,
         stdio: 'inherit',
       },
     );
+    expect(spawn.sync).toHaveBeenNthCalledWith(2, 'poetry', ['install'], {
+      cwd: 'apps/app',
+      shell: false,
+      stdio: 'inherit',
+    });
     expect(output.success).toBe(true);
   });
 
@@ -467,17 +487,22 @@ version = "1.0.0"
     const output = await executor(options, context);
     expect(checkPoetryExecutableMock).toHaveBeenCalled();
     expect(activateVenvMock).toHaveBeenCalledWith('.');
-    expect(spawn.sync).toHaveBeenCalledTimes(1);
+    expect(spawn.sync).toHaveBeenCalledTimes(2);
     expect(spawn.sync).toHaveBeenNthCalledWith(
       1,
       'poetry',
-      ['update', 'dgx-devops-lib1'],
+      ['lock', '--no-update'],
       {
         cwd: 'apps/app',
         shell: false,
         stdio: 'inherit',
       },
     );
+    expect(spawn.sync).toHaveBeenNthCalledWith(2, 'poetry', ['install'], {
+      cwd: 'apps/app',
+      shell: false,
+      stdio: 'inherit',
+    });
     expect(output.success).toBe(true);
 
     const {
@@ -786,7 +811,7 @@ version = "1.0.0"
     expect(spawn.sync).toHaveBeenNthCalledWith(
       2,
       'poetry',
-      ['update', 'shared1', '--lock'],
+      ['lock', '--no-update'],
       {
         cwd: 'libs/lib1',
         shell: false,
@@ -796,7 +821,7 @@ version = "1.0.0"
     expect(spawn.sync).toHaveBeenNthCalledWith(
       3,
       'poetry',
-      ['update', 'lib1', '--lock'],
+      ['lock', '--no-update'],
       {
         cwd: 'apps/app',
         shell: false,
@@ -806,7 +831,7 @@ version = "1.0.0"
     expect(spawn.sync).toHaveBeenNthCalledWith(
       4,
       'poetry',
-      ['update', 'lib1', '--lock'],
+      ['lock', '--no-update'],
       {
         cwd: 'apps/app1',
         shell: false,

--- a/packages/nx-python/src/executors/utils/poetry.ts
+++ b/packages/nx-python/src/executors/utils/poetry.ts
@@ -69,15 +69,11 @@ export function addLocalProjectToPoetryProject(
   return dependencyName;
 }
 
-export function updateProject(
-  projectName: string,
-  cwd: string,
-  updateLockOnly: boolean,
-) {
-  const updateLockArgs = ['update', projectName].concat(
-    updateLockOnly ? ['--lock'] : [],
-  );
-  runPoetry(updateLockArgs, { cwd });
+export function updateProject(cwd: string, updateLockOnly: boolean) {
+  runPoetry(['lock', '--no-update'], { cwd });
+  if (!updateLockOnly) {
+    runPoetry(['install'], { cwd });
+  }
 }
 
 export function getProjectTomlPath(targetConfig: ProjectConfiguration) {


### PR DESCRIPTION
## Current Behavior

currently, when there are more than 2 levels of local project dependencies, when a dependency is added to the 2 levels or deeper the nx python plugin uses `poetry update <lib>` to update to keep all the `poetry.lock` in sync.

however, the poetry update only works well for the first level, for all the others the poetry lock is not updated correctly.

## Expected Behavior

the combination of `poetry lock` and only running `poetry install` when the root `pyproject.toml` is not present, updates the `poetry.lock` for all the levels of dependencies.
