### PR TITLE
fix(nx-python): resolve poetry export local path for windows

### DIFF
--- a/packages/nx-python/src/executors/build/resolvers/locked.ts
+++ b/packages/nx-python/src/executors/build/resolvers/locked.ts
@@ -8,6 +8,7 @@ import chalk from 'chalk';
 import { parseToml, runPoetry } from '../../utils/poetry';
 import uri2path from 'file-uri-to-path';
 import { getLoggingTab, includeDependencyPackage } from './utils';
+import { isWindows } from '../../utils/os';
 
 export class LockedDependencyResolver {
   private logger: Logger;
@@ -187,7 +188,9 @@ export class LockedDependencyResolver {
 
   private extractLocalPackageInfo(exportedLineElements: string[]) {
     if (exportedLineElements[0].startsWith('-e file:')) {
-      const location = exportedLineElements[0].substring(10).trim();
+      const location = isWindows()
+        ? exportedLineElements[0].substring(11).trim() // -e file:///C:/Users/
+        : exportedLineElements[0].substring(10).trim(); // -e file:///Users/
       const pyprojectToml = path.join(location, 'pyproject.toml');
       if (!existsSync(pyprojectToml)) {
         throw new Error(

--- a/packages/nx-python/src/executors/utils/os.ts
+++ b/packages/nx-python/src/executors/utils/os.ts
@@ -1,0 +1,3 @@
+export function isWindows() {
+  return process.platform === 'win32';
+}


### PR DESCRIPTION
## Current Behavior

Currently, when the projects has a local dependency and the build executor is called in a Windows machine the following error happen:

```
ERROR  pyproject.toml not found in /C:/Users/
```

That happens because the `@nxlv/python` plugin uses the output of the `poetry export` command, and the pattern for Mac/Linux is: `-e file:///Users/...` and for Windows is `-e file:///C:/Users/`.

The resolved location for Mac/Linux is `/Users/...` and `/C:/Users/` for Windows.

## Expected Behavior

The resolved location should stay as-is for Mac/Linux and change from `/C:/Users/` to `C:/Users/` for Windows.
