### PR TITLE
fix(nx-python): use @nxlv/python:publish for nx-release-publish

### DIFF
--- a/packages/nx-python/src/generators/poetry-project/generator.ts
+++ b/packages/nx-python/src/generators/poetry-project/generator.ts
@@ -467,13 +467,9 @@ export default async function (
   if (normalizedOptions.publishable) {
     projectConfiguration.targets ??= {};
     projectConfiguration.targets['nx-release-publish'] = {
-      executor: 'nx:run-commands',
-      options: {
-        command: 'poetry publish',
-        cwd: normalizedOptions.projectRoot,
-        forwardAllArgs: false,
-      },
-      dependsOn: ['build'],
+      executor: '@nxlv/python:publish',
+      options: {},
+      outputs: [],
     };
   }
 


### PR DESCRIPTION
This PR changes the `nx-release-publish` default target to use `@nxlv/python:publish` executor