### PR TITLE
fix: add dry-run option to publish target

### DIFF
--- a/packages/nx-python/src/executors/publish/executor.ts
+++ b/packages/nx-python/src/executors/publish/executor.ts
@@ -51,9 +51,16 @@ export default async function executor(
       chalk`\n  {bold Publishing project {bgBlue  ${context.projectName} }...}\n`,
     );
 
-    await runPoetry(['publish', ...(options.__unparsed__ ?? [])], {
-      cwd: buildFolderPath,
-    });
+    await runPoetry(
+      [
+        'publish',
+        ...(options.dryRun ? ['--dry-run'] : []),
+        ...(options.__unparsed__ ?? []),
+      ],
+      {
+        cwd: buildFolderPath,
+      },
+    );
 
     removeSync(buildFolderPath);
 

--- a/packages/nx-python/src/executors/publish/schema.d.ts
+++ b/packages/nx-python/src/executors/publish/schema.d.ts
@@ -1,5 +1,6 @@
 export interface PublishExecutorSchema {
   silent: boolean;
   buildTarget: string;
+  dryRun: boolean;
   __unparsed__?: string[];
 }

--- a/packages/nx-python/src/executors/publish/schema.json
+++ b/packages/nx-python/src/executors/publish/schema.json
@@ -14,6 +14,11 @@
       "description": "Hide output text.",
       "default": false
     },
+    "dryRun": {
+      "type": "boolean",
+      "description": "Do not publish the package.",
+      "default": false
+    },
     "__unparsed__": {
       "hidden": true,
       "type": "array",


### PR DESCRIPTION
This PR adds `dryRun` option to publish target (this option is also provided when you run `npm nx release publish --dry-run`)
