### PR TITLE
fix(nx-python): remove deprecated property and replace with `context.projectsConfigurations`

### DIFF
--- a/packages/nx-python/src/dependency/update-dependency.ts
+++ b/packages/nx-python/src/dependency/update-dependency.ts
@@ -20,7 +20,7 @@ export function updateDependencyTree(context: ExecutorContext) {
 
   updateDependents(
     context,
-    context.workspace,
+    context.projectsConfigurations,
     context.projectName,
     rootPyprojectToml,
     context.root,
@@ -79,7 +79,7 @@ export function updateDependents(
 }
 
 function getProjectPackageName(context: ExecutorContext, projectName: string) {
-  const projectConfig = context.workspace.projects[projectName];
+  const projectConfig = context.projectsConfigurations.projects[projectName];
   const projectToml = getProjectTomlPath(projectConfig);
   const {
     tool: {

--- a/packages/nx-python/src/executors/add/executor.spec.ts
+++ b/packages/nx-python/src/executors/add/executor.spec.ts
@@ -53,8 +53,7 @@ describe('Add Executor', () => {
       root: '.',
       isVerbose: false,
       projectName: 'app',
-      workspace: {
-        npmScope: 'nxlv',
+      projectsConfigurations: {
         version: 2,
         projects: {
           app: {
@@ -100,8 +99,7 @@ describe('Add Executor', () => {
       root: '.',
       isVerbose: false,
       projectName: 'app',
-      workspace: {
-        npmScope: 'nxlv',
+      projectsConfigurations: {
         version: 2,
         projects: {
           app: {
@@ -152,8 +150,7 @@ describe('Add Executor', () => {
       root: '.',
       isVerbose: false,
       projectName: 'app',
-      workspace: {
-        npmScope: 'nxlv',
+      projectsConfigurations: {
         version: 2,
         projects: {
           app: {
@@ -208,8 +205,7 @@ describe('Add Executor', () => {
       root: '.',
       isVerbose: false,
       projectName: 'app',
-      workspace: {
-        npmScope: 'nxlv',
+      projectsConfigurations: {
         version: 2,
         projects: {
           app: {
@@ -259,8 +255,7 @@ version = "1.0.0"
       root: '.',
       isVerbose: false,
       projectName: 'app',
-      workspace: {
-        npmScope: 'nxlv',
+      projectsConfigurations: {
         version: 2,
         projects: {
           app: {
@@ -306,8 +301,7 @@ version = "1.0.0"
       root: '.',
       isVerbose: false,
       projectName: 'app',
-      workspace: {
-        npmScope: 'nxlv',
+      projectsConfigurations: {
         version: 2,
         projects: {
           app: {
@@ -391,9 +385,8 @@ version = "1.0.0"
       root: '.',
       isVerbose: false,
       projectName: 'shared1',
-      workspace: {
+      projectsConfigurations: {
         version: 2,
-        npmScope: 'nxlv',
         projects: {
           app: {
             root: 'apps/app',
@@ -538,9 +531,8 @@ version = "1.0.0"
       root: '.',
       isVerbose: false,
       projectName: 'shared1',
-      workspace: {
+      projectsConfigurations: {
         version: 2,
-        npmScope: 'nxlv',
         projects: {
           app: {
             root: 'apps/app',
@@ -655,9 +647,8 @@ version = "1.0.0"
       root: '.',
       isVerbose: false,
       projectName: 'app',
-      workspace: {
+      projectsConfigurations: {
         version: 2,
-        npmScope: 'nxlv',
         projects: {
           app: {
             root: 'apps/app',
@@ -726,9 +717,8 @@ version = "1.0.0"
       root: '.',
       isVerbose: false,
       projectName: 'app',
-      workspace: {
+      projectsConfigurations: {
         version: 2,
-        npmScope: 'nxlv',
         projects: {
           app: {
             root: 'apps/app',
@@ -801,9 +791,8 @@ version = "1.0.0"
       root: '.',
       isVerbose: false,
       projectName: 'app',
-      workspace: {
+      projectsConfigurations: {
         version: 2,
-        npmScope: 'nxlv',
         projects: {
           app: {
             root: 'apps/app',
@@ -877,9 +866,8 @@ version = "1.0.0"
       root: '.',
       isVerbose: false,
       projectName: 'app',
-      workspace: {
+      projectsConfigurations: {
         version: 2,
-        npmScope: 'nxlv',
         projects: {
           app: {
             root: 'apps/app',
@@ -947,9 +935,8 @@ version = "1.0.0"
       root: '.',
       isVerbose: false,
       projectName: 'app',
-      workspace: {
+      projectsConfigurations: {
         version: 2,
-        npmScope: 'nxlv',
         projects: {
           app: {
             root: 'apps/app',
@@ -1021,9 +1008,8 @@ version = "1.0.0"
       root: '.',
       isVerbose: false,
       projectName: 'app',
-      workspace: {
+      projectsConfigurations: {
         version: 2,
-        npmScope: 'nxlv',
         projects: {
           app: {
             root: 'apps/app',
@@ -1082,8 +1068,7 @@ version = "1.0.0"
       root: '.',
       isVerbose: false,
       projectName: 'app',
-      workspace: {
-        npmScope: 'nxlv',
+      projectsConfigurations: {
         version: 2,
         projects: {
           app: {
@@ -1165,8 +1150,7 @@ version = "1.0.0"
       root: '.',
       isVerbose: false,
       projectName: 'app',
-      workspace: {
-        npmScope: 'nxlv',
+      projectsConfigurations: {
         version: 2,
         projects: {
           app: {

--- a/packages/nx-python/src/executors/add/executor.ts
+++ b/packages/nx-python/src/executors/add/executor.ts
@@ -22,7 +22,8 @@ export default async function executor(
   try {
     activateVenv(workspaceRoot);
     await checkPoetryExecutable();
-    const projectConfig = context.workspace.projects[context.projectName];
+    const projectConfig =
+      context.projectsConfigurations.projects[context.projectName];
     const rootPyprojectToml = existsSync('pyproject.toml');
 
     if (options.local) {

--- a/packages/nx-python/src/executors/build/executor.spec.ts
+++ b/packages/nx-python/src/executors/build/executor.spec.ts
@@ -72,8 +72,7 @@ describe('Build Executor', () => {
       root: '.',
       isVerbose: false,
       projectName: 'app',
-      workspace: {
-        npmScope: 'nxlv',
+      projectsConfigurations: {
         version: 2,
         projects: {
           app: {
@@ -109,9 +108,7 @@ describe('Build Executor', () => {
       root: '.',
       isVerbose: false,
       projectName: 'app',
-      workspace: {
-        npmScope: 'nxlv',
-        version: 2,
+      projectsConfigurations: {
         projects: {
           app: {
             root: 'apps/app',
@@ -254,7 +251,7 @@ describe('Build Executor', () => {
         root: '.',
         isVerbose: false,
         projectName: 'app',
-        workspace: {
+        projectsConfigurations: {
           version: 2,
           projects: {
             app: {
@@ -439,7 +436,7 @@ describe('Build Executor', () => {
         root: '.',
         isVerbose: false,
         projectName: 'app',
-        workspace: {
+        projectsConfigurations: {
           version: 2,
           projects: {
             app: {
@@ -626,8 +623,9 @@ describe('Build Executor', () => {
         root: '.',
         isVerbose: false,
         projectName: 'app',
-        workspace: {
+        projectsConfigurations: {
           version: 2,
+
           projects: {
             app: {
               root: 'apps/app',
@@ -811,8 +809,9 @@ describe('Build Executor', () => {
         root: '.',
         isVerbose: false,
         projectName: 'app',
-        workspace: {
+        projectsConfigurations: {
           version: 2,
+
           projects: {
             app: {
               root: 'apps/app',
@@ -904,8 +903,9 @@ describe('Build Executor', () => {
         root: '.',
         isVerbose: false,
         projectName: 'app',
-        workspace: {
+        projectsConfigurations: {
           version: 2,
+
           projects: {
             app: {
               root: 'apps/app',
@@ -1022,8 +1022,9 @@ describe('Build Executor', () => {
         root: '.',
         isVerbose: false,
         projectName: 'app',
-        workspace: {
+        projectsConfigurations: {
           version: 2,
+
           projects: {
             app: {
               root: 'apps/app',
@@ -1138,8 +1139,9 @@ describe('Build Executor', () => {
         root: '.',
         isVerbose: false,
         projectName: 'app',
-        workspace: {
+        projectsConfigurations: {
           version: 2,
+
           projects: {
             app: {
               root: 'apps/app',
@@ -1245,8 +1247,9 @@ describe('Build Executor', () => {
         root: '.',
         isVerbose: false,
         projectName: 'app',
-        workspace: {
+        projectsConfigurations: {
           version: 2,
+
           projects: {
             app: {
               root: 'apps/app',
@@ -1385,8 +1388,9 @@ describe('Build Executor', () => {
         root: '.',
         isVerbose: false,
         projectName: 'app',
-        workspace: {
+        projectsConfigurations: {
           version: 2,
+
           projects: {
             app: {
               root: 'apps/app',
@@ -1531,8 +1535,9 @@ describe('Build Executor', () => {
         root: '.',
         isVerbose: false,
         projectName: 'app',
-        workspace: {
+        projectsConfigurations: {
           version: 2,
+
           projects: {
             app: {
               root: 'apps/app',
@@ -1698,8 +1703,9 @@ describe('Build Executor', () => {
         root: '.',
         isVerbose: false,
         projectName: 'app',
-        workspace: {
+        projectsConfigurations: {
           version: 2,
+
           projects: {
             app: {
               root: 'apps/app',
@@ -1844,8 +1850,9 @@ describe('Build Executor', () => {
         root: '.',
         isVerbose: false,
         projectName: 'app',
-        workspace: {
+        projectsConfigurations: {
           version: 2,
+
           projects: {
             app: {
               root: 'apps/app',
@@ -1946,8 +1953,9 @@ describe('Build Executor', () => {
         root: '.',
         isVerbose: false,
         projectName: 'app',
-        workspace: {
+        projectsConfigurations: {
           version: 2,
+
           projects: {
             app: {
               root: 'apps/app',
@@ -2021,8 +2029,9 @@ describe('Build Executor', () => {
         root: '.',
         isVerbose: false,
         projectName: 'app',
-        workspace: {
+        projectsConfigurations: {
           version: 2,
+
           projects: {
             app: {
               root: 'apps/app',
@@ -2092,8 +2101,9 @@ describe('Build Executor', () => {
         root: '.',
         isVerbose: false,
         projectName: 'app',
-        workspace: {
+        projectsConfigurations: {
           version: 2,
+
           projects: {
             app: {
               root: 'apps/app',
@@ -2175,8 +2185,9 @@ describe('Build Executor', () => {
         root: '.',
         isVerbose: false,
         projectName: 'app',
-        workspace: {
+        projectsConfigurations: {
           version: 2,
+
           projects: {
             app: {
               root: 'apps/app',
@@ -2257,8 +2268,9 @@ describe('Build Executor', () => {
         root: '.',
         isVerbose: false,
         projectName: 'app',
-        workspace: {
+        projectsConfigurations: {
           version: 2,
+
           projects: {
             app: {
               root: 'apps/app',
@@ -2369,8 +2381,9 @@ describe('Build Executor', () => {
         root: '.',
         isVerbose: false,
         projectName: 'app',
-        workspace: {
+        projectsConfigurations: {
           version: 2,
+
           projects: {
             app: {
               root: 'apps/app',
@@ -2508,8 +2521,9 @@ describe('Build Executor', () => {
         root: '.',
         isVerbose: false,
         projectName: 'app',
-        workspace: {
+        projectsConfigurations: {
           version: 2,
+
           projects: {
             app: {
               root: 'apps/app',
@@ -2722,8 +2736,9 @@ describe('Build Executor', () => {
         root: '.',
         isVerbose: false,
         projectName: 'app',
-        workspace: {
+        projectsConfigurations: {
           version: 2,
+
           projects: {
             app: {
               root: 'apps/app',

--- a/packages/nx-python/src/executors/build/executor.ts
+++ b/packages/nx-python/src/executors/build/executor.ts
@@ -54,7 +54,8 @@ export default async function executor(
       chalk`\n  {bold Building project {bgBlue  ${context.projectName} }...}\n`,
     );
 
-    const { root } = context.workspace.projects[context.projectName];
+    const { root } =
+      context.projectsConfigurations.projects[context.projectName];
 
     const buildFolderPath = join(tmpdir(), 'nx-python', 'build', uuid());
 

--- a/packages/nx-python/src/executors/build/resolvers/project.ts
+++ b/packages/nx-python/src/executors/build/resolvers/project.ts
@@ -146,7 +146,9 @@ export class ProjectDependencyResolver {
   }
 
   private getProjectConfig(root: string) {
-    for (const [, config] of Object.entries(this.context.workspace.projects)) {
+    for (const [, config] of Object.entries(
+      this.context.projectsConfigurations.projects,
+    )) {
       if (normalize(config.root) === normalize(root)) {
         return config;
       }

--- a/packages/nx-python/src/executors/flake8/executor.spec.ts
+++ b/packages/nx-python/src/executors/flake8/executor.spec.ts
@@ -60,7 +60,7 @@ describe('Flake8 Executor', () => {
       root: '.',
       isVerbose: false,
       projectName: 'app',
-      workspace: {
+      projectsConfigurations: {
         version: 2,
         projects: {
           app: {
@@ -102,8 +102,9 @@ describe('Flake8 Executor', () => {
         root: '.',
         isVerbose: false,
         projectName: 'app',
-        workspace: {
+        projectsConfigurations: {
           version: 2,
+
           projects: {
             app: {
               root: 'apps/app',
@@ -145,8 +146,9 @@ describe('Flake8 Executor', () => {
         root: '.',
         isVerbose: false,
         projectName: 'app',
-        workspace: {
+        projectsConfigurations: {
           version: 2,
+
           projects: {
             app: {
               root: 'apps/app',
@@ -177,8 +179,9 @@ describe('Flake8 Executor', () => {
         root: '.',
         isVerbose: false,
         projectName: 'app',
-        workspace: {
+        projectsConfigurations: {
           version: 2,
+
           projects: {
             app: {
               root: 'apps/app',
@@ -219,8 +222,9 @@ describe('Flake8 Executor', () => {
         root: '.',
         isVerbose: false,
         projectName: 'app',
-        workspace: {
+        projectsConfigurations: {
           version: 2,
+
           projects: {
             app: {
               root: 'apps/app',

--- a/packages/nx-python/src/executors/flake8/executor.ts
+++ b/packages/nx-python/src/executors/flake8/executor.ts
@@ -26,7 +26,8 @@ export default async function executor(
       chalk`\n  {bold Running flake8 linting on project {bgBlue  ${context.projectName} }...}\n`,
     );
 
-    const projectConfig = context.workspace.projects[context.projectName];
+    const projectConfig =
+      context.projectsConfigurations.projects[context.projectName];
     const cwd = projectConfig.root;
 
     const absPath = path.resolve(options.outputFile);

--- a/packages/nx-python/src/executors/install/executor.spec.ts
+++ b/packages/nx-python/src/executors/install/executor.spec.ts
@@ -13,9 +13,9 @@ describe('Install Executor', () => {
     root: '.',
     isVerbose: false,
     projectName: 'app',
-    workspace: {
+    projectsConfigurations: {
       version: 2,
-      npmScope: 'nxlv',
+
       projects: {
         app: {
           root: 'apps/app',
@@ -55,9 +55,7 @@ describe('Install Executor', () => {
       root: '.',
       isVerbose: false,
       projectName: 'app',
-      workspace: {
-        npmScope: 'nxlv',
-        version: 2,
+      projectsConfigurations: {
         projects: {
           app: {
             root: 'apps/app',

--- a/packages/nx-python/src/executors/install/executor.ts
+++ b/packages/nx-python/src/executors/install/executor.ts
@@ -20,7 +20,8 @@ export default async function executor(
   process.chdir(workspaceRoot);
   try {
     await checkPoetryExecutable();
-    const projectConfig = context.workspace.projects[context.projectName];
+    const projectConfig =
+      context.projectsConfigurations.projects[context.projectName];
     let verboseArg = '-v';
 
     if (options.debug) {

--- a/packages/nx-python/src/executors/publish/executor.spec.ts
+++ b/packages/nx-python/src/executors/publish/executor.spec.ts
@@ -43,8 +43,9 @@ describe('Publish Executor', () => {
     root: '.',
     isVerbose: false,
     projectName: 'app',
-    workspace: {
+    projectsConfigurations: {
       version: 2,
+
       projects: {
         app: {
           root: 'apps/app',
@@ -89,6 +90,7 @@ describe('Publish Executor', () => {
     const options = {
       buildTarget: 'build',
       silent: false,
+      dryRun: false,
     };
 
     const output = await executor(options, context);
@@ -104,6 +106,7 @@ describe('Publish Executor', () => {
     const options = {
       buildTarget: 'build',
       silent: false,
+      dryRun: false,
     };
 
     const output = await executor(options, context);
@@ -119,6 +122,7 @@ describe('Publish Executor', () => {
     const options = {
       buildTarget: 'build',
       silent: false,
+      dryRun: false,
       __unparsed__: [],
     };
 
@@ -138,6 +142,7 @@ describe('Publish Executor', () => {
     const options = {
       buildTarget: 'build',
       silent: false,
+      dryRun: false,
     };
 
     const output = await executor(options, context);
@@ -171,6 +176,7 @@ describe('Publish Executor', () => {
 
     const options = {
       buildTarget: 'build',
+      dryRun: false,
       silent: false,
       __unparsed__: ['-vvv', '--dry-run'],
     };

--- a/packages/nx-python/src/executors/remove/executor.spec.ts
+++ b/packages/nx-python/src/executors/remove/executor.spec.ts
@@ -56,9 +56,7 @@ describe('Delete Executor', () => {
       root: '.',
       isVerbose: false,
       projectName: 'app',
-      workspace: {
-        npmScope: 'nxlv',
-        version: 2,
+      projectsConfigurations: {
         projects: {
           app: {
             root: 'apps/app',
@@ -131,9 +129,9 @@ version = "1.0.0"
       root: '.',
       isVerbose: false,
       projectName: 'lib1',
-      workspace: {
+      projectsConfigurations: {
         version: 2,
-        npmScope: 'nxlv',
+
         projects: {
           app: {
             root: 'apps/app',
@@ -268,9 +266,9 @@ version = "1.0.0"
       root: '.',
       isVerbose: false,
       projectName: 'shared1',
-      workspace: {
+      projectsConfigurations: {
         version: 2,
-        npmScope: 'nxlv',
+
         projects: {
           app: {
             root: 'apps/app',
@@ -378,9 +376,9 @@ version = "1.0.0"
       root: '.',
       isVerbose: false,
       projectName: 'app',
-      workspace: {
+      projectsConfigurations: {
         version: 2,
-        npmScope: 'nxlv',
+
         projects: {
           app: {
             root: 'apps/app',
@@ -434,9 +432,9 @@ version = "1.0.0"
       root: '.',
       isVerbose: false,
       projectName: 'app',
-      workspace: {
+      projectsConfigurations: {
         version: 2,
-        npmScope: 'nxlv',
+
         projects: {
           app: {
             root: 'apps/app',
@@ -497,9 +495,7 @@ version = "1.0.0"
       root: '.',
       isVerbose: false,
       projectName: 'app',
-      workspace: {
-        npmScope: 'nxlv',
-        version: 2,
+      projectsConfigurations: {
         projects: {
           app: {
             root: 'apps/app',
@@ -579,9 +575,7 @@ version = "1.0.0"
       root: '.',
       isVerbose: false,
       projectName: 'app',
-      workspace: {
-        npmScope: 'nxlv',
-        version: 2,
+      projectsConfigurations: {
         projects: {
           app: {
             root: 'apps/app',

--- a/packages/nx-python/src/executors/remove/executor.ts
+++ b/packages/nx-python/src/executors/remove/executor.ts
@@ -23,7 +23,8 @@ export default async function executor(
     activateVenv(workspaceRoot);
     await checkPoetryExecutable();
     const rootPyprojectToml = existsSync('pyproject.toml');
-    const projectConfig = context.workspace.projects[context.projectName];
+    const projectConfig =
+      context.projectsConfigurations.projects[context.projectName];
     console.log(
       chalk`\n  {bold Removing {bgBlue  ${options.name} } dependency...}\n`,
     );

--- a/packages/nx-python/src/executors/ruff-check/executor.spec.ts
+++ b/packages/nx-python/src/executors/ruff-check/executor.spec.ts
@@ -53,7 +53,7 @@ describe('Ruff Check Executor', () => {
       root: '.',
       isVerbose: false,
       projectName: 'app',
-      workspace: {
+      projectsConfigurations: {
         version: 2,
         projects: {
           app: {
@@ -91,7 +91,7 @@ describe('Ruff Check Executor', () => {
         root: '.',
         isVerbose: false,
         projectName: 'app',
-        workspace: {
+        projectsConfigurations: {
           version: 2,
           projects: {
             app: {
@@ -133,7 +133,7 @@ describe('Ruff Check Executor', () => {
         root: '.',
         isVerbose: false,
         projectName: 'app',
-        workspace: {
+        projectsConfigurations: {
           version: 2,
           projects: {
             app: {

--- a/packages/nx-python/src/executors/ruff-check/executor.ts
+++ b/packages/nx-python/src/executors/ruff-check/executor.ts
@@ -24,7 +24,8 @@ export default async function executor(
       chalk`\n{bold Running ruff check on project {bgBlue  ${context.projectName} }...}\n`,
     );
 
-    const projectConfig = context.workspace.projects[context.projectName];
+    const projectConfig =
+      context.projectsConfigurations.projects[context.projectName];
 
     const commandArgs = ['run', 'ruff', 'check']
       .concat(options.lintFilePatterns)

--- a/packages/nx-python/src/executors/run-commands/executor.spec.ts
+++ b/packages/nx-python/src/executors/run-commands/executor.spec.ts
@@ -11,9 +11,7 @@ describe('run commands executor', () => {
     root: '.',
     isVerbose: false,
     projectName: 'app',
-    workspace: {
-      npmScope: 'nxlv',
-      version: 2,
+    projectsConfigurations: {
       projects: {
         app: {
           root: 'apps/app',

--- a/packages/nx-python/src/executors/sls-deploy/executor.spec.ts
+++ b/packages/nx-python/src/executors/sls-deploy/executor.spec.ts
@@ -15,9 +15,9 @@ describe('Serverless Framework Deploy Executor', () => {
     root: '.',
     isVerbose: false,
     projectName: 'app',
-    workspace: {
+    projectsConfigurations: {
       version: 2,
-      npmScope: 'nxlv',
+
       projects: {
         app: {
           root: 'apps/app',

--- a/packages/nx-python/src/executors/sls-deploy/executor.ts
+++ b/packages/nx-python/src/executors/sls-deploy/executor.ts
@@ -17,7 +17,8 @@ export default async function executor(
   process.chdir(workspaceRoot);
   activateVenv(workspaceRoot);
 
-  const projectConfig = context.workspace.projects[context.projectName];
+  const projectConfig =
+    context.projectsConfigurations.projects[context.projectName];
   const cwd = projectConfig.root;
   const requirementsTxt = path.join(cwd, 'requirements.txt');
 

--- a/packages/nx-python/src/executors/sls-package/executor.spec.ts
+++ b/packages/nx-python/src/executors/sls-package/executor.spec.ts
@@ -15,9 +15,9 @@ describe('Serverless Framework Package Executor', () => {
     root: '.',
     isVerbose: false,
     projectName: 'app',
-    workspace: {
+    projectsConfigurations: {
       version: 2,
-      npmScope: 'nxlv',
+
       projects: {
         app: {
           root: 'apps/app',

--- a/packages/nx-python/src/executors/sls-package/executor.ts
+++ b/packages/nx-python/src/executors/sls-package/executor.ts
@@ -17,7 +17,8 @@ export default async function executor(
   process.chdir(workspaceRoot);
   activateVenv(workspaceRoot);
 
-  const projectConfig = context.workspace.projects[context.projectName];
+  const projectConfig =
+    context.projectsConfigurations.projects[context.projectName];
   const cwd = projectConfig.root;
   const requirementsTxt = path.join(cwd, 'requirements.txt');
 

--- a/packages/nx-python/src/executors/tox/executor.spec.ts
+++ b/packages/nx-python/src/executors/tox/executor.spec.ts
@@ -23,9 +23,9 @@ describe('Tox Executor', () => {
     root: '.',
     isVerbose: false,
     projectName: 'app',
-    workspace: {
+    projectsConfigurations: {
       version: 2,
-      npmScope: 'nxlv',
+
       projects: {
         app: {
           root: 'apps/app',
@@ -73,9 +73,7 @@ describe('Tox Executor', () => {
       root: '.',
       isVerbose: false,
       projectName: 'app',
-      workspace: {
-        npmScope: 'nxlv',
-        version: 2,
+      projectsConfigurations: {
         projects: {
           app: {
             root: 'apps/app',

--- a/packages/nx-python/src/executors/tox/executor.ts
+++ b/packages/nx-python/src/executors/tox/executor.ts
@@ -23,7 +23,8 @@ export default async function executor(
   try {
     activateVenv(workspaceRoot);
     await checkPoetryExecutable();
-    const projectConfig = context.workspace.projects[context.projectName];
+    const projectConfig =
+      context.projectsConfigurations.projects[context.projectName];
     const distFolder = path.join(projectConfig.root, 'dist');
 
     const buildResult = await buildExecutor(

--- a/packages/nx-python/src/executors/update/executor.spec.ts
+++ b/packages/nx-python/src/executors/update/executor.spec.ts
@@ -53,9 +53,7 @@ describe('Update Executor', () => {
       root: '.',
       isVerbose: false,
       projectName: 'app',
-      workspace: {
-        npmScope: 'nxlv',
-        version: 2,
+      projectsConfigurations: {
         projects: {
           app: {
             root: 'apps/app',
@@ -96,9 +94,9 @@ version = "1.0.0"
       root: '.',
       isVerbose: false,
       projectName: 'app',
-      workspace: {
+      projectsConfigurations: {
         version: 2,
-        npmScope: 'nxlv',
+
         projects: {
           app: {
             root: 'apps/app',
@@ -143,9 +141,9 @@ version = "1.0.0"
       root: '.',
       isVerbose: false,
       projectName: 'app',
-      workspace: {
+      projectsConfigurations: {
         version: 2,
-        npmScope: 'nxlv',
+
         projects: {
           app: {
             root: 'apps/app',
@@ -190,9 +188,9 @@ version = "1.0.0"
       root: '.',
       isVerbose: false,
       projectName: 'app',
-      workspace: {
+      projectsConfigurations: {
         version: 2,
-        npmScope: 'nxlv',
+
         projects: {
           app: {
             root: 'apps/app',
@@ -276,9 +274,9 @@ version = "1.0.0"
       root: '.',
       isVerbose: false,
       projectName: 'shared1',
-      workspace: {
+      projectsConfigurations: {
         version: 2,
-        npmScope: 'nxlv',
+
         projects: {
           app: {
             root: 'apps/app',
@@ -394,9 +392,9 @@ version = "1.0.0"
       root: '.',
       isVerbose: false,
       projectName: 'app',
-      workspace: {
+      projectsConfigurations: {
         version: 2,
-        npmScope: 'nxlv',
+
         projects: {
           app: {
             root: 'apps/app',
@@ -468,9 +466,9 @@ version = "1.0.0"
       root: '.',
       isVerbose: false,
       projectName: 'app',
-      workspace: {
+      projectsConfigurations: {
         version: 2,
-        npmScope: 'nxlv',
+
         projects: {
           app: {
             root: 'apps/app',
@@ -542,9 +540,9 @@ version = "1.0.0"
       root: '.',
       isVerbose: false,
       projectName: 'app',
-      workspace: {
+      projectsConfigurations: {
         version: 2,
-        npmScope: 'nxlv',
+
         projects: {
           app: {
             root: 'apps/app',
@@ -592,9 +590,9 @@ version = "1.0.0"
       root: '.',
       isVerbose: false,
       projectName: 'app',
-      workspace: {
+      projectsConfigurations: {
         version: 2,
-        npmScope: 'nxlv',
+
         projects: {
           app: {
             root: 'apps/app',
@@ -649,9 +647,9 @@ version = "1.0.0"
       root: '.',
       isVerbose: false,
       projectName: 'app',
-      workspace: {
+      projectsConfigurations: {
         version: 2,
-        npmScope: 'nxlv',
+
         projects: {
           app: {
             root: 'apps/app',
@@ -766,9 +764,9 @@ version = "1.0.0"
       root: '.',
       isVerbose: false,
       projectName: 'shared1',
-      workspace: {
+      projectsConfigurations: {
         version: 2,
-        npmScope: 'nxlv',
+
         projects: {
           app: {
             root: 'apps/app',

--- a/packages/nx-python/src/executors/update/executor.ts
+++ b/packages/nx-python/src/executors/update/executor.ts
@@ -20,7 +20,8 @@ export default async function executor(
   try {
     activateVenv(workspaceRoot);
     await checkPoetryExecutable();
-    const projectConfig = context.workspace.projects[context.projectName];
+    const projectConfig =
+      context.projectsConfigurations.projects[context.projectName];
     const rootPyprojectToml = existsSync('pyproject.toml');
 
     if (options.local && options.name) {
@@ -29,7 +30,7 @@ export default async function executor(
       );
 
       if (
-        !Object.keys(context.workspace.projects).some(
+        !Object.keys(context.projectsConfigurations.projects).some(
           (projectName) => options.name === projectName,
         )
       ) {

--- a/packages/nx-python/src/executors/utils/poetry.ts
+++ b/packages/nx-python/src/executors/utils/poetry.ts
@@ -105,7 +105,8 @@ export function getLocalDependencyConfig(
   context: ExecutorContext,
   dependencyName: string,
 ) {
-  const dependencyConfig = context.workspace.projects[dependencyName];
+  const dependencyConfig =
+    context.projectsConfigurations.projects[dependencyName];
   if (!dependencyConfig) {
     throw new Error(
       chalk`project {bold ${dependencyName}} not found in the Nx workspace`,


### PR DESCRIPTION
Hey!

First off, thank you for maintaining the python plugin for Nx. :) While doing some testing with the latest version of Nx, we found that this plugin does not work properly. This requires some changes because we removed a deprecated property from `context`. I've updated the references I found in this PR now.

Let me know if you have any questions or concerns, thanks!

## Current Behavior

<!-- This is the behavior we have today -->
Running this plugin with Nx 20 throws errors because of use of removed property on context.

## Expected Behavior

<!-- This is the behavior we should expect with the changes in this PR -->
Replaced `context.workspace` with `context.projectsConfigurations` which should be available since Nx 17. 

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
