### PR TITLE
feat: change publish executor to not fail if package version exists

### DIFF
--- a/packages/nx-python/src/executors/publish/executor.ts
+++ b/packages/nx-python/src/executors/publish/executor.ts
@@ -68,6 +68,15 @@ export default async function executor(
       success: true,
     };
   } catch (error) {
+    if (error.message && error.message.includes('File already exists')) {
+      logger.info(
+        chalk`\n  {bgYellow.bold  WARNING } {bold The package is already published}\n`,
+      );
+      return {
+        success: true,
+      };
+    }
+
     logger.info(chalk`\n  {bgRed.bold  ERROR } ${error.message}\n`);
     return {
       success: false,


### PR DESCRIPTION
## Current Behavior

When the publish executor is called and the version already exists, the executor fails.

## Expected Behavior

It should warn but not fail.