### PR TITLE
fix: capture stdout on the publish executor to check the error message

### DIFF
--- a/packages/nx-python/src/executors/utils/cmd.ts
+++ b/packages/nx-python/src/executors/utils/cmd.ts
@@ -1,0 +1,56 @@
+import type { SpawnSyncOptions } from 'child_process';
+import { spawn } from 'child_process';
+
+export type SpawnPromiseResult = {
+  success: boolean;
+  code: number | null;
+  output: string;
+};
+
+export const spawnPromise = function (
+  command: string,
+  cwd: string,
+  envVars?: Record<string, string | undefined>,
+  output = true,
+): Promise<SpawnPromiseResult> {
+  return new Promise((resolve, reject) => {
+    console.log(`Running command: ${command}`);
+    const env: Record<string, string> = {
+      ...process.env,
+      ...(envVars ?? {}),
+      ...(output ? { FORCE_COLOR: 'true' } : {}),
+    };
+
+    const args: SpawnSyncOptions = {
+      cwd,
+      shell: true,
+      stdio: output ? ['inherit', 'pipe', 'pipe'] : 'inherit',
+      env,
+    };
+
+    const child = spawn(command, args);
+    let outputStr = '';
+
+    if (output) {
+      child.stdout?.on('data', (data) => {
+        process.stdout.write(data);
+        outputStr += data;
+      });
+
+      child.stderr?.on('data', (data) => {
+        process.stderr.write(data);
+        outputStr += data;
+      });
+    }
+
+    child.on('close', (code) => {
+      const result = {
+        success: code === 0,
+        code,
+        output: outputStr,
+      };
+
+      code === 0 ? resolve(result) : reject(result);
+    });
+  });
+};


### PR DESCRIPTION
In the previous PR https://github.com/lucasvieirasilva/nx-plugins/pull/251 I've attempted to check the error message in the publish executor, however, the current code does return the the stdout.

This PR changes the way the command is executed to stdout to the terminal but also captures the CLI's return so I can check the content later.