### PR TITLE
Fix UV Package Manager Nx Release Feature

### DIFF
--- a/packages/nx-python/src/generators/release-version/release-version.ts
+++ b/packages/nx-python/src/generators/release-version/release-version.ts
@@ -1,9 +1,12 @@
 import {
+  ExpandedPluginConfiguration,
+  NxJsonConfiguration,
   ProjectGraphProjectNode,
   Tree,
   formatFiles,
   joinPathFragments,
   output,
+  readJson,
 } from '@nx/devkit';
 import chalk from 'chalk';
 import { exec } from 'node:child_process';
@@ -39,13 +42,26 @@ import {
 import { sortProjectsTopologically } from './utils/sort-projects-topologically';
 import path, { dirname } from 'node:path';
 import { getProvider } from '../../provider';
+import { PluginOptions } from '../../types';
 
 export async function releaseVersionGenerator(
   tree: Tree,
   options: ReleaseVersionGeneratorSchema,
 ): Promise<ReleaseVersionGeneratorResult> {
   let logger: ProjectLogger | undefined;
-  const provider = await getProvider('.', undefined, tree);
+  const nxJson = readJson<NxJsonConfiguration>(tree, 'nx.json');
+  const pluginConfig = nxJson.plugins?.find(
+    (plugin): plugin is ExpandedPluginConfiguration =>
+      typeof plugin === 'object' && plugin.plugin === '@nxlv/python',
+  );
+
+  const provider = await getProvider(
+    '.',
+    undefined,
+    tree,
+    undefined,
+    pluginConfig?.options as PluginOptions,
+  );
   const updatedProjects: string[] = [];
 
   try {

--- a/packages/nx-python/src/provider/uv/provider.ts
+++ b/packages/nx-python/src/provider/uv/provider.ts
@@ -94,9 +94,11 @@ export class UVProvider implements IProvider {
       ? readPyprojectToml<UVPyprojectToml>(this.tree, pyprojectTomlPath)
       : getPyprojectData<UVPyprojectToml>(pyprojectTomlPath);
 
-    const data = this.rootLockfile.package[projectData.project.name];
-    console.log('data', data);
+    const lockData = this.isWorkspace
+      ? this.rootLockfile
+      : getUvLockfile(joinPathFragments(projectRoot, 'uv.lock'), this.tree);
 
+    const data = lockData.package[projectData.project.name];
     const group = data?.dependencies?.find(
       (item) => item.name === dependencyName,
     )
@@ -106,8 +108,8 @@ export class UVProvider implements IProvider {
         )?.[0];
 
     return {
-      name: this.rootLockfile.package[dependencyName].name,
-      version: this.rootLockfile.package[dependencyName].version,
+      name: lockData.package[dependencyName].name,
+      version: lockData.package[dependencyName].version,
       group,
     };
   }


### PR DESCRIPTION
## Current Behavior

The Nx release generator always pick Poetry provider for non-workspace UV projects.

## Expected Behavior

the Nx release generator should resolve the right package manager.

## Related Issue(s)

Fixes #266 
