### PR TITLE
feat: add ruff-format executor for formatting files

### DIFF
--- a/packages/nx-python/executors.json
+++ b/packages/nx-python/executors.json
@@ -60,6 +60,11 @@
       "implementation": "./src/executors/ruff-check/executor",
       "schema": "./src/executors/ruff-check/schema.json",
       "description": "Ruff Check Executor"
+    },
+    "ruff-format": {
+      "implementation": "./src/executors/ruff-format/executor",
+      "schema": "./src/executors/ruff-format/schema.json",
+      "description": "Ruff Format Executor"
     }
   }
 }

--- a/packages/nx-python/src/executors/ruff-format/executor.spec.ts
+++ b/packages/nx-python/src/executors/ruff-format/executor.spec.ts
@@ -1,0 +1,347 @@
+import { vi, MockInstance } from 'vitest';
+import { vol } from 'memfs';
+import chalk from 'chalk';
+import '../../utils/mocks/fs.mock';
+import '../../utils/mocks/cross-spawn.mock';
+import * as poetryUtils from '../../provider/poetry/utils';
+import executor from './executor';
+import spawn from 'cross-spawn';
+import { ExecutorContext } from '@nx/devkit';
+import { UVProvider } from '../../provider/uv';
+
+describe('Ruff Format Executor', () => {
+  beforeAll(() => {
+    console.log(chalk`init chalk`);
+  });
+
+  afterEach(() => {
+    vol.reset();
+    vi.resetAllMocks();
+  });
+
+  describe('poetry', () => {
+    let checkPoetryExecutableMock: MockInstance;
+    let activateVenvMock: MockInstance;
+
+    beforeEach(() => {
+      checkPoetryExecutableMock = vi
+        .spyOn(poetryUtils, 'checkPoetryExecutable')
+        .mockResolvedValue(undefined);
+
+      activateVenvMock = vi
+        .spyOn(poetryUtils, 'activateVenv')
+        .mockReturnValue(undefined);
+
+      vi.mocked(spawn.sync).mockReturnValue({
+        status: 0,
+        output: [''],
+        pid: 0,
+        signal: null,
+        stderr: null,
+        stdout: null,
+      });
+      vi.spyOn(process, 'chdir').mockReturnValue(undefined);
+    });
+
+    it('should return success false when the poetry is not installed', async () => {
+      checkPoetryExecutableMock.mockRejectedValue(
+        new Error('poetry not found'),
+      );
+
+      const options = {
+        filePatterns: ['app'],
+        __unparsed__: [],
+      };
+
+      const context: ExecutorContext = {
+        cwd: '',
+        root: '.',
+        isVerbose: false,
+        projectName: 'app',
+        projectsConfigurations: {
+          version: 2,
+          projects: {
+            app: {
+              root: 'apps/app',
+              targets: {},
+            },
+          },
+        },
+        nxJsonConfiguration: {},
+        projectGraph: {
+          dependencies: {},
+          nodes: {},
+        },
+      };
+
+      const output = await executor(options, context);
+      expect(checkPoetryExecutableMock).toHaveBeenCalled();
+      expect(activateVenvMock).toHaveBeenCalledWith('.');
+      expect(spawn.sync).not.toHaveBeenCalled();
+      expect(output.success).toBe(false);
+    });
+
+    it('should execute ruff format', async () => {
+      vi.mocked(spawn.sync).mockReturnValueOnce({
+        status: 0,
+        output: [''],
+        pid: 0,
+        signal: null,
+        stderr: null,
+        stdout: null,
+      });
+
+      const output = await executor(
+        {
+          filePatterns: ['app'],
+          __unparsed__: [],
+        },
+        {
+          cwd: '',
+          root: '.',
+          isVerbose: false,
+          projectName: 'app',
+          projectsConfigurations: {
+            version: 2,
+            projects: {
+              app: {
+                root: 'apps/app',
+                targets: {},
+              },
+            },
+          },
+          nxJsonConfiguration: {},
+          projectGraph: {
+            dependencies: {},
+            nodes: {},
+          },
+        },
+      );
+      expect(checkPoetryExecutableMock).toHaveBeenCalled();
+      expect(activateVenvMock).toHaveBeenCalledWith('.');
+      expect(spawn.sync).toHaveBeenCalledTimes(1);
+      expect(spawn.sync).toHaveBeenCalledWith(
+        'poetry',
+        ['run', 'ruff', 'format', 'app'],
+        {
+          cwd: 'apps/app',
+          shell: true,
+          stdio: 'inherit',
+        },
+      );
+      expect(output.success).toBe(true);
+    });
+
+    it('should fail to execute ruff format ', async () => {
+      vi.mocked(spawn.sync).mockReturnValueOnce({
+        status: 1,
+        output: [''],
+        pid: 0,
+        signal: null,
+        stderr: null,
+        stdout: null,
+      });
+
+      const output = await executor(
+        {
+          filePatterns: ['app'],
+          __unparsed__: [],
+        },
+        {
+          cwd: '',
+          root: '.',
+          isVerbose: false,
+          projectName: 'app',
+          projectsConfigurations: {
+            version: 2,
+            projects: {
+              app: {
+                root: 'apps/app',
+                targets: {},
+              },
+            },
+          },
+          nxJsonConfiguration: {},
+          projectGraph: {
+            dependencies: {},
+            nodes: {},
+          },
+        },
+      );
+      expect(checkPoetryExecutableMock).toHaveBeenCalled();
+      expect(activateVenvMock).toHaveBeenCalledWith('.');
+      expect(spawn.sync).toHaveBeenCalledTimes(1);
+      expect(spawn.sync).toHaveBeenCalledWith(
+        'poetry',
+        ['run', 'ruff', 'format', 'app'],
+        {
+          cwd: 'apps/app',
+          shell: true,
+          stdio: 'inherit',
+        },
+      );
+      expect(output.success).toBe(false);
+    });
+  });
+
+  describe('uv', () => {
+    let checkPrerequisites: MockInstance;
+
+    beforeEach(() => {
+      checkPrerequisites = vi
+        .spyOn(UVProvider.prototype, 'checkPrerequisites')
+        .mockResolvedValue(undefined);
+
+      vi.mocked(spawn.sync).mockReturnValue({
+        status: 0,
+        output: [''],
+        pid: 0,
+        signal: null,
+        stderr: null,
+        stdout: null,
+      });
+      vi.spyOn(process, 'chdir').mockReturnValue(undefined);
+    });
+
+    beforeEach(() => {
+      vol.fromJSON({
+        'uv.lock': '',
+      });
+    });
+
+    it('should return success false when the uv is not installed', async () => {
+      checkPrerequisites.mockRejectedValue(new Error('uv not found'));
+
+      const options = {
+        filePatterns: ['app'],
+        __unparsed__: [],
+      };
+
+      const context: ExecutorContext = {
+        cwd: '',
+        root: '.',
+        isVerbose: false,
+        projectName: 'app',
+        projectsConfigurations: {
+          version: 2,
+          projects: {
+            app: {
+              root: 'apps/app',
+              targets: {},
+            },
+          },
+        },
+        nxJsonConfiguration: {},
+        projectGraph: {
+          dependencies: {},
+          nodes: {},
+        },
+      };
+
+      const output = await executor(options, context);
+      expect(checkPrerequisites).toHaveBeenCalled();
+      expect(spawn.sync).not.toHaveBeenCalled();
+      expect(output.success).toBe(false);
+    });
+
+    it('should execute ruff format', async () => {
+      vi.mocked(spawn.sync).mockReturnValueOnce({
+        status: 0,
+        output: [''],
+        pid: 0,
+        signal: null,
+        stderr: null,
+        stdout: null,
+      });
+
+      const output = await executor(
+        {
+          filePatterns: ['app'],
+          __unparsed__: [],
+        },
+        {
+          cwd: '',
+          root: '.',
+          isVerbose: false,
+          projectName: 'app',
+          projectsConfigurations: {
+            version: 2,
+            projects: {
+              app: {
+                root: 'apps/app',
+                targets: {},
+              },
+            },
+          },
+          nxJsonConfiguration: {},
+          projectGraph: {
+            dependencies: {},
+            nodes: {},
+          },
+        },
+      );
+      expect(checkPrerequisites).toHaveBeenCalled();
+      expect(spawn.sync).toHaveBeenCalledTimes(1);
+      expect(spawn.sync).toHaveBeenCalledWith(
+        'uv',
+        ['run', 'ruff', 'format', 'app'],
+        {
+          cwd: 'apps/app',
+          shell: true,
+          stdio: 'inherit',
+        },
+      );
+      expect(output.success).toBe(true);
+    });
+
+    it('should fail to execute ruff format ', async () => {
+      vi.mocked(spawn.sync).mockReturnValueOnce({
+        status: 1,
+        output: [''],
+        pid: 0,
+        signal: null,
+        stderr: null,
+        stdout: null,
+      });
+
+      const output = await executor(
+        {
+          filePatterns: ['app'],
+          __unparsed__: [],
+        },
+        {
+          cwd: '',
+          root: '.',
+          isVerbose: false,
+          projectName: 'app',
+          projectsConfigurations: {
+            version: 2,
+            projects: {
+              app: {
+                root: 'apps/app',
+                targets: {},
+              },
+            },
+          },
+          nxJsonConfiguration: {},
+          projectGraph: {
+            dependencies: {},
+            nodes: {},
+          },
+        },
+      );
+      expect(checkPrerequisites).toHaveBeenCalled();
+      expect(spawn.sync).toHaveBeenCalledTimes(1);
+      expect(spawn.sync).toHaveBeenCalledWith(
+        'uv',
+        ['run', 'ruff', 'format', 'app'],
+        {
+          cwd: 'apps/app',
+          shell: true,
+          stdio: 'inherit',
+        },
+      );
+      expect(output.success).toBe(false);
+    });
+  });
+});

--- a/packages/nx-python/src/executors/ruff-format/executor.ts
+++ b/packages/nx-python/src/executors/ruff-format/executor.ts
@@ -1,0 +1,49 @@
+import { ExecutorContext } from '@nx/devkit';
+import chalk from 'chalk';
+import { Logger } from '../utils/logger';
+import { RuffFormatExecutorSchema } from './schema';
+import { getProvider } from '../../provider';
+
+const logger = new Logger();
+
+export default async function executor(
+  options: RuffFormatExecutorSchema,
+  context: ExecutorContext,
+) {
+  const workspaceRoot = context.root;
+  process.chdir(workspaceRoot);
+  try {
+    logger.info(
+      chalk`\n{bold Running ruff format on project {bgBlue  ${context.projectName} }...}\n`,
+    );
+
+    const projectConfig =
+      context.projectsConfigurations.projects[context.projectName];
+
+    const commandArgs = ['ruff', 'format']
+      .concat(options.filePatterns)
+      .concat(options.__unparsed__);
+
+    const provider = await getProvider(
+      workspaceRoot,
+      undefined,
+      undefined,
+      context,
+    );
+    await provider.run(commandArgs, workspaceRoot, {
+      cwd: projectConfig.root,
+      log: false,
+      error: true,
+      shell: true,
+    });
+
+    return {
+      success: true,
+    };
+  } catch (error) {
+    logger.info(chalk`\n  {bgRed.bold  ERROR } ${error.message}\n`);
+    return {
+      success: false,
+    };
+  }
+}

--- a/packages/nx-python/src/executors/ruff-format/schema.d.ts
+++ b/packages/nx-python/src/executors/ruff-format/schema.d.ts
@@ -1,0 +1,4 @@
+export interface RuffFormatExecutorSchema {
+  filePatterns: string[];
+  __unparsed__: string[];
+}

--- a/packages/nx-python/src/executors/ruff-format/schema.json
+++ b/packages/nx-python/src/executors/ruff-format/schema.json
@@ -1,0 +1,27 @@
+{
+  "$schema": "http://json-schema.org/schema",
+  "title": "Ruff Format executor",
+  "description": "Run ruff format on the given folders/files, this executor forwards all arguments to ruff format, see https://docs.astral.sh/ruff/formatter/#ruff-format for more details.",
+  "type": "object",
+  "properties": {
+    "filePatterns": {
+      "type": "array",
+      "description": "File patterns to format (relative path to the project root)",
+      "items": {
+        "type": "string"
+      }
+    },
+    "__unparsed__": {
+      "hidden": true,
+      "type": "array",
+      "items": {
+        "type": "string"
+      },
+      "$default": {
+        "$source": "unparsed"
+      },
+      "x-priority": "internal"
+    }
+  },
+  "required": ["filePatterns"]
+}

--- a/packages/nx-python/src/generators/poetry-project/__snapshots__/generator.spec.ts.snap
+++ b/packages/nx-python/src/generators/poetry-project/__snapshots__/generator.spec.ts.snap
@@ -2098,6 +2098,17 @@ exports[`application generator > individual package > should run successfully wi
         "{projectRoot}/dist",
       ],
     },
+    "format": {
+      "cache": true,
+      "executor": "@nxlv/python:ruff-format",
+      "options": {
+        "filePatterns": [
+          "test",
+          "tests",
+        ],
+      },
+      "outputs": [],
+    },
     "install": {
       "executor": "@nxlv/python:install",
       "options": {
@@ -2553,6 +2564,16 @@ exports[`application generator > individual package > should run successfully wi
         "{projectRoot}/dist",
       ],
     },
+    "format": {
+      "cache": true,
+      "executor": "@nxlv/python:ruff-format",
+      "options": {
+        "filePatterns": [
+          "test",
+        ],
+      },
+      "outputs": [],
+    },
     "install": {
       "executor": "@nxlv/python:install",
       "options": {
@@ -2697,6 +2718,17 @@ exports[`application generator > individual package > should run successfully wi
       "outputs": [
         "{projectRoot}/dist",
       ],
+    },
+    "format": {
+      "cache": true,
+      "executor": "@nxlv/python:ruff-format",
+      "options": {
+        "filePatterns": [
+          "test",
+          "tests",
+        ],
+      },
+      "outputs": [],
     },
     "install": {
       "executor": "@nxlv/python:install",

--- a/packages/nx-python/src/generators/poetry-project/generator.ts
+++ b/packages/nx-python/src/generators/poetry-project/generator.ts
@@ -21,6 +21,7 @@ import {
 import {
   addFiles,
   normalizeOptions as baseNormalizeOptions,
+  getDefaultPythonProjectTargets,
   getPyprojectTomlByProjectName,
 } from '../utils';
 import { DEV_DEPENDENCIES_VERSION_MAP } from '../consts';
@@ -218,35 +219,13 @@ export default async function (
   const normalizedOptions = normalizeOptions(tree, options);
 
   const targets: ProjectConfiguration['targets'] = {
+    ...getDefaultPythonProjectTargets(normalizedOptions),
     lock: {
       executor: '@nxlv/python:run-commands',
       options: {
         command: 'poetry lock --no-update',
         cwd: normalizedOptions.projectRoot,
       },
-    },
-    add: {
-      executor: '@nxlv/python:add',
-      options: {},
-    },
-    update: {
-      executor: '@nxlv/python:update',
-      options: {},
-    },
-    remove: {
-      executor: '@nxlv/python:remove',
-      options: {},
-    },
-    build: {
-      executor: '@nxlv/python:build',
-      outputs: ['{projectRoot}/dist'],
-      options: {
-        outputPath: `${normalizedOptions.projectRoot}/dist`,
-        publish: normalizedOptions.publishable,
-        lockedVersions: normalizedOptions.buildLockedVersions,
-        bundleLocalDependencies: normalizedOptions.buildBundleLocalDependencies,
-      },
-      cache: true,
     },
     install: {
       executor: '@nxlv/python:install',
@@ -259,43 +238,6 @@ export default async function (
       },
     },
   };
-
-  if (options.linter === 'flake8') {
-    targets.lint = {
-      executor: '@nxlv/python:flake8',
-      outputs: [
-        `{workspaceRoot}/reports/${normalizedOptions.projectRoot}/pylint.txt`,
-      ],
-      options: {
-        outputFile: `reports/${normalizedOptions.projectRoot}/pylint.txt`,
-      },
-      cache: true,
-    };
-  }
-
-  if (options.linter === 'ruff') {
-    targets.lint = {
-      executor: '@nxlv/python:ruff-check',
-      outputs: [],
-      options: {
-        lintFilePatterns: [normalizedOptions.moduleName].concat(
-          options.unitTestRunner === 'pytest' ? ['tests'] : [],
-        ),
-      },
-      cache: true,
-    };
-
-    targets.format = {
-      executor: '@nxlv/python:ruff-format',
-      outputs: [],
-      options: {
-        filePatterns: [normalizedOptions.moduleName].concat(
-          options.unitTestRunner === 'pytest' ? ['tests'] : [],
-        ),
-      },
-      cache: true,
-    };
-  }
 
   if (options.unitTestRunner === 'pytest') {
     targets.test = {

--- a/packages/nx-python/src/generators/poetry-project/generator.ts
+++ b/packages/nx-python/src/generators/poetry-project/generator.ts
@@ -1,9 +1,6 @@
 import {
   addProjectConfiguration,
   formatFiles,
-  generateFiles,
-  names,
-  offsetFromRoot,
   ProjectConfiguration,
   readProjectConfiguration,
   Tree,
@@ -22,6 +19,7 @@ import {
   BasePythonProjectGeneratorSchema,
 } from '../types';
 import {
+  addFiles,
   normalizeOptions as baseNormalizeOptions,
   getPyprojectTomlByProjectName,
 } from '../utils';
@@ -65,51 +63,6 @@ function normalizeOptions(
     devDependenciesProjectPkgName,
     individualPackage: !tree.exists('pyproject.toml'),
   };
-}
-
-function addFiles(tree: Tree, options: NormalizedSchema) {
-  const templateOptions = {
-    ...options,
-    ...names(options.name),
-    offsetFromRoot: offsetFromRoot(options.projectRoot),
-    template: '',
-    dot: '.',
-    versionMap: DEV_DEPENDENCIES_VERSION_MAP,
-  };
-  if (options.templateDir) {
-    generateFiles(
-      tree,
-      path.join(options.templateDir),
-      options.projectRoot,
-      templateOptions,
-    );
-    return;
-  }
-
-  generateFiles(
-    tree,
-    path.join(__dirname, 'files', 'base'),
-    options.projectRoot,
-    templateOptions,
-  );
-
-  if (options.unitTestRunner === 'pytest') {
-    generateFiles(
-      tree,
-      path.join(__dirname, 'files', 'pytest'),
-      options.projectRoot,
-      templateOptions,
-    );
-  }
-
-  if (options.linter === 'flake8') {
-    generateFiles(
-      tree,
-      path.join(__dirname, 'files', 'flake8'),
-      options.projectRoot,
-      templateOptions,
-    );
-  }
 }
 
 function updateRootPyprojectToml(
@@ -388,7 +341,7 @@ export default async function (
     projectConfiguration,
   );
 
-  addFiles(tree, normalizedOptions);
+  addFiles(tree, normalizedOptions, __dirname);
   updateDevDependenciesProject(tree, normalizedOptions);
   updateRootPyprojectToml(tree, normalizedOptions);
   await formatFiles(tree);

--- a/packages/nx-python/src/generators/poetry-project/generator.ts
+++ b/packages/nx-python/src/generators/poetry-project/generator.ts
@@ -331,6 +331,17 @@ export default async function (
       },
       cache: true,
     };
+
+    targets.format = {
+      executor: '@nxlv/python:ruff-format',
+      outputs: [],
+      options: {
+        filePatterns: [normalizedOptions.moduleName].concat(
+          options.unitTestRunner === 'pytest' ? ['tests'] : [],
+        ),
+      },
+      cache: true,
+    };
   }
 
   if (options.unitTestRunner === 'pytest') {

--- a/packages/nx-python/src/generators/uv-project/__snapshots__/generator.spec.ts.snap
+++ b/packages/nx-python/src/generators/uv-project/__snapshots__/generator.spec.ts.snap
@@ -2048,6 +2048,17 @@ exports[`application generator > project > should run successfully with linting 
         "{projectRoot}/dist",
       ],
     },
+    "format": {
+      "cache": true,
+      "executor": "@nxlv/python:ruff-format",
+      "options": {
+        "filePatterns": [
+          "test",
+          "tests",
+        ],
+      },
+      "outputs": [],
+    },
     "install": {
       "executor": "@nxlv/python:install",
       "options": {
@@ -2557,6 +2568,16 @@ exports[`application generator > project > should run successfully with ruff lin
         "{projectRoot}/dist",
       ],
     },
+    "format": {
+      "cache": true,
+      "executor": "@nxlv/python:ruff-format",
+      "options": {
+        "filePatterns": [
+          "test",
+        ],
+      },
+      "outputs": [],
+    },
     "install": {
       "executor": "@nxlv/python:install",
       "options": {
@@ -2708,6 +2729,17 @@ exports[`application generator > project > should run successfully with ruff lin
       "outputs": [
         "{projectRoot}/dist",
       ],
+    },
+    "format": {
+      "cache": true,
+      "executor": "@nxlv/python:ruff-format",
+      "options": {
+        "filePatterns": [
+          "test",
+          "tests",
+        ],
+      },
+      "outputs": [],
     },
     "install": {
       "executor": "@nxlv/python:install",

--- a/packages/nx-python/src/generators/uv-project/generator.ts
+++ b/packages/nx-python/src/generators/uv-project/generator.ts
@@ -347,6 +347,17 @@ export default async function (
       },
       cache: true,
     };
+
+    targets.format = {
+      executor: '@nxlv/python:ruff-format',
+      outputs: [],
+      options: {
+        filePatterns: [normalizedOptions.moduleName].concat(
+          options.unitTestRunner === 'pytest' ? ['tests'] : [],
+        ),
+      },
+      cache: true,
+    };
   }
 
   if (options.unitTestRunner === 'pytest') {

--- a/packages/nx-python/src/generators/uv-project/generator.ts
+++ b/packages/nx-python/src/generators/uv-project/generator.ts
@@ -15,6 +15,7 @@ import { DEV_DEPENDENCIES_VERSION_MAP } from '../consts';
 import {
   addFiles,
   normalizeOptions as baseNormalizeOptions,
+  getDefaultPythonProjectTargets,
   getPyprojectTomlByProjectName,
 } from '../utils';
 import {
@@ -235,35 +236,13 @@ export default async function (
   const normalizedOptions = normalizeOptions(tree, options);
 
   const targets: ProjectConfiguration['targets'] = {
+    ...getDefaultPythonProjectTargets(normalizedOptions),
     lock: {
       executor: '@nxlv/python:run-commands',
       options: {
         command: 'uv lock',
         cwd: normalizedOptions.projectRoot,
       },
-    },
-    add: {
-      executor: '@nxlv/python:add',
-      options: {},
-    },
-    update: {
-      executor: '@nxlv/python:update',
-      options: {},
-    },
-    remove: {
-      executor: '@nxlv/python:remove',
-      options: {},
-    },
-    build: {
-      executor: '@nxlv/python:build',
-      outputs: ['{projectRoot}/dist'],
-      options: {
-        outputPath: `${normalizedOptions.projectRoot}/dist`,
-        publish: normalizedOptions.publishable,
-        lockedVersions: normalizedOptions.buildLockedVersions,
-        bundleLocalDependencies: normalizedOptions.buildBundleLocalDependencies,
-      },
-      cache: true,
     },
     install: {
       executor: '@nxlv/python:install',
@@ -275,43 +254,6 @@ export default async function (
       },
     },
   };
-
-  if (options.linter === 'flake8') {
-    targets.lint = {
-      executor: '@nxlv/python:flake8',
-      outputs: [
-        `{workspaceRoot}/reports/${normalizedOptions.projectRoot}/pylint.txt`,
-      ],
-      options: {
-        outputFile: `reports/${normalizedOptions.projectRoot}/pylint.txt`,
-      },
-      cache: true,
-    };
-  }
-
-  if (options.linter === 'ruff') {
-    targets.lint = {
-      executor: '@nxlv/python:ruff-check',
-      outputs: [],
-      options: {
-        lintFilePatterns: [normalizedOptions.moduleName].concat(
-          options.unitTestRunner === 'pytest' ? ['tests'] : [],
-        ),
-      },
-      cache: true,
-    };
-
-    targets.format = {
-      executor: '@nxlv/python:ruff-format',
-      outputs: [],
-      options: {
-        filePatterns: [normalizedOptions.moduleName].concat(
-          options.unitTestRunner === 'pytest' ? ['tests'] : [],
-        ),
-      },
-      cache: true,
-    };
-  }
 
   if (options.unitTestRunner === 'pytest') {
     targets.test = {

--- a/packages/nx-python/src/generators/uv-project/generator.ts
+++ b/packages/nx-python/src/generators/uv-project/generator.ts
@@ -1,9 +1,6 @@
 import {
   addProjectConfiguration,
   formatFiles,
-  generateFiles,
-  names,
-  offsetFromRoot,
   ProjectConfiguration,
   readProjectConfiguration,
   Tree,
@@ -16,6 +13,7 @@ import { UVPyprojectToml } from '../../provider/uv/types';
 import { checkUvExecutable, runUv } from '../../provider/uv/utils';
 import { DEV_DEPENDENCIES_VERSION_MAP } from '../consts';
 import {
+  addFiles,
   normalizeOptions as baseNormalizeOptions,
   getPyprojectTomlByProjectName,
 } from '../utils';
@@ -61,51 +59,6 @@ function normalizeOptions(
     devDependenciesProjectPkgName,
     individualPackage: !tree.exists('pyproject.toml'),
   };
-}
-
-function addFiles(tree: Tree, options: NormalizedSchema) {
-  const templateOptions = {
-    ...options,
-    ...names(options.name),
-    offsetFromRoot: offsetFromRoot(options.projectRoot),
-    template: '',
-    dot: '.',
-    versionMap: DEV_DEPENDENCIES_VERSION_MAP,
-  };
-  if (options.templateDir) {
-    generateFiles(
-      tree,
-      path.join(options.templateDir),
-      options.projectRoot,
-      templateOptions,
-    );
-    return;
-  }
-
-  generateFiles(
-    tree,
-    path.join(__dirname, 'files', 'base'),
-    options.projectRoot,
-    templateOptions,
-  );
-
-  if (options.unitTestRunner === 'pytest') {
-    generateFiles(
-      tree,
-      path.join(__dirname, 'files', 'pytest'),
-      options.projectRoot,
-      templateOptions,
-    );
-  }
-
-  if (options.linter === 'flake8') {
-    generateFiles(
-      tree,
-      path.join(__dirname, 'files', 'flake8'),
-      options.projectRoot,
-      templateOptions,
-    );
-  }
 }
 
 function updateRootPyprojectToml(
@@ -404,7 +357,7 @@ export default async function (
     projectConfiguration,
   );
 
-  addFiles(tree, normalizedOptions);
+  addFiles(tree, normalizedOptions, __dirname);
   updateDevDependenciesProject(tree, normalizedOptions);
   updateRootPyprojectToml(tree, normalizedOptions);
   await formatFiles(tree);


### PR DESCRIPTION
This PR adds a new executor `ruff-format` that wraps the `ruff format` command.

## Current Behavior

The user needs to create a Nx target with `@nxlv/python:run-commands` to run the ruff format.

## Expected Behavior

The `ruff-format` should run the `ruff format` similarly as `ruff-check` executor, and if the user selects `ruff` as linter when creating a new python project, the `format` target needs to automatically added to the `project.json`

## Related Issue(s)

Fixes #269 
