### PR TITLE
fix: handle optional poetry dependencies and improve dependency resolution logic

### DIFF
--- a/packages/nx-python/src/provider/poetry/build/resolvers/project.ts
+++ b/packages/nx-python/src/provider/poetry/build/resolvers/project.ts
@@ -52,7 +52,9 @@ export class ProjectDependencyResolver {
     const deps: PackageDependency[] = [];
 
     const dependencies = Object.entries(
-      pyproject.tool.poetry.dependencies,
+      pyproject.tool?.poetry?.dependencies ??
+        pyproject.tool?.poetry?.group?.main?.dependencies ??
+        {},
     ).filter(([name]) => name != 'python');
 
     for (const [name, data] of dependencies) {


### PR DESCRIPTION
This PR fixes the poetry's main dependency resolution for non-locked builds to support the explicit format `group.main` or implicit `poetry.dependencies`

## Current Behavior

As reported here https://github.com/lucasvieirasilva/nx-plugins/issues/270#issuecomment-2623555654, when changed from `[tool.poetry.dependencies]` to `[tool.poetry.group.main.dependencies]` the build target breaks.

## Expected Behavior

The build target should work regardless the format of the main dependencies (implicit or explicit)

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #270 
