### PR TITLE
fix: fix lock behavior during uv build

### DIFF
--- a/packages/nx-python/src/executors/build/executor.spec.ts
+++ b/packages/nx-python/src/executors/build/executor.spec.ts
@@ -3275,8 +3275,6 @@ describe('Build Executor', () => {
             [tool.uv.sources]
             dep1 = { workspace = true }
             `,
-
-            'apps/app/uv.lock': '',
           });
 
           vi.mocked(spawn.sync)
@@ -3428,7 +3426,6 @@ describe('Build Executor', () => {
             [tool.hatch.build.targets.wheel]
             packages = ["dep1"]
             `,
-            'libs/dep1/uv.lock': '',
           });
 
           vi.mocked(spawn.sync)
@@ -3581,7 +3578,6 @@ describe('Build Executor', () => {
             [tool.hatch.build.targets.wheel]
             packages = ["dep1"]
             `,
-            'libs/dep1/uv.lock': '',
           });
 
           vi.mocked(spawn.sync)
@@ -3735,7 +3731,6 @@ describe('Build Executor', () => {
             [tool.hatch.build.targets.wheel]
             packages = ["dep1"]
             `,
-            'libs/dep1/uv.lock': '',
           });
 
           vi.mocked(spawn.sync)
@@ -3831,7 +3826,8 @@ describe('Build Executor', () => {
           expect(output.success).toBe(true);
         });
 
-        it('should run uv lock command before executing the export command', async () => {
+        it('should run uv lock command before executing the export command if lock file does not exist', async () => {
+          vol.rmSync('uv.lock');
           vol.fromJSON({
             'apps/app/app1/index.py': 'print("Hello from app")',
             'apps/app/pyproject.toml': dedent`

--- a/packages/nx-python/src/provider/uv/build/resolvers/locked.ts
+++ b/packages/nx-python/src/provider/uv/build/resolvers/locked.ts
@@ -108,7 +108,7 @@ export class LockedDependencyResolver {
       exportArgs.push('--no-dev');
     }
 
-    if (!existsSync(path.join(projectRoot, 'uv.lock'))) {
+    if (!this.lockFileExists(projectRoot, workspaceRoot)) {
       this.logger.info('  Generating uv.lock file');
       const lockCmd = spawn.sync(UV_EXECUTABLE, ['lock'], {
         cwd: projectRoot,
@@ -136,5 +136,13 @@ export class LockedDependencyResolver {
     }
 
     return result.stdout.toString('utf-8');
+  }
+
+  private lockFileExists(projectRoot: string, workspaceRoot: string): boolean {
+    if (this.isWorkspace) {
+      return existsSync(path.join(workspaceRoot, 'uv.lock'));
+    } else {
+      return existsSync(path.join(projectRoot, 'uv.lock'));
+    }
   }
 }


### PR DESCRIPTION
## Current Behavior

When the `build` executor is run on a project in a uv workspace, `uv lock` is run if `{workspaceRoot}/path/to/project/uv.lock` does not exist.

## Expected Behavior

When the `build` executor is run on a project in a uv workspace, `uv lock` is run if `{workspaceRoot}/uv.lock` does not exist.

---

Also, while we're here, don't create `{workspaceRoot}/path/to/project/uv.lock` files in uv workspace tests, since such files won't exist in a uv workspace.