### PR TITLE
feat(nx-python): add an optional fix option for the ruff-check executor

### DIFF
--- a/packages/nx-python/src/executors/ruff-check/executor.spec.ts
+++ b/packages/nx-python/src/executors/ruff-check/executor.spec.ts
@@ -294,6 +294,57 @@ describe('Ruff Check Executor', () => {
       expect(output.success).toBe(true);
     });
 
+    it('should execute ruff check linting', async () => {
+      vi.mocked(spawn.sync).mockReturnValueOnce({
+        status: 0,
+        output: [''],
+        pid: 0,
+        signal: null,
+        stderr: null,
+        stdout: null,
+      });
+
+      const output = await executor(
+        {
+          lintFilePatterns: ['app'],
+          fix: true,
+          __unparsed__: [],
+        },
+        {
+          cwd: '',
+          root: '.',
+          isVerbose: false,
+          projectName: 'app',
+          projectsConfigurations: {
+            version: 2,
+            projects: {
+              app: {
+                root: 'apps/app',
+                targets: {},
+              },
+            },
+          },
+          nxJsonConfiguration: {},
+          projectGraph: {
+            dependencies: {},
+            nodes: {},
+          },
+        },
+      );
+      expect(checkPrerequisites).toHaveBeenCalled();
+      expect(spawn.sync).toHaveBeenCalledTimes(1);
+      expect(spawn.sync).toHaveBeenCalledWith(
+        'uv',
+        ['run', 'ruff', 'check', 'app', '--fix'],
+        {
+          cwd: 'apps/app',
+          shell: true,
+          stdio: 'inherit',
+        },
+      );
+      expect(output.success).toBe(true);
+    });
+
     it('should fail to execute ruff check linting ', async () => {
       vi.mocked(spawn.sync).mockReturnValueOnce({
         status: 1,

--- a/packages/nx-python/src/executors/ruff-check/executor.ts
+++ b/packages/nx-python/src/executors/ruff-check/executor.ts
@@ -24,6 +24,10 @@ export default async function executor(
       .concat(options.lintFilePatterns)
       .concat(options.__unparsed__);
 
+    if (options.fix) {
+      commandArgs.push('--fix');
+    }
+
     const provider = await getProvider(
       workspaceRoot,
       undefined,

--- a/packages/nx-python/src/executors/ruff-check/schema.d.ts
+++ b/packages/nx-python/src/executors/ruff-check/schema.d.ts
@@ -1,4 +1,5 @@
 export interface RuffCheckExecutorSchema {
   lintFilePatterns: string[];
+  fix?: boolean;
   __unparsed__: string[];
 }

--- a/packages/nx-python/src/executors/ruff-check/schema.json
+++ b/packages/nx-python/src/executors/ruff-check/schema.json
@@ -11,6 +11,12 @@
         "type": "string"
       }
     },
+    "fix": {
+      "type": "boolean",
+      "description": "Fixes linting errors (may overwrite linted files).",
+      "default": false,
+      "x-priority": "important"
+    },
     "__unparsed__": {
       "hidden": true,
       "type": "array",


### PR DESCRIPTION
Allows a user to configure whether they want to fix lint errors via nx configurations by setting the fix property to true.

## Current Behavior

Users are unable to specify whether a lint task should fix errors via[ NX configuration](https://nx.dev/recipes/running-tasks/pass-args-to-commands#pass-args-in-the-projectjson-task-configuration)

## Expected Behavior

Assume I have a `targetDefaults` in `nx.json` as follows:

```
"lint": {
      "cache": true,
      "configurations": {
        "fix": {
          "fix": true
        }
      },
      "inputs": [
        "default",
        "{workspaceRoot}/eslint.config.mjs",
        "{projectRoot}/eslint.config.mjs"
      ]
    }
```

By specifying `fix` as true, when the ruff-check executor runs it will append the `--fix` flag.

I tried working around this via:

```
"configurations": {
        "fix": {
          "__unparsed__":"--fix"
        }
      }
```
however NX doesn't respect the inputs passed in and is always resolved to [].