### PR TITLE
fix: read uv sources from root pyproject.toml

### DIFF
--- a/packages/nx-python/src/graph/dependency-graph.spec.ts
+++ b/packages/nx-python/src/graph/dependency-graph.spec.ts
@@ -485,6 +485,8 @@ describe('nx-python dependency graph', () => {
           dependencies = []
           `,
 
+          'pyproject.toml': '',
+
           'uv.lock': dedent`
           version = 1
           requires-python = ">=3.12"
@@ -595,6 +597,8 @@ describe('nx-python dependency graph', () => {
           packages = ["dep1"]
           `,
 
+          'pyproject.toml': '',
+
           'uv.lock': dedent`
           version = 1
           requires-python = ">=3.12"
@@ -697,6 +701,8 @@ describe('nx-python dependency graph', () => {
           packages = ["dep1"]
           `,
 
+          'pyproject.toml': '',
+
           'uv.lock': dedent`
           version = 1
           requires-python = ">=3.12"
@@ -727,6 +733,92 @@ describe('nx-python dependency graph', () => {
               { name = "ruff", specifier = ">=0.8.2" },
           ]
           other = [
+              { name = "dep1", editable = "libs/dep1" },
+          ]
+          `,
+        });
+
+        const projects = {
+          app1: {
+            root: 'apps/app1',
+            targets: {},
+          },
+          dep1: {
+            root: 'libs/dep1',
+            targets: {},
+          },
+        };
+
+        const result = await createDependencies(null, {
+          externalNodes: {},
+          workspaceRoot: '.',
+          projects,
+          nxJsonConfiguration: {},
+          fileMap: {
+            nonProjectFiles: [],
+            projectFileMap: {},
+          },
+          filesToProcess: {
+            nonProjectFiles: [],
+            projectFileMap: {},
+          },
+        });
+
+        expect(result).toStrictEqual([
+          {
+            source: 'app1',
+            target: 'dep1',
+            type: 'implicit',
+          },
+        ]);
+      });
+
+      it('should read sources from root pyproject.toml', async () => {
+        vol.fromJSON({
+          'apps/app1/pyproject.toml': dedent`
+          [project]
+          name = "app1"
+          version = "0.1.0"
+          readme = "README.md"
+          requires-python = ">=3.12"
+          dependencies = ["dep1"]
+
+          [tool.hatch.build.targets.wheel]
+          packages = ["app1"]
+          `,
+
+          'libs/dep1/pyproject.toml': dedent`
+          [project]
+          name = "dep1"
+          version = "0.1.0"
+          readme = "README.md"
+          requires-python = ">=3.12"
+          dependencies = []
+
+          [tool.hatch.build.targets.wheel]
+          packages = ["dep1"]
+          `,
+
+          'pyproject.toml': dedent`
+          [tool.uv.sources]
+          app1 = { workspace = true }
+          dep1 = { workspace = true }
+          `,
+
+          'uv.lock': dedent`
+          version = 1
+          requires-python = ">=3.12"
+
+          [[package]]
+          name = "app1"
+          version = "0.1.0"
+          source = { editable = "apps/app1" }
+          dependencies = [
+              { name = "dep1" },
+          ]
+
+          [package.metadata]
+          requires-dist = [
               { name = "dep1", editable = "libs/dep1" },
           ]
           `,
@@ -832,6 +924,8 @@ describe('nx-python dependency graph', () => {
           requires-python = ">=3.12"
           dependencies = []
           `,
+
+          'pyproject.toml': '',
 
           'uv.lock': dedent`
           version = 1
@@ -939,6 +1033,7 @@ describe('nx-python dependency graph', () => {
           requires-python = ">=3.12"
           dependencies = []
           `,
+          'pyproject.toml': '',
           'uv.lock': dedent`
           version = 1
           requires-python = ">=3.12"
@@ -1031,6 +1126,8 @@ describe('nx-python dependency graph', () => {
           dependencies = []
           `,
 
+          'pyproject.toml': '',
+
           'uv.lock': dedent`
           version = 1
           requires-python = ">=3.12"
@@ -1078,6 +1175,7 @@ describe('nx-python dependency graph', () => {
           requires-python = ">=3.12"
           dependencies = []
           `,
+          'pyproject.toml': '',
           'uv.lock': dedent`
           version = 1
           requires-python = ">=3.12"


### PR DESCRIPTION
If workspace sources are listed (in `tool.uv.sources`) in the root `pyproject.toml`, they do not need to also be listed in a project's `pyproject.toml`.

## Current Behavior

If project A depends on project B, and the `tool.uv.sources` entry for project B is present only in the root `pyproject.toml`, no implicit dependency from A to B is created. 

## Expected Behavior

If project A depends on project B, and the `tool.uv.sources` entry for project B is present only in the root `pyproject.toml`, an implicit dependency from A to B should be created.