### PR TITLE
feat(nx-python): add sync and lock executors

### DIFF
--- a/packages/nx-python/README.md
+++ b/packages/nx-python/README.md
@@ -551,6 +551,53 @@ The `@nxlv/python:install` handles the `install` command for a project.
 | `--verbose`  | `boolean` | Use verbose mode in the install `poetry install -vv` | `false`  | `false` |
 | `--debug`    | `boolean` | Use debug mode in the install `poetry install -vvv`  | `false`  | `false` |
 
+#### sync
+
+The `@nxlv/python:sync` executor handles sync the locked dependencies with the python virtual environment.
+
+- `poetry`:
+  - v1: `poetry install --sync`
+  - v2: `poetry sync`
+- `uv`: `uv sync`
+
+##### Options
+
+| Option       |   Type    | Description                                                 | Required | Default |
+| ------------ | :-------: | ----------------------------------------------------------- | -------- | ------- |
+| `--silent`   | `boolean` | Hide output text                                            | `false`  | `false` |
+| `--args`     | `string`  | Custom arguments (e.g `--check dev`)                        | `false`  |         |
+| `--cacheDir` | `string`  | Custom poetry install cache directory                       | `false`  |         |
+| `--verbose`  | `boolean` | Use verbose mode in the install (e.g. `poetry install -vv`) | `false`  | `false` |
+| `--debug`    | `boolean` | Use debug mode in the install (e.g. `poetry install -vvv`)  | `false`  | `false` |
+
+#### lock
+
+The `@nxlv/python:lock` executor handles the `lock` command for a project.
+
+- `poetry`:
+  - With default options:
+    - v1: `poetry lock --no-update`
+    - v2: `poetry lock`
+  - With update option:
+    - v1: `poetry lock`
+    - v2: `poetry lock --regenerate`
+- `uv`:
+  - With default options:
+    - `uv lock`
+  - With update option:
+    - `uv lock --upgrade`
+
+##### Options
+
+| Option       |   Type    | Description                                              | Required | Default |
+| ------------ | :-------: | -------------------------------------------------------- | -------- | ------- |
+| `--silent`   | `boolean` | Hide output text                                         | `false`  | `false` |
+| `--args`     | `string`  | Custom arguments (e.g `--check dev`)                     | `false`  |         |
+| `--cacheDir` | `string`  | Custom poetry install cache directory                    | `false`  |         |
+| `--verbose`  | `boolean` | Use verbose mode in the install (e.g. `poetry lock -vv`) | `false`  | `false` |
+| `--debug`    | `boolean` | Use debug mode in the install (e.g. `poetry lock -vvv`)  | `false`  | `false` |
+| `--update`   | `boolean` | Update dependencies versions                             | `false`  | `false` |
+
 #### publish
 
 The `@nxlv/python:publish` executor handles the `publish` command for a project.

--- a/packages/nx-python/executors.json
+++ b/packages/nx-python/executors.json
@@ -65,6 +65,16 @@
       "implementation": "./src/executors/ruff-format/executor",
       "schema": "./src/executors/ruff-format/schema.json",
       "description": "Ruff Format Executor"
+    },
+    "sync": {
+      "implementation": "./src/executors/sync/executor",
+      "schema": "./src/executors/sync/schema.json",
+      "description": "Sync Dependencies Executor"
+    },
+    "lock": {
+      "implementation": "./src/executors/lock/executor",
+      "schema": "./src/executors/lock/schema.json",
+      "description": "Lock Dependencies Executor"
     }
   }
 }

--- a/packages/nx-python/src/executors/lock/executor.spec.ts
+++ b/packages/nx-python/src/executors/lock/executor.spec.ts
@@ -1,0 +1,528 @@
+import { vi, MockInstance } from 'vitest';
+import { vol } from 'memfs';
+import '../../utils/mocks/fs.mock';
+import '../../utils/mocks/cross-spawn.mock';
+import * as poetryUtils from '../../provider/poetry/utils';
+import executor from './executor';
+import path from 'path';
+import spawn from 'cross-spawn';
+import { ExecutorContext } from '@nx/devkit';
+import { UVProvider } from '../../provider/uv';
+import dedent from 'string-dedent';
+
+describe('Lock Executor', () => {
+  const context: ExecutorContext = {
+    cwd: '',
+    root: '.',
+    isVerbose: false,
+    projectName: 'app',
+    projectsConfigurations: {
+      version: 2,
+      projects: {
+        app: {
+          root: 'apps/app',
+          targets: {},
+        },
+      },
+    },
+    nxJsonConfiguration: {},
+    projectGraph: {
+      dependencies: {},
+      nodes: {},
+    },
+  };
+
+  afterEach(() => {
+    vol.reset();
+    vi.resetAllMocks();
+  });
+
+  describe('poetry', () => {
+    let checkPoetryExecutableMock: MockInstance;
+    let checkPoetryVersionMock: MockInstance;
+
+    beforeEach(() => {
+      checkPoetryExecutableMock = vi
+        .spyOn(poetryUtils, 'checkPoetryExecutable')
+        .mockResolvedValue(undefined);
+
+      checkPoetryVersionMock = vi
+        .spyOn(poetryUtils, 'getPoetryVersion')
+        .mockResolvedValue('1.0.0');
+
+      vi.mocked(spawn.sync).mockReturnValue({
+        status: 0,
+        output: [''],
+        pid: 0,
+        signal: null,
+        stderr: null,
+        stdout: null,
+      });
+      vi.spyOn(process, 'chdir').mockReturnValue(undefined);
+    });
+
+    it('should return success false when the poetry is not installed', async () => {
+      checkPoetryExecutableMock.mockRejectedValue(
+        new Error('poetry not found'),
+      );
+
+      const options = {
+        silent: false,
+        debug: false,
+        verbose: false,
+        update: false,
+      };
+
+      const context: ExecutorContext = {
+        cwd: '',
+        root: '.',
+        isVerbose: false,
+        projectName: 'app',
+        projectsConfigurations: {
+          version: 2,
+          projects: {
+            app: {
+              root: 'apps/app',
+              targets: {},
+            },
+          },
+        },
+        nxJsonConfiguration: {},
+        projectGraph: {
+          dependencies: {},
+          nodes: {},
+        },
+      };
+
+      const output = await executor(options, context);
+      expect(checkPoetryExecutableMock).toHaveBeenCalled();
+      expect(spawn.sync).not.toHaveBeenCalled();
+      expect(output.success).toBe(false);
+    });
+
+    it('should lock the poetry dependencies using default values', async () => {
+      const options = {
+        silent: false,
+        debug: false,
+        verbose: false,
+        update: false,
+      };
+
+      const output = await executor(options, context);
+      expect(checkPoetryExecutableMock).toHaveBeenCalled();
+      expect(spawn.sync).toHaveBeenCalledWith(
+        'poetry',
+        ['lock', '--no-update'],
+        {
+          stdio: 'inherit',
+          shell: false,
+          cwd: 'apps/app',
+        },
+      );
+      expect(output.success).toBe(true);
+    });
+
+    it('should lock the poetry dependencies with args', async () => {
+      const options = {
+        silent: false,
+        debug: false,
+        verbose: false,
+        args: '--check',
+        update: false,
+      };
+
+      const output = await executor(options, context);
+      expect(checkPoetryExecutableMock).toHaveBeenCalled();
+      expect(spawn.sync).toHaveBeenCalledWith(
+        'poetry',
+        ['lock', '--no-update', '--check'],
+        {
+          stdio: 'inherit',
+          shell: false,
+          cwd: 'apps/app',
+        },
+      );
+      expect(output.success).toBe(true);
+    });
+
+    it('should lock the poetry dependencies with verbose flag', async () => {
+      const options = {
+        silent: false,
+        debug: false,
+        verbose: true,
+        update: false,
+      };
+
+      const output = await executor(options, context);
+      expect(checkPoetryExecutableMock).toHaveBeenCalled();
+      expect(spawn.sync).toHaveBeenCalledWith(
+        'poetry',
+        ['lock', '--no-update', '-v'],
+        {
+          stdio: 'inherit',
+          shell: false,
+          cwd: 'apps/app',
+        },
+      );
+      expect(output.success).toBe(true);
+    });
+
+    it('should lock the poetry dependencies with debug flag', async () => {
+      const options = {
+        silent: false,
+        debug: true,
+        verbose: false,
+        update: false,
+      };
+
+      const output = await executor(options, context);
+      expect(checkPoetryExecutableMock).toHaveBeenCalled();
+      expect(spawn.sync).toHaveBeenCalledWith(
+        'poetry',
+        ['lock', '--no-update', '-vvv'],
+        {
+          stdio: 'inherit',
+          shell: false,
+          cwd: 'apps/app',
+        },
+      );
+      expect(output.success).toBe(true);
+    });
+
+    it('should lock the poetry dependencies with custom cache dir', async () => {
+      const options = {
+        silent: false,
+        debug: false,
+        verbose: false,
+        cacheDir: 'apps/app/.cache/pypoetry',
+        update: false,
+      };
+
+      const output = await executor(options, context);
+      expect(checkPoetryExecutableMock).toHaveBeenCalled();
+      expect(spawn.sync).toHaveBeenCalledWith(
+        'poetry',
+        ['lock', '--no-update'],
+        {
+          stdio: 'inherit',
+          cwd: 'apps/app',
+          shell: false,
+          env: {
+            ...process.env,
+            POETRY_CACHE_DIR: path.resolve('apps/app/.cache/pypoetry'),
+          },
+        },
+      );
+      expect(output.success).toBe(true);
+    });
+
+    it('should lock the poetry dependencies with update true (poetry v1.x)', async () => {
+      const options = {
+        silent: false,
+        debug: false,
+        verbose: false,
+        update: true,
+      };
+
+      const output = await executor(options, context);
+      expect(checkPoetryExecutableMock).toHaveBeenCalled();
+      expect(spawn.sync).toHaveBeenCalledWith('poetry', ['lock'], {
+        stdio: 'inherit',
+        cwd: 'apps/app',
+        shell: false,
+      });
+      expect(output.success).toBe(true);
+    });
+
+    it('should lock the poetry dependencies with update true (poetry v2.x)', async () => {
+      checkPoetryVersionMock.mockResolvedValue('2.0.0');
+
+      const options = {
+        silent: false,
+        debug: false,
+        verbose: false,
+        update: true,
+      };
+
+      const output = await executor(options, context);
+      expect(checkPoetryExecutableMock).toHaveBeenCalled();
+      expect(spawn.sync).toHaveBeenCalledWith(
+        'poetry',
+        ['lock', '--regenerate'],
+        {
+          stdio: 'inherit',
+          cwd: 'apps/app',
+          shell: false,
+        },
+      );
+      expect(output.success).toBe(true);
+    });
+
+    it('should not lock when the command fail', async () => {
+      vi.mocked(spawn.sync).mockImplementation(() => {
+        throw new Error('fake');
+      });
+
+      const options = {
+        silent: false,
+        debug: false,
+        verbose: false,
+        cacheDir: 'apps/app/.cache/pypoetry',
+        update: false,
+      };
+
+      const output = await executor(options, context);
+      expect(checkPoetryExecutableMock).toHaveBeenCalled();
+      expect(spawn.sync).toHaveBeenCalledWith(
+        'poetry',
+        ['lock', '--no-update'],
+        {
+          stdio: 'inherit',
+          shell: false,
+          cwd: 'apps/app',
+          env: {
+            ...process.env,
+            POETRY_CACHE_DIR: path.resolve('apps/app/.cache/pypoetry'),
+          },
+        },
+      );
+      expect(output.success).toBe(false);
+    });
+  });
+
+  describe('uv', () => {
+    let checkPrerequisites: MockInstance;
+
+    beforeEach(() => {
+      vi.resetAllMocks();
+
+      checkPrerequisites = vi
+        .spyOn(UVProvider.prototype, 'checkPrerequisites')
+        .mockResolvedValue(undefined);
+
+      vi.mocked(spawn.sync).mockReturnValue({
+        status: 0,
+        output: [''],
+        pid: 0,
+        signal: null,
+        stderr: null,
+        stdout: null,
+      });
+      vi.spyOn(process, 'chdir').mockReturnValue(undefined);
+    });
+
+    describe('worskpace', () => {
+      beforeEach(() => {
+        vol.fromJSON({
+          'uv.lock': '',
+        });
+      });
+
+      it('should return success false when the uv is not installed', async () => {
+        checkPrerequisites.mockRejectedValue(new Error('uv not found'));
+
+        const options = {
+          silent: false,
+          debug: false,
+          verbose: false,
+          update: false,
+        };
+
+        const context: ExecutorContext = {
+          cwd: '',
+          root: '.',
+          isVerbose: false,
+          projectName: 'app',
+          projectsConfigurations: {
+            version: 2,
+            projects: {
+              app: {
+                root: 'apps/app',
+                targets: {},
+              },
+            },
+          },
+          nxJsonConfiguration: {},
+          projectGraph: {
+            dependencies: {},
+            nodes: {},
+          },
+        };
+
+        const output = await executor(options, context);
+        expect(checkPrerequisites).toHaveBeenCalled();
+        expect(spawn.sync).not.toHaveBeenCalled();
+        expect(output.success).toBe(false);
+      });
+
+      it('should lock the dependencies using default values', async () => {
+        const options = {
+          silent: false,
+          debug: false,
+          verbose: false,
+          update: false,
+        };
+
+        const output = await executor(options, context);
+        expect(checkPrerequisites).toHaveBeenCalled();
+        expect(spawn.sync).toHaveBeenCalledWith('uv', ['lock'], {
+          stdio: 'inherit',
+          shell: false,
+          cwd: '.',
+        });
+        expect(output.success).toBe(true);
+      });
+
+      it('should lock the dependencies with args', async () => {
+        const options = {
+          silent: false,
+          debug: false,
+          verbose: false,
+          args: '--frozen',
+          update: false,
+        };
+
+        const output = await executor(options, context);
+        expect(checkPrerequisites).toHaveBeenCalled();
+        expect(spawn.sync).toHaveBeenCalledWith('uv', ['lock', '--frozen'], {
+          stdio: 'inherit',
+          shell: false,
+          cwd: '.',
+        });
+        expect(output.success).toBe(true);
+      });
+
+      it('should lock the dependencies with verbose flag', async () => {
+        const options = {
+          silent: false,
+          debug: false,
+          verbose: true,
+          update: false,
+        };
+
+        const output = await executor(options, context);
+        expect(checkPrerequisites).toHaveBeenCalled();
+        expect(spawn.sync).toHaveBeenCalledWith('uv', ['lock', '-v'], {
+          stdio: 'inherit',
+          shell: false,
+          cwd: '.',
+        });
+        expect(output.success).toBe(true);
+      });
+
+      it('should lock the dependencies with debug flag', async () => {
+        const options = {
+          silent: false,
+          debug: true,
+          verbose: false,
+          update: false,
+        };
+
+        const output = await executor(options, context);
+        expect(checkPrerequisites).toHaveBeenCalled();
+        expect(spawn.sync).toHaveBeenCalledWith('uv', ['lock', '-vvv'], {
+          stdio: 'inherit',
+          shell: false,
+          cwd: '.',
+        });
+        expect(output.success).toBe(true);
+      });
+
+      it('should lock the dependencies with custom cache dir', async () => {
+        const options = {
+          silent: false,
+          debug: false,
+          verbose: false,
+          cacheDir: 'apps/app/.cache/custom',
+          update: false,
+        };
+
+        const output = await executor(options, context);
+        expect(checkPrerequisites).toHaveBeenCalled();
+        expect(spawn.sync).toHaveBeenCalledWith(
+          'uv',
+          ['lock', '--cache-dir', 'apps/app/.cache/custom'],
+          {
+            stdio: 'inherit',
+            cwd: '.',
+            shell: false,
+          },
+        );
+        expect(output.success).toBe(true);
+      });
+
+      it('should lock the dependencies with update true', async () => {
+        const options = {
+          silent: false,
+          debug: false,
+          verbose: false,
+          update: true,
+        };
+
+        const output = await executor(options, context);
+        expect(checkPrerequisites).toHaveBeenCalled();
+        expect(spawn.sync).toHaveBeenCalledWith('uv', ['lock', '--upgrade'], {
+          stdio: 'inherit',
+          cwd: '.',
+          shell: false,
+        });
+        expect(output.success).toBe(true);
+      });
+
+      it('should not lock when the command fail', async () => {
+        vi.mocked(spawn.sync).mockImplementation(() => {
+          throw new Error('fake');
+        });
+
+        const options = {
+          silent: false,
+          debug: false,
+          verbose: false,
+          update: false,
+        };
+
+        const output = await executor(options, context);
+        expect(checkPrerequisites).toHaveBeenCalled();
+        expect(spawn.sync).toHaveBeenCalledWith('uv', ['lock'], {
+          stdio: 'inherit',
+          shell: false,
+          cwd: '.',
+        });
+        expect(output.success).toBe(false);
+      });
+    });
+
+    describe('project', () => {
+      beforeEach(() => {
+        vol.fromJSON({
+          'apps/app/pyproject.toml': dedent`
+          [project]
+          name = "app"
+          version = "0.1.0"
+          readme = "README.md"
+          requires-python = ">=3.12"
+          dependencies = []
+          `,
+        });
+      });
+
+      it('should lock the dependencies using default values', async () => {
+        const options = {
+          silent: false,
+          debug: false,
+          verbose: false,
+          update: false,
+        };
+
+        const output = await executor(options, context);
+        expect(checkPrerequisites).toHaveBeenCalled();
+        expect(spawn.sync).toHaveBeenCalledWith('uv', ['lock'], {
+          stdio: 'inherit',
+          shell: false,
+          cwd: 'apps/app',
+        });
+        expect(output.success).toBe(true);
+      });
+    });
+  });
+});

--- a/packages/nx-python/src/executors/lock/executor.ts
+++ b/packages/nx-python/src/executors/lock/executor.ts
@@ -1,0 +1,34 @@
+import { LockExecutorSchema } from './schema';
+import { Logger } from '../utils/logger';
+import { ExecutorContext } from '@nx/devkit';
+import chalk from 'chalk';
+import { getProvider } from '../../provider';
+
+const logger = new Logger();
+
+export default async function executor(
+  options: LockExecutorSchema,
+  context: ExecutorContext,
+) {
+  logger.setOptions(options);
+  const workspaceRoot = context.root;
+  process.chdir(workspaceRoot);
+  try {
+    const provider = await getProvider(
+      workspaceRoot,
+      logger,
+      undefined,
+      context,
+    );
+    await provider.lock(options, context);
+
+    return {
+      success: true,
+    };
+  } catch (error) {
+    logger.info(chalk`\n  {bgRed.bold  ERROR } ${error.message}\n`);
+    return {
+      success: false,
+    };
+  }
+}

--- a/packages/nx-python/src/executors/lock/schema.d.ts
+++ b/packages/nx-python/src/executors/lock/schema.d.ts
@@ -1,0 +1,8 @@
+export interface LockExecutorSchema {
+  silent: boolean;
+  args?: string;
+  cacheDir?: string;
+  verbose: boolean;
+  debug: boolean;
+  update: boolean;
+}

--- a/packages/nx-python/src/executors/lock/schema.json
+++ b/packages/nx-python/src/executors/lock/schema.json
@@ -1,0 +1,37 @@
+{
+  "$schema": "http://json-schema.org/schema",
+  "title": "Lock executor",
+  "description": "",
+  "type": "object",
+  "properties": {
+    "silent": {
+      "type": "boolean",
+      "description": "Hide output text.",
+      "default": false
+    },
+    "args": {
+      "type": "string",
+      "description": "Lock custom args"
+    },
+    "cacheDir": {
+      "type": "string",
+      "description": "Lock Custom Cache Directory"
+    },
+    "verbose": {
+      "type": "boolean",
+      "description": "Verbose level '-vv'",
+      "default": false
+    },
+    "debug": {
+      "type": "boolean",
+      "description": "Verbose debug level '-vvv'",
+      "default": false
+    },
+    "update": {
+      "type": "boolean",
+      "description": "Upgrade the dependencies",
+      "default": false
+    }
+  },
+  "required": []
+}

--- a/packages/nx-python/src/executors/sync/executor.spec.ts
+++ b/packages/nx-python/src/executors/sync/executor.spec.ts
@@ -1,0 +1,458 @@
+import { vi, MockInstance } from 'vitest';
+import { vol } from 'memfs';
+import '../../utils/mocks/fs.mock';
+import '../../utils/mocks/cross-spawn.mock';
+import * as poetryUtils from '../../provider/poetry/utils';
+import executor from './executor';
+import path from 'path';
+import spawn from 'cross-spawn';
+import { ExecutorContext } from '@nx/devkit';
+import { UVProvider } from '../../provider/uv';
+import dedent from 'string-dedent';
+
+describe('Sync Executor', () => {
+  const context: ExecutorContext = {
+    cwd: '',
+    root: '.',
+    isVerbose: false,
+    projectName: 'app',
+    projectsConfigurations: {
+      version: 2,
+      projects: {
+        app: {
+          root: 'apps/app',
+          targets: {},
+        },
+      },
+    },
+    nxJsonConfiguration: {},
+    projectGraph: {
+      dependencies: {},
+      nodes: {},
+    },
+  };
+
+  afterEach(() => {
+    vol.reset();
+    vi.resetAllMocks();
+  });
+
+  describe('poetry', () => {
+    let checkPoetryExecutableMock: MockInstance;
+    let checkPoetryVersionMock: MockInstance;
+    beforeEach(() => {
+      checkPoetryExecutableMock = vi
+        .spyOn(poetryUtils, 'checkPoetryExecutable')
+        .mockResolvedValue(undefined);
+
+      checkPoetryVersionMock = vi
+        .spyOn(poetryUtils, 'getPoetryVersion')
+        .mockResolvedValue('1.0.0');
+
+      vi.mocked(spawn.sync).mockReturnValue({
+        status: 0,
+        output: [''],
+        pid: 0,
+        signal: null,
+        stderr: null,
+        stdout: null,
+      });
+      vi.spyOn(process, 'chdir').mockReturnValue(undefined);
+    });
+
+    it('should return success false when the poetry is not installed', async () => {
+      checkPoetryExecutableMock.mockRejectedValue(
+        new Error('poetry not found'),
+      );
+
+      const options = {
+        silent: false,
+        debug: false,
+        verbose: false,
+      };
+
+      const context: ExecutorContext = {
+        cwd: '',
+        root: '.',
+        isVerbose: false,
+        projectName: 'app',
+        projectsConfigurations: {
+          version: 2,
+          projects: {
+            app: {
+              root: 'apps/app',
+              targets: {},
+            },
+          },
+        },
+        nxJsonConfiguration: {},
+        projectGraph: {
+          dependencies: {},
+          nodes: {},
+        },
+      };
+
+      const output = await executor(options, context);
+      expect(checkPoetryExecutableMock).toHaveBeenCalled();
+      expect(spawn.sync).not.toHaveBeenCalled();
+      expect(output.success).toBe(false);
+    });
+
+    it('should sync the poetry dependencies using default values', async () => {
+      const options = {
+        silent: false,
+        debug: false,
+        verbose: false,
+      };
+
+      const output = await executor(options, context);
+      expect(checkPoetryExecutableMock).toHaveBeenCalled();
+      expect(spawn.sync).toHaveBeenCalledWith('poetry', ['install', '--sync'], {
+        stdio: 'inherit',
+        shell: false,
+        cwd: 'apps/app',
+      });
+      expect(output.success).toBe(true);
+    });
+
+    it('should lock the poetry dependencies with args', async () => {
+      const options = {
+        silent: false,
+        debug: false,
+        verbose: false,
+        args: '--no-dev',
+      };
+
+      const output = await executor(options, context);
+      expect(checkPoetryExecutableMock).toHaveBeenCalled();
+      expect(spawn.sync).toHaveBeenCalledWith(
+        'poetry',
+        ['install', '--sync', '--no-dev'],
+        {
+          stdio: 'inherit',
+          shell: false,
+          cwd: 'apps/app',
+        },
+      );
+      expect(output.success).toBe(true);
+    });
+
+    it('should sync the poetry dependencies with verbose flag', async () => {
+      const options = {
+        silent: false,
+        debug: false,
+        verbose: true,
+      };
+
+      const output = await executor(options, context);
+      expect(checkPoetryExecutableMock).toHaveBeenCalled();
+      expect(spawn.sync).toHaveBeenCalledWith(
+        'poetry',
+        ['install', '--sync', '-v'],
+        {
+          stdio: 'inherit',
+          shell: false,
+          cwd: 'apps/app',
+        },
+      );
+      expect(output.success).toBe(true);
+    });
+
+    it('should sync the poetry dependencies with debug flag', async () => {
+      const options = {
+        silent: false,
+        debug: true,
+        verbose: false,
+      };
+
+      const output = await executor(options, context);
+      expect(checkPoetryExecutableMock).toHaveBeenCalled();
+      expect(spawn.sync).toHaveBeenCalledWith(
+        'poetry',
+        ['install', '--sync', '-vvv'],
+        {
+          stdio: 'inherit',
+          shell: false,
+          cwd: 'apps/app',
+        },
+      );
+      expect(output.success).toBe(true);
+    });
+
+    it('should sync the poetry dependencies with custom cache dir', async () => {
+      const options = {
+        silent: false,
+        debug: false,
+        verbose: false,
+        cacheDir: 'apps/app/.cache/pypoetry',
+      };
+
+      const output = await executor(options, context);
+      expect(checkPoetryExecutableMock).toHaveBeenCalled();
+      expect(spawn.sync).toHaveBeenCalledWith('poetry', ['install', '--sync'], {
+        stdio: 'inherit',
+        cwd: 'apps/app',
+        shell: false,
+        env: {
+          ...process.env,
+          POETRY_CACHE_DIR: path.resolve('apps/app/.cache/pypoetry'),
+        },
+      });
+      expect(output.success).toBe(true);
+    });
+
+    it('should sync the poetry dependencies with python v2.x', async () => {
+      checkPoetryVersionMock.mockResolvedValue('2.0.0');
+      const options = {
+        silent: false,
+        debug: false,
+        verbose: false,
+      };
+
+      const output = await executor(options, context);
+      expect(checkPoetryExecutableMock).toHaveBeenCalled();
+      expect(spawn.sync).toHaveBeenCalledWith('poetry', ['sync'], {
+        stdio: 'inherit',
+        cwd: 'apps/app',
+        shell: false,
+      });
+      expect(output.success).toBe(true);
+    });
+
+    it('should not sync when the command fail', async () => {
+      vi.mocked(spawn.sync).mockImplementation(() => {
+        throw new Error('fake');
+      });
+
+      const options = {
+        silent: false,
+        debug: false,
+        verbose: false,
+        cacheDir: 'apps/app/.cache/pypoetry',
+      };
+
+      const output = await executor(options, context);
+      expect(checkPoetryExecutableMock).toHaveBeenCalled();
+      expect(spawn.sync).toHaveBeenCalledWith('poetry', ['install', '--sync'], {
+        stdio: 'inherit',
+        shell: false,
+        cwd: 'apps/app',
+        env: {
+          ...process.env,
+          POETRY_CACHE_DIR: path.resolve('apps/app/.cache/pypoetry'),
+        },
+      });
+      expect(output.success).toBe(false);
+    });
+  });
+
+  describe('uv', () => {
+    let checkPrerequisites: MockInstance;
+
+    beforeEach(() => {
+      vi.resetAllMocks();
+
+      checkPrerequisites = vi
+        .spyOn(UVProvider.prototype, 'checkPrerequisites')
+        .mockResolvedValue(undefined);
+
+      vi.mocked(spawn.sync).mockReturnValue({
+        status: 0,
+        output: [''],
+        pid: 0,
+        signal: null,
+        stderr: null,
+        stdout: null,
+      });
+      vi.spyOn(process, 'chdir').mockReturnValue(undefined);
+    });
+
+    describe('worskpace', () => {
+      beforeEach(() => {
+        vol.fromJSON({
+          'uv.lock': '',
+        });
+      });
+
+      it('should return success false when the uv is not installed', async () => {
+        checkPrerequisites.mockRejectedValue(new Error('uv not found'));
+
+        const options = {
+          silent: false,
+          debug: false,
+          verbose: false,
+        };
+
+        const context: ExecutorContext = {
+          cwd: '',
+          root: '.',
+          isVerbose: false,
+          projectName: 'app',
+          projectsConfigurations: {
+            version: 2,
+            projects: {
+              app: {
+                root: 'apps/app',
+                targets: {},
+              },
+            },
+          },
+          nxJsonConfiguration: {},
+          projectGraph: {
+            dependencies: {},
+            nodes: {},
+          },
+        };
+
+        const output = await executor(options, context);
+        expect(checkPrerequisites).toHaveBeenCalled();
+        expect(spawn.sync).not.toHaveBeenCalled();
+        expect(output.success).toBe(false);
+      });
+
+      it('should sync the dependencies using default values', async () => {
+        const options = {
+          silent: false,
+          debug: false,
+          verbose: false,
+        };
+
+        const output = await executor(options, context);
+        expect(checkPrerequisites).toHaveBeenCalled();
+        expect(spawn.sync).toHaveBeenCalledWith('uv', ['sync'], {
+          stdio: 'inherit',
+          shell: false,
+          cwd: '.',
+        });
+        expect(output.success).toBe(true);
+      });
+
+      it('should sync the dependencies with args', async () => {
+        const options = {
+          silent: false,
+          debug: false,
+          verbose: false,
+          args: '--no-dev',
+        };
+
+        const output = await executor(options, context);
+        expect(checkPrerequisites).toHaveBeenCalled();
+        expect(spawn.sync).toHaveBeenCalledWith('uv', ['sync', '--no-dev'], {
+          stdio: 'inherit',
+          shell: false,
+          cwd: '.',
+        });
+        expect(output.success).toBe(true);
+      });
+
+      it('should sync the dependencies with verbose flag', async () => {
+        const options = {
+          silent: false,
+          debug: false,
+          verbose: true,
+        };
+
+        const output = await executor(options, context);
+        expect(checkPrerequisites).toHaveBeenCalled();
+        expect(spawn.sync).toHaveBeenCalledWith('uv', ['sync', '-v'], {
+          stdio: 'inherit',
+          shell: false,
+          cwd: '.',
+        });
+        expect(output.success).toBe(true);
+      });
+
+      it('should sync the dependencies with debug flag', async () => {
+        const options = {
+          silent: false,
+          debug: true,
+          verbose: false,
+        };
+
+        const output = await executor(options, context);
+        expect(checkPrerequisites).toHaveBeenCalled();
+        expect(spawn.sync).toHaveBeenCalledWith('uv', ['sync', '-vvv'], {
+          stdio: 'inherit',
+          shell: false,
+          cwd: '.',
+        });
+        expect(output.success).toBe(true);
+      });
+
+      it('should sync the dependencies with custom cache dir', async () => {
+        const options = {
+          silent: false,
+          debug: false,
+          verbose: false,
+          cacheDir: 'apps/app/.cache/custom',
+        };
+
+        const output = await executor(options, context);
+        expect(checkPrerequisites).toHaveBeenCalled();
+        expect(spawn.sync).toHaveBeenCalledWith(
+          'uv',
+          ['sync', '--cache-dir', 'apps/app/.cache/custom'],
+          {
+            stdio: 'inherit',
+            cwd: '.',
+            shell: false,
+          },
+        );
+        expect(output.success).toBe(true);
+      });
+
+      it('should not sync when the command fail', async () => {
+        vi.mocked(spawn.sync).mockImplementation(() => {
+          throw new Error('fake');
+        });
+
+        const options = {
+          silent: false,
+          debug: false,
+          verbose: false,
+        };
+
+        const output = await executor(options, context);
+        expect(checkPrerequisites).toHaveBeenCalled();
+        expect(spawn.sync).toHaveBeenCalledWith('uv', ['sync'], {
+          stdio: 'inherit',
+          shell: false,
+          cwd: '.',
+        });
+        expect(output.success).toBe(false);
+      });
+    });
+
+    describe('project', () => {
+      beforeEach(() => {
+        vol.fromJSON({
+          'apps/app/pyproject.toml': dedent`
+          [project]
+          name = "app"
+          version = "0.1.0"
+          readme = "README.md"
+          requires-python = ">=3.12"
+          dependencies = []
+          `,
+        });
+      });
+
+      it('should sync the dependencies using default values', async () => {
+        const options = {
+          silent: false,
+          debug: false,
+          verbose: false,
+        };
+
+        const output = await executor(options, context);
+        expect(checkPrerequisites).toHaveBeenCalled();
+        expect(spawn.sync).toHaveBeenCalledWith('uv', ['sync'], {
+          stdio: 'inherit',
+          shell: false,
+          cwd: 'apps/app',
+        });
+        expect(output.success).toBe(true);
+      });
+    });
+  });
+});

--- a/packages/nx-python/src/executors/sync/executor.ts
+++ b/packages/nx-python/src/executors/sync/executor.ts
@@ -1,0 +1,34 @@
+import { SyncExecutorSchema } from './schema';
+import { Logger } from '../utils/logger';
+import { ExecutorContext } from '@nx/devkit';
+import chalk from 'chalk';
+import { getProvider } from '../../provider';
+
+const logger = new Logger();
+
+export default async function executor(
+  options: SyncExecutorSchema,
+  context: ExecutorContext,
+) {
+  logger.setOptions(options);
+  const workspaceRoot = context.root;
+  process.chdir(workspaceRoot);
+  try {
+    const provider = await getProvider(
+      workspaceRoot,
+      logger,
+      undefined,
+      context,
+    );
+    await provider.sync(options, context);
+
+    return {
+      success: true,
+    };
+  } catch (error) {
+    logger.info(chalk`\n  {bgRed.bold  ERROR } ${error.message}\n`);
+    return {
+      success: false,
+    };
+  }
+}

--- a/packages/nx-python/src/executors/sync/schema.d.ts
+++ b/packages/nx-python/src/executors/sync/schema.d.ts
@@ -1,0 +1,7 @@
+export interface SyncExecutorSchema {
+  silent: boolean;
+  args?: string;
+  cacheDir?: string;
+  verbose: boolean;
+  debug: boolean;
+}

--- a/packages/nx-python/src/executors/sync/schema.json
+++ b/packages/nx-python/src/executors/sync/schema.json
@@ -1,0 +1,32 @@
+{
+  "$schema": "http://json-schema.org/schema",
+  "title": "Sync executor",
+  "description": "",
+  "type": "object",
+  "properties": {
+    "silent": {
+      "type": "boolean",
+      "description": "Hide output text.",
+      "default": false
+    },
+    "args": {
+      "type": "string",
+      "description": "Sync custom args"
+    },
+    "cacheDir": {
+      "type": "string",
+      "description": "Sync Custom Cache Directory"
+    },
+    "verbose": {
+      "type": "boolean",
+      "description": "Verbose level '-vv'",
+      "default": false
+    },
+    "debug": {
+      "type": "boolean",
+      "description": "Verbose debug level '-vvv'",
+      "default": false
+    }
+  },
+  "required": []
+}

--- a/packages/nx-python/src/generators/poetry-project/__snapshots__/generator.spec.ts.snap
+++ b/packages/nx-python/src/generators/poetry-project/__snapshots__/generator.spec.ts.snap
@@ -42,14 +42,17 @@ exports[`application generator > as-provided > should run successfully minimal c
       },
     },
     "lock": {
-      "executor": "@nxlv/python:run-commands",
+      "executor": "@nxlv/python:lock",
       "options": {
-        "command": "poetry lock --no-update",
-        "cwd": "src/app/test",
+        "update": false,
       },
     },
     "remove": {
       "executor": "@nxlv/python:remove",
+      "options": {},
+    },
+    "sync": {
+      "executor": "@nxlv/python:sync",
       "options": {},
     },
     "update": {
@@ -145,14 +148,17 @@ exports[`application generator > as-provided > should run successfully minimal c
       },
     },
     "lock": {
-      "executor": "@nxlv/python:run-commands",
+      "executor": "@nxlv/python:lock",
       "options": {
-        "command": "poetry lock --no-update",
-        "cwd": "my-app-test",
+        "update": false,
       },
     },
     "remove": {
       "executor": "@nxlv/python:remove",
+      "options": {},
+    },
+    "sync": {
+      "executor": "@nxlv/python:sync",
       "options": {},
     },
     "update": {
@@ -248,14 +254,17 @@ exports[`application generator > custom template dir > should run successfully w
       },
     },
     "lock": {
-      "executor": "@nxlv/python:run-commands",
+      "executor": "@nxlv/python:lock",
       "options": {
-        "command": "poetry lock --no-update",
-        "cwd": "apps/test",
+        "update": false,
       },
     },
     "remove": {
       "executor": "@nxlv/python:remove",
+      "options": {},
+    },
+    "sync": {
+      "executor": "@nxlv/python:sync",
       "options": {},
     },
     "update": {
@@ -333,14 +342,17 @@ exports[`application generator > individual package > should run successfully mi
       },
     },
     "lock": {
-      "executor": "@nxlv/python:run-commands",
+      "executor": "@nxlv/python:lock",
       "options": {
-        "command": "poetry lock --no-update",
-        "cwd": "apps/test",
+        "update": false,
       },
     },
     "remove": {
       "executor": "@nxlv/python:remove",
+      "options": {},
+    },
+    "sync": {
+      "executor": "@nxlv/python:sync",
       "options": {},
     },
     "update": {
@@ -436,14 +448,17 @@ exports[`application generator > individual package > should run successfully mi
       },
     },
     "lock": {
-      "executor": "@nxlv/python:run-commands",
+      "executor": "@nxlv/python:lock",
       "options": {
-        "command": "poetry lock --no-update",
-        "cwd": "libs/test",
+        "update": false,
       },
     },
     "remove": {
       "executor": "@nxlv/python:remove",
+      "options": {},
+    },
+    "sync": {
+      "executor": "@nxlv/python:sync",
       "options": {},
     },
     "update": {
@@ -539,14 +554,17 @@ exports[`application generator > individual package > should run successfully mi
       },
     },
     "lock": {
-      "executor": "@nxlv/python:run-commands",
+      "executor": "@nxlv/python:lock",
       "options": {
-        "command": "poetry lock --no-update",
-        "cwd": "apps/subdir/test",
+        "update": false,
       },
     },
     "remove": {
       "executor": "@nxlv/python:remove",
+      "options": {},
+    },
+    "sync": {
+      "executor": "@nxlv/python:sync",
       "options": {},
     },
     "update": {
@@ -645,14 +663,17 @@ exports[`application generator > individual package > should run successfully mi
       },
     },
     "lock": {
-      "executor": "@nxlv/python:run-commands",
+      "executor": "@nxlv/python:lock",
       "options": {
-        "command": "poetry lock --no-update",
-        "cwd": "apps/test",
+        "update": false,
       },
     },
     "remove": {
       "executor": "@nxlv/python:remove",
+      "options": {},
+    },
+    "sync": {
+      "executor": "@nxlv/python:sync",
       "options": {},
     },
     "update": {
@@ -758,14 +779,17 @@ exports[`application generator > individual package > should run successfully wi
       ],
     },
     "lock": {
-      "executor": "@nxlv/python:run-commands",
+      "executor": "@nxlv/python:lock",
       "options": {
-        "command": "poetry lock --no-update",
-        "cwd": "apps/test",
+        "update": false,
       },
     },
     "remove": {
       "executor": "@nxlv/python:remove",
+      "options": {},
+    },
+    "sync": {
+      "executor": "@nxlv/python:sync",
       "options": {},
     },
     "update": {
@@ -890,14 +914,17 @@ exports[`application generator > individual package > should run successfully wi
       ],
     },
     "lock": {
-      "executor": "@nxlv/python:run-commands",
+      "executor": "@nxlv/python:lock",
       "options": {
-        "command": "poetry lock --no-update",
-        "cwd": "apps/test",
+        "update": false,
       },
     },
     "remove": {
       "executor": "@nxlv/python:remove",
+      "options": {},
+    },
+    "sync": {
+      "executor": "@nxlv/python:sync",
       "options": {},
     },
     "test": {
@@ -1061,14 +1088,17 @@ exports[`application generator > individual package > should run successfully wi
       ],
     },
     "lock": {
-      "executor": "@nxlv/python:run-commands",
+      "executor": "@nxlv/python:lock",
       "options": {
-        "command": "poetry lock --no-update",
-        "cwd": "apps/test",
+        "update": false,
       },
     },
     "remove": {
       "executor": "@nxlv/python:remove",
+      "options": {},
+    },
+    "sync": {
+      "executor": "@nxlv/python:sync",
       "options": {},
     },
     "test": {
@@ -1232,14 +1262,17 @@ exports[`application generator > individual package > should run successfully wi
       ],
     },
     "lock": {
-      "executor": "@nxlv/python:run-commands",
+      "executor": "@nxlv/python:lock",
       "options": {
-        "command": "poetry lock --no-update",
-        "cwd": "apps/test",
+        "update": false,
       },
     },
     "remove": {
       "executor": "@nxlv/python:remove",
+      "options": {},
+    },
+    "sync": {
+      "executor": "@nxlv/python:sync",
       "options": {},
     },
     "test": {
@@ -1403,14 +1436,17 @@ exports[`application generator > individual package > should run successfully wi
       ],
     },
     "lock": {
-      "executor": "@nxlv/python:run-commands",
+      "executor": "@nxlv/python:lock",
       "options": {
-        "command": "poetry lock --no-update",
-        "cwd": "apps/test",
+        "update": false,
       },
     },
     "remove": {
       "executor": "@nxlv/python:remove",
+      "options": {},
+    },
+    "sync": {
+      "executor": "@nxlv/python:sync",
       "options": {},
     },
     "test": {
@@ -1574,14 +1610,17 @@ exports[`application generator > individual package > should run successfully wi
       ],
     },
     "lock": {
-      "executor": "@nxlv/python:run-commands",
+      "executor": "@nxlv/python:lock",
       "options": {
-        "command": "poetry lock --no-update",
-        "cwd": "apps/test",
+        "update": false,
       },
     },
     "remove": {
       "executor": "@nxlv/python:remove",
+      "options": {},
+    },
+    "sync": {
+      "executor": "@nxlv/python:sync",
       "options": {},
     },
     "test": {
@@ -1745,14 +1784,17 @@ exports[`application generator > individual package > should run successfully wi
       ],
     },
     "lock": {
-      "executor": "@nxlv/python:run-commands",
+      "executor": "@nxlv/python:lock",
       "options": {
-        "command": "poetry lock --no-update",
-        "cwd": "apps/test",
+        "update": false,
       },
     },
     "remove": {
       "executor": "@nxlv/python:remove",
+      "options": {},
+    },
+    "sync": {
+      "executor": "@nxlv/python:sync",
       "options": {},
     },
     "test": {
@@ -1903,14 +1945,17 @@ exports[`application generator > individual package > should run successfully wi
       ],
     },
     "lock": {
-      "executor": "@nxlv/python:run-commands",
+      "executor": "@nxlv/python:lock",
       "options": {
-        "command": "poetry lock --no-update",
-        "cwd": "apps/test",
+        "update": false,
       },
     },
     "remove": {
       "executor": "@nxlv/python:remove",
+      "options": {},
+    },
+    "sync": {
+      "executor": "@nxlv/python:sync",
       "options": {},
     },
     "test": {
@@ -2131,14 +2176,17 @@ exports[`application generator > individual package > should run successfully wi
       "outputs": [],
     },
     "lock": {
-      "executor": "@nxlv/python:run-commands",
+      "executor": "@nxlv/python:lock",
       "options": {
-        "command": "poetry lock --no-update",
-        "cwd": "apps/test",
+        "update": false,
       },
     },
     "remove": {
       "executor": "@nxlv/python:remove",
+      "options": {},
+    },
+    "sync": {
+      "executor": "@nxlv/python:sync",
       "options": {},
     },
     "test": {
@@ -2368,14 +2416,17 @@ exports[`application generator > individual package > should run successfully wi
       ],
     },
     "lock": {
-      "executor": "@nxlv/python:run-commands",
+      "executor": "@nxlv/python:lock",
       "options": {
-        "command": "poetry lock --no-update",
-        "cwd": "apps/test",
+        "update": false,
       },
     },
     "remove": {
       "executor": "@nxlv/python:remove",
+      "options": {},
+    },
+    "sync": {
+      "executor": "@nxlv/python:sync",
       "options": {},
     },
     "test": {
@@ -2595,14 +2646,17 @@ exports[`application generator > individual package > should run successfully wi
       "outputs": [],
     },
     "lock": {
-      "executor": "@nxlv/python:run-commands",
+      "executor": "@nxlv/python:lock",
       "options": {
-        "command": "poetry lock --no-update",
-        "cwd": "apps/test",
+        "update": false,
       },
     },
     "remove": {
       "executor": "@nxlv/python:remove",
+      "options": {},
+    },
+    "sync": {
+      "executor": "@nxlv/python:sync",
       "options": {},
     },
     "update": {
@@ -2752,14 +2806,17 @@ exports[`application generator > individual package > should run successfully wi
       "outputs": [],
     },
     "lock": {
-      "executor": "@nxlv/python:run-commands",
+      "executor": "@nxlv/python:lock",
       "options": {
-        "command": "poetry lock --no-update",
-        "cwd": "apps/test",
+        "update": false,
       },
     },
     "remove": {
       "executor": "@nxlv/python:remove",
+      "options": {},
+    },
+    "sync": {
+      "executor": "@nxlv/python:sync",
       "options": {},
     },
     "test": {
@@ -2917,14 +2974,17 @@ exports[`application generator > shared virtual environment > should run success
       },
     },
     "lock": {
-      "executor": "@nxlv/python:run-commands",
+      "executor": "@nxlv/python:lock",
       "options": {
-        "command": "poetry lock",
-        "cwd": "apps/test",
+        "update": false,
       },
     },
     "remove": {
       "executor": "@nxlv/python:remove",
+      "options": {},
+    },
+    "sync": {
+      "executor": "@nxlv/python:sync",
       "options": {},
     },
     "update": {
@@ -3040,14 +3100,17 @@ exports[`application generator > shared virtual environment > should run success
       },
     },
     "lock": {
-      "executor": "@nxlv/python:run-commands",
+      "executor": "@nxlv/python:lock",
       "options": {
-        "command": "poetry lock --no-update",
-        "cwd": "apps/test",
+        "update": false,
       },
     },
     "remove": {
       "executor": "@nxlv/python:remove",
+      "options": {},
+    },
+    "sync": {
+      "executor": "@nxlv/python:sync",
       "options": {},
     },
     "update": {
@@ -3163,14 +3226,17 @@ exports[`application generator > shared virtual environment > should run success
       },
     },
     "lock": {
-      "executor": "@nxlv/python:run-commands",
+      "executor": "@nxlv/python:lock",
       "options": {
-        "command": "poetry lock --no-update",
-        "cwd": "apps/test",
+        "update": false,
       },
     },
     "remove": {
       "executor": "@nxlv/python:remove",
+      "options": {},
+    },
+    "sync": {
+      "executor": "@nxlv/python:sync",
       "options": {},
     },
     "update": {
@@ -3286,14 +3352,17 @@ exports[`application generator > shared virtual environment > should run success
       },
     },
     "lock": {
-      "executor": "@nxlv/python:run-commands",
+      "executor": "@nxlv/python:lock",
       "options": {
-        "command": "poetry lock --no-update",
-        "cwd": "apps/test",
+        "update": false,
       },
     },
     "remove": {
       "executor": "@nxlv/python:remove",
+      "options": {},
+    },
+    "sync": {
+      "executor": "@nxlv/python:sync",
       "options": {},
     },
     "update": {
@@ -3410,14 +3479,17 @@ exports[`application generator > shared virtual environment > should run success
       },
     },
     "lock": {
-      "executor": "@nxlv/python:run-commands",
+      "executor": "@nxlv/python:lock",
       "options": {
-        "command": "poetry lock --no-update",
-        "cwd": "apps/test",
+        "update": false,
       },
     },
     "remove": {
       "executor": "@nxlv/python:remove",
+      "options": {},
+    },
+    "sync": {
+      "executor": "@nxlv/python:sync",
       "options": {},
     },
     "update": {

--- a/packages/nx-python/src/generators/poetry-project/generator.ts
+++ b/packages/nx-python/src/generators/poetry-project/generator.ts
@@ -222,13 +222,6 @@ export default async function (
 
   const targets: ProjectConfiguration['targets'] = {
     ...(await getDefaultPythonProjectTargets(normalizedOptions, provider)),
-    lock: {
-      executor: '@nxlv/python:run-commands',
-      options: {
-        command: await provider.getLockCommand(),
-        cwd: normalizedOptions.projectRoot,
-      },
-    },
     install: {
       executor: '@nxlv/python:install',
       options: {

--- a/packages/nx-python/src/generators/utils.ts
+++ b/packages/nx-python/src/generators/utils.ts
@@ -212,11 +212,14 @@ export async function getDefaultPythonProjectTargets(
 ): Promise<ProjectConfiguration['targets']> {
   const targets: ProjectConfiguration['targets'] = {
     lock: {
-      executor: '@nxlv/python:run-commands',
+      executor: '@nxlv/python:lock',
       options: {
-        command: await provider.getLockCommand(),
-        cwd: options.projectRoot,
+        update: false,
       },
+    },
+    sync: {
+      executor: '@nxlv/python:sync',
+      options: {},
     },
     add: {
       executor: '@nxlv/python:add',

--- a/packages/nx-python/src/generators/uv-project/__snapshots__/generator.spec.ts.snap
+++ b/packages/nx-python/src/generators/uv-project/__snapshots__/generator.spec.ts.snap
@@ -41,14 +41,17 @@ exports[`application generator > as-provided > should run successfully minimal c
       },
     },
     "lock": {
-      "executor": "@nxlv/python:run-commands",
+      "executor": "@nxlv/python:lock",
       "options": {
-        "command": "uv lock",
-        "cwd": "src/app/test",
+        "update": false,
       },
     },
     "remove": {
       "executor": "@nxlv/python:remove",
+      "options": {},
+    },
+    "sync": {
+      "executor": "@nxlv/python:sync",
       "options": {},
     },
     "update": {
@@ -148,14 +151,17 @@ exports[`application generator > as-provided > should run successfully minimal c
       },
     },
     "lock": {
-      "executor": "@nxlv/python:run-commands",
+      "executor": "@nxlv/python:lock",
       "options": {
-        "command": "uv lock",
-        "cwd": "my-app-test",
+        "update": false,
       },
     },
     "remove": {
       "executor": "@nxlv/python:remove",
+      "options": {},
+    },
+    "sync": {
+      "executor": "@nxlv/python:sync",
       "options": {},
     },
     "update": {
@@ -255,14 +261,17 @@ exports[`application generator > custom template dir > should run successfully w
       },
     },
     "lock": {
-      "executor": "@nxlv/python:run-commands",
+      "executor": "@nxlv/python:lock",
       "options": {
-        "command": "uv lock",
-        "cwd": "apps/test",
+        "update": false,
       },
     },
     "remove": {
       "executor": "@nxlv/python:remove",
+      "options": {},
+    },
+    "sync": {
+      "executor": "@nxlv/python:sync",
       "options": {},
     },
     "update": {
@@ -337,14 +346,17 @@ exports[`application generator > project > should run successfully minimal confi
       },
     },
     "lock": {
-      "executor": "@nxlv/python:run-commands",
+      "executor": "@nxlv/python:lock",
       "options": {
-        "command": "uv lock",
-        "cwd": "libs/test",
+        "update": false,
       },
     },
     "remove": {
       "executor": "@nxlv/python:remove",
+      "options": {},
+    },
+    "sync": {
+      "executor": "@nxlv/python:sync",
       "options": {},
     },
     "update": {
@@ -446,14 +458,17 @@ exports[`application generator > project > should run successfully minimal confi
       },
     },
     "lock": {
-      "executor": "@nxlv/python:run-commands",
+      "executor": "@nxlv/python:lock",
       "options": {
-        "command": "uv lock",
-        "cwd": "apps/subdir/test",
+        "update": false,
       },
     },
     "remove": {
       "executor": "@nxlv/python:remove",
+      "options": {},
+    },
+    "sync": {
+      "executor": "@nxlv/python:sync",
       "options": {},
     },
     "update": {
@@ -558,14 +573,17 @@ exports[`application generator > project > should run successfully minimal confi
       },
     },
     "lock": {
-      "executor": "@nxlv/python:run-commands",
+      "executor": "@nxlv/python:lock",
       "options": {
-        "command": "uv lock",
-        "cwd": "apps/test",
+        "update": false,
       },
     },
     "remove": {
       "executor": "@nxlv/python:remove",
+      "options": {},
+    },
+    "sync": {
+      "executor": "@nxlv/python:sync",
       "options": {},
     },
     "update": {
@@ -677,14 +695,17 @@ exports[`application generator > project > should run successfully with flake8 l
       ],
     },
     "lock": {
-      "executor": "@nxlv/python:run-commands",
+      "executor": "@nxlv/python:lock",
       "options": {
-        "command": "uv lock",
-        "cwd": "apps/test",
+        "update": false,
       },
     },
     "remove": {
       "executor": "@nxlv/python:remove",
+      "options": {},
+    },
+    "sync": {
+      "executor": "@nxlv/python:sync",
       "options": {},
     },
     "update": {
@@ -812,14 +833,17 @@ exports[`application generator > project > should run successfully with flake8 l
       ],
     },
     "lock": {
-      "executor": "@nxlv/python:run-commands",
+      "executor": "@nxlv/python:lock",
       "options": {
-        "command": "uv lock",
-        "cwd": "apps/test",
+        "update": false,
       },
     },
     "remove": {
       "executor": "@nxlv/python:remove",
+      "options": {},
+    },
+    "sync": {
+      "executor": "@nxlv/python:sync",
       "options": {},
     },
     "test": {
@@ -986,14 +1010,17 @@ exports[`application generator > project > should run successfully with flake8 l
       ],
     },
     "lock": {
-      "executor": "@nxlv/python:run-commands",
+      "executor": "@nxlv/python:lock",
       "options": {
-        "command": "uv lock",
-        "cwd": "apps/test",
+        "update": false,
       },
     },
     "remove": {
       "executor": "@nxlv/python:remove",
+      "options": {},
+    },
+    "sync": {
+      "executor": "@nxlv/python:sync",
       "options": {},
     },
     "test": {
@@ -1160,14 +1187,17 @@ exports[`application generator > project > should run successfully with flake8 l
       ],
     },
     "lock": {
-      "executor": "@nxlv/python:run-commands",
+      "executor": "@nxlv/python:lock",
       "options": {
-        "command": "uv lock",
-        "cwd": "apps/test",
+        "update": false,
       },
     },
     "remove": {
       "executor": "@nxlv/python:remove",
+      "options": {},
+    },
+    "sync": {
+      "executor": "@nxlv/python:sync",
       "options": {},
     },
     "test": {
@@ -1334,14 +1364,17 @@ exports[`application generator > project > should run successfully with flake8 l
       ],
     },
     "lock": {
-      "executor": "@nxlv/python:run-commands",
+      "executor": "@nxlv/python:lock",
       "options": {
-        "command": "uv lock",
-        "cwd": "apps/test",
+        "update": false,
       },
     },
     "remove": {
       "executor": "@nxlv/python:remove",
+      "options": {},
+    },
+    "sync": {
+      "executor": "@nxlv/python:sync",
       "options": {},
     },
     "test": {
@@ -1508,14 +1541,17 @@ exports[`application generator > project > should run successfully with flake8 l
       ],
     },
     "lock": {
-      "executor": "@nxlv/python:run-commands",
+      "executor": "@nxlv/python:lock",
       "options": {
-        "command": "uv lock",
-        "cwd": "apps/test",
+        "update": false,
       },
     },
     "remove": {
       "executor": "@nxlv/python:remove",
+      "options": {},
+    },
+    "sync": {
+      "executor": "@nxlv/python:sync",
       "options": {},
     },
     "test": {
@@ -1682,14 +1718,17 @@ exports[`application generator > project > should run successfully with flake8 l
       ],
     },
     "lock": {
-      "executor": "@nxlv/python:run-commands",
+      "executor": "@nxlv/python:lock",
       "options": {
-        "command": "uv lock",
-        "cwd": "apps/test",
+        "update": false,
       },
     },
     "remove": {
       "executor": "@nxlv/python:remove",
+      "options": {},
+    },
+    "sync": {
+      "executor": "@nxlv/python:sync",
       "options": {},
     },
     "test": {
@@ -1843,14 +1882,17 @@ exports[`application generator > project > should run successfully with linting 
       ],
     },
     "lock": {
-      "executor": "@nxlv/python:run-commands",
+      "executor": "@nxlv/python:lock",
       "options": {
-        "command": "uv lock",
-        "cwd": "apps/test",
+        "update": false,
       },
     },
     "remove": {
       "executor": "@nxlv/python:remove",
+      "options": {},
+    },
+    "sync": {
+      "executor": "@nxlv/python:sync",
       "options": {},
     },
     "test": {
@@ -2080,14 +2122,17 @@ exports[`application generator > project > should run successfully with linting 
       "outputs": [],
     },
     "lock": {
-      "executor": "@nxlv/python:run-commands",
+      "executor": "@nxlv/python:lock",
       "options": {
-        "command": "uv lock",
-        "cwd": "apps/test",
+        "update": false,
       },
     },
     "remove": {
       "executor": "@nxlv/python:remove",
+      "options": {},
+    },
+    "sync": {
+      "executor": "@nxlv/python:sync",
       "options": {},
     },
     "test": {
@@ -2364,14 +2409,17 @@ exports[`application generator > project > should run successfully with linting 
       ],
     },
     "lock": {
-      "executor": "@nxlv/python:run-commands",
+      "executor": "@nxlv/python:lock",
       "options": {
-        "command": "uv lock",
-        "cwd": "apps/test",
+        "update": false,
       },
     },
     "remove": {
       "executor": "@nxlv/python:remove",
+      "options": {},
+    },
+    "sync": {
+      "executor": "@nxlv/python:sync",
       "options": {},
     },
     "test": {
@@ -2598,14 +2646,17 @@ exports[`application generator > project > should run successfully with ruff lin
       "outputs": [],
     },
     "lock": {
-      "executor": "@nxlv/python:run-commands",
+      "executor": "@nxlv/python:lock",
       "options": {
-        "command": "uv lock",
-        "cwd": "apps/test",
+        "update": false,
       },
     },
     "remove": {
       "executor": "@nxlv/python:remove",
+      "options": {},
+    },
+    "sync": {
+      "executor": "@nxlv/python:sync",
       "options": {},
     },
     "update": {
@@ -2762,14 +2813,17 @@ exports[`application generator > project > should run successfully with ruff lin
       "outputs": [],
     },
     "lock": {
-      "executor": "@nxlv/python:run-commands",
+      "executor": "@nxlv/python:lock",
       "options": {
-        "command": "uv lock",
-        "cwd": "apps/test",
+        "update": false,
       },
     },
     "remove": {
       "executor": "@nxlv/python:remove",
+      "options": {},
+    },
+    "sync": {
+      "executor": "@nxlv/python:sync",
       "options": {},
     },
     "test": {
@@ -2930,14 +2984,17 @@ exports[`application generator > should run successfully with minimal options 1`
       },
     },
     "lock": {
-      "executor": "@nxlv/python:run-commands",
+      "executor": "@nxlv/python:lock",
       "options": {
-        "command": "uv lock",
-        "cwd": "apps/test",
+        "update": false,
       },
     },
     "remove": {
       "executor": "@nxlv/python:remove",
+      "options": {},
+    },
+    "sync": {
+      "executor": "@nxlv/python:sync",
       "options": {},
     },
     "update": {
@@ -3039,14 +3096,17 @@ exports[`application generator > workspace > should run successfully with minima
       },
     },
     "lock": {
-      "executor": "@nxlv/python:run-commands",
+      "executor": "@nxlv/python:lock",
       "options": {
-        "command": "uv lock",
-        "cwd": "apps/test",
+        "update": false,
       },
     },
     "remove": {
       "executor": "@nxlv/python:remove",
+      "options": {},
+    },
+    "sync": {
+      "executor": "@nxlv/python:sync",
       "options": {},
     },
     "update": {
@@ -3158,14 +3218,17 @@ exports[`application generator > workspace > should run successfully with minima
       },
     },
     "lock": {
-      "executor": "@nxlv/python:run-commands",
+      "executor": "@nxlv/python:lock",
       "options": {
-        "command": "uv lock",
-        "cwd": "apps/test",
+        "update": false,
       },
     },
     "remove": {
       "executor": "@nxlv/python:remove",
+      "options": {},
+    },
+    "sync": {
+      "executor": "@nxlv/python:sync",
       "options": {},
     },
     "update": {
@@ -3277,14 +3340,17 @@ exports[`application generator > workspace > should run successfully with minima
       },
     },
     "lock": {
-      "executor": "@nxlv/python:run-commands",
+      "executor": "@nxlv/python:lock",
       "options": {
-        "command": "uv lock",
-        "cwd": "apps/test",
+        "update": false,
       },
     },
     "remove": {
       "executor": "@nxlv/python:remove",
+      "options": {},
+    },
+    "sync": {
+      "executor": "@nxlv/python:sync",
       "options": {},
     },
     "update": {

--- a/packages/nx-python/src/provider/base.ts
+++ b/packages/nx-python/src/provider/base.ts
@@ -6,6 +6,8 @@ import { RemoveExecutorSchema } from '../executors/remove/schema';
 import { PublishExecutorSchema } from '../executors/publish/schema';
 import { InstallExecutorSchema } from '../executors/install/schema';
 import { BuildExecutorSchema } from '../executors/build/schema';
+import { LockExecutorSchema } from '../executors/lock/schema';
+import { SyncExecutorSchema } from '../executors/sync/schema';
 
 export type Dependency = {
   name: string;
@@ -80,9 +82,13 @@ export interface IProvider {
 
   install(cwd?: string): Promise<void>;
 
-  getLockCommand(projectRoot?: string): Promise<string>;
+  lock(options?: LockExecutorSchema, context?: ExecutorContext): Promise<void>;
 
-  lock(projectRoot?: string): Promise<void>;
+  lock(projectRoot?: string, update?: boolean): Promise<void>;
+
+  getLockCommand(projectRoot?: string, update?: boolean): Promise<string>;
+
+  sync(options?: SyncExecutorSchema, context?: ExecutorContext): Promise<void>;
 
   build(
     options: BuildExecutorSchema,


### PR DESCRIPTION
Add new executors for syncing and locking dependencies in Python projects:
- Introduced `@nxlv/python:sync` executor for synchronizing dependencies
- Introduced `@nxlv/python:lock` executor for locking dependencies
- Updated project generators to include these new executors in default targets
- Supports both Poetry and UV dependency management tools
- Provides options for verbose output, custom arguments, and cache directory configuration

## Current Behavior

Currently, only the `install` executor is available.

## Expected Behavior

Be able to use all the following actions for all poetry versions:

| Action              | Poetry 1.x              | Poetry 2.x               | UV |
|---------------------|-------------------------|--------------------------|----|
| Install             | poetry install          | poetry install           | uv sync |
| Sync                | poetry install --sync   | poetry sync              | uv sync |
| Lock with update    | poetry lock             | poetry lock --regenerate | uv lock --upgrade | 
| Lock without update | poetry lock --no-update | poetry lock              | uv lock |

## Related Issue(s)

#280 
