### PR TITLE
fix: handle null values in dependency metadata retrieval

### DIFF
--- a/packages/nx-python/src/generators/release-version/utils/package.ts
+++ b/packages/nx-python/src/generators/release-version/utils/package.ts
@@ -27,6 +27,10 @@ export class Package {
       depName,
     );
 
+    if (!depMatadata) {
+      return null;
+    }
+
     return {
       collection:
         depMatadata.group === 'main'

--- a/packages/nx-python/src/provider/base.ts
+++ b/packages/nx-python/src/provider/base.ts
@@ -42,7 +42,7 @@ export interface IProvider {
   getDependencyMetadata(
     projectRoot: string,
     dependencyName: string,
-  ): DependencyProjectMetadata;
+  ): DependencyProjectMetadata | null;
 
   updateVersion(projectRoot: string, newVersion: string): void;
 

--- a/packages/nx-python/src/provider/poetry/provider.ts
+++ b/packages/nx-python/src/provider/poetry/provider.ts
@@ -110,14 +110,14 @@ export class PoetryProvider implements IProvider {
   public getDependencyMetadata(
     projectRoot: string,
     dependencyName: string,
-  ): DependencyProjectMetadata {
+  ): DependencyProjectMetadata | null {
     const pyprojectTomlPath = joinPathFragments(projectRoot, 'pyproject.toml');
 
     const projectData = this.tree
       ? readPyprojectToml<PoetryPyprojectToml>(this.tree, pyprojectTomlPath)
       : getPyprojectData<PoetryPyprojectToml>(pyprojectTomlPath);
 
-    const main = projectData.tool?.poetry?.dependencies ?? {};
+    const main = projectData?.tool?.poetry?.dependencies ?? {};
     if (typeof main[dependencyName] === 'object' && main[dependencyName].path) {
       const dependentPyproject = readPyprojectToml<PoetryPyprojectToml>(
         this.tree,
@@ -135,8 +135,8 @@ export class PoetryProvider implements IProvider {
       };
     }
 
-    for (const key in projectData.tool?.poetry?.group ?? {}) {
-      const group = projectData.tool?.poetry?.group[key].dependencies;
+    for (const key in projectData?.tool?.poetry?.group ?? {}) {
+      const group = projectData?.tool?.poetry?.group?.[key].dependencies;
 
       if (
         typeof group[dependencyName] === 'object' &&
@@ -161,9 +161,7 @@ export class PoetryProvider implements IProvider {
       }
     }
 
-    console.log('Dependency not found', projectRoot, dependencyName);
-
-    throw new Error('Dependency not found');
+    return null;
   }
 
   public getDependencies(

--- a/packages/nx-python/src/provider/uv/provider.ts
+++ b/packages/nx-python/src/provider/uv/provider.ts
@@ -96,14 +96,18 @@ export class UVProvider implements IProvider {
   public getDependencyMetadata(
     projectRoot: string,
     dependencyName: string,
-  ): DependencyProjectMetadata {
+  ): DependencyProjectMetadata | null {
     const pyprojectTomlPath = joinPathFragments(projectRoot, 'pyproject.toml');
     const projectData = this.tree
       ? readPyprojectToml<UVPyprojectToml>(this.tree, pyprojectTomlPath)
       : getPyprojectData<UVPyprojectToml>(pyprojectTomlPath);
 
+    if (!projectData) {
+      return null;
+    }
+
     if (this.isWorkspace) {
-      const data = this.rootLockfile.package[projectData.project.name];
+      const data = this.rootLockfile.package?.[projectData?.project?.name];
       const group = data?.dependencies?.find(
         (item) => item.name === dependencyName,
       )
@@ -119,7 +123,7 @@ export class UVProvider implements IProvider {
       };
     } else {
       const dependencyRelativePath =
-        projectData.tool?.uv?.sources?.[dependencyName]?.path;
+        projectData?.tool?.uv?.sources?.[dependencyName]?.path;
       if (!dependencyRelativePath) {
         throw new Error(
           `Dependency ${dependencyName} not found in pyproject.toml`,


### PR DESCRIPTION
## Current Behavior

On the Python release-version generator, when the project dependency can't be resolved the process fails with an error:

```
NX   Running release version for project: test-python-version

test-python-version 🔍 Reading data for package "test-python-version" from apps/project-folder/projectname/pyproject.toml
test-python-version 📄 Resolved the current version as 1.0.0 from apps/project-folder/projectname/pyproject.toml
test-python-version 🚫 No changes were detected within version plans.
TypeError: Cannot read properties of null (reading 'tool')
    at PoetryProvider.getDependencyMetadata (/projects-folder/repository/node_modules/.pnpm/@nxlv+python@20.7.0_nx@20.5.0_@swc-node+register@1.9.2_@swc+core@1.5.29_@swc+helpers@0.5.13___j6h6nrsonrsxpscyl3b24iikfq/packages/nx-python/src/provider/poetry/provider.ts:120:30)
    at Package.getLocalDependency (/projects-folder/repository/node_modules/.pnpm/@nxlv+python@20.7.0_nx@20.5.0_@swc-node+register@1.9.2_@swc+core@1.5.29_@swc+helpers@0.5.13___j6h6nrsonrsxpscyl3b24iikfq/packages/nx-python/src/generators/release-version/utils/package.ts:25:39)
    at resolveLocalPackageDependencies (/projects-folder/repository/node_modules/.pnpm/@nxlv+python@20.7.0_nx@20.5.0_@swc-node+register@1.9.2_@swc+core@1.5.29_@swc+helpers@0.5.13___j6h6nrsonrsxpscyl3b24iikfq/packages/nx-python/src/generators/release-version/utils/resolve-local-package-dependencies.ts:77:52)
    at /projects-folder/repository/node_modules/.pnpm/@nxlv+python@20.7.0_nx@20.5.0_@swc-node+register@1.9.2_@swc+core@1.5.29_@swc+helpers@0.5.13___j6h6nrsonrsxpscyl3b24iikfq/packages/nx-python/src/generators/release-version/release-version.ts:546:71
    at Generator.next (<anonymous>)
    at fulfilled (/projects-folder/repository/node_modules/.pnpm/tslib@2.7.0/node_modules/tslib/tslib.js:166:62)
    at processTicksAndRejections (node:internal/process/task_queues:95:5)
```

## Expected Behavior

The release-version generator should handle null values in a way that prevents the release process from crashing if one of the dependencies can't be resolved.

## Related Issue(s)

Fixes #284 
