### PR TITLE
feat(nx-python): update output paths and addopts formatting

### DIFF
--- a/package.json
+++ b/package.json
@@ -95,5 +95,6 @@
     "commitizen": {
       "path": "./node_modules/cz-conventional-changelog"
     }
-  }
+  },
+  "packageManager": "pnpm@10.5.2+sha512.da9dc28cd3ff40d0592188235ab25d3202add8a207afbedc682220e4a0029ffbff4562102b9e6e46b4e3f9e8bd53e6d05de48544b0c57d4b0179e22c76d1199b"
 }

--- a/packages/nx-python/src/generators/migrate-to-shared-venv/__snapshots__/generator.spec.ts.snap
+++ b/packages/nx-python/src/generators/migrate-to-shared-venv/__snapshots__/generator.spec.ts.snap
@@ -266,7 +266,13 @@ exclude_lines = [ "if TYPE_CHECKING:" ]
 show_missing = true
 
 [tool.pytest.ini_options]
-addopts = "--cov --cov-report html:'../../coverage/apps/proj1/html' --cov-report xml:'../../coverage/apps/proj1/coverage.xml' --html='../../reports/apps/proj1/unittests/html/index.html' --junitxml='../../reports/apps/proj1/unittests/junit.xml'"
+addopts = """
+ --cov
+ --cov-report html:'../../coverage/apps/proj1/html'
+ --cov-report xml:'../../coverage/apps/proj1/coverage.xml'
+ --html='../../reports/apps/proj1/unittests/html/index.html'
+ --junitxml='../../reports/apps/proj1/unittests/junit.xml'
+"""
 
 [tool.hatch.build.targets.wheel]
 packages = [ "proj1" ]

--- a/packages/nx-python/src/generators/poetry-project/__snapshots__/generator.spec.ts.snap
+++ b/packages/nx-python/src/generators/poetry-project/__snapshots__/generator.spec.ts.snap
@@ -24,7 +24,7 @@ exports[`application generator > as-provided > should run successfully minimal c
       "options": {
         "bundleLocalDependencies": false,
         "lockedVersions": false,
-        "outputPath": "src/app/test/dist",
+        "outputPath": "{projectRoot}/dist",
         "publish": false,
       },
       "outputs": [
@@ -130,7 +130,7 @@ exports[`application generator > as-provided > should run successfully minimal c
       "options": {
         "bundleLocalDependencies": false,
         "lockedVersions": false,
-        "outputPath": "my-app-test/dist",
+        "outputPath": "{projectRoot}/dist",
         "publish": false,
       },
       "outputs": [
@@ -236,7 +236,7 @@ exports[`application generator > custom template dir > should run successfully w
       "options": {
         "bundleLocalDependencies": false,
         "lockedVersions": false,
-        "outputPath": "apps/test/dist",
+        "outputPath": "{projectRoot}/dist",
         "publish": false,
       },
       "outputs": [
@@ -324,7 +324,7 @@ exports[`application generator > individual package > should run successfully mi
       "options": {
         "bundleLocalDependencies": false,
         "lockedVersions": false,
-        "outputPath": "apps/test/dist",
+        "outputPath": "{projectRoot}/dist",
         "publish": false,
       },
       "outputs": [
@@ -430,7 +430,7 @@ exports[`application generator > individual package > should run successfully mi
       "options": {
         "bundleLocalDependencies": false,
         "lockedVersions": false,
-        "outputPath": "libs/test/dist",
+        "outputPath": "{projectRoot}/dist",
         "publish": false,
       },
       "outputs": [
@@ -536,7 +536,7 @@ exports[`application generator > individual package > should run successfully mi
       "options": {
         "bundleLocalDependencies": false,
         "lockedVersions": false,
-        "outputPath": "apps/subdir/test/dist",
+        "outputPath": "{projectRoot}/dist",
         "publish": false,
       },
       "outputs": [
@@ -645,7 +645,7 @@ exports[`application generator > individual package > should run successfully mi
       "options": {
         "bundleLocalDependencies": false,
         "lockedVersions": false,
-        "outputPath": "apps/test/dist",
+        "outputPath": "{projectRoot}/dist",
         "publish": false,
       },
       "outputs": [
@@ -751,7 +751,7 @@ exports[`application generator > individual package > should run successfully wi
       "options": {
         "bundleLocalDependencies": false,
         "lockedVersions": false,
-        "outputPath": "apps/test/dist",
+        "outputPath": "{projectRoot}/dist",
         "publish": false,
       },
       "outputs": [
@@ -772,10 +772,10 @@ exports[`application generator > individual package > should run successfully wi
       "cache": true,
       "executor": "@nxlv/python:flake8",
       "options": {
-        "outputFile": "reports/apps/test/pylint.txt",
+        "outputFile": "reports/{projectRoot}/pylint.txt",
       },
       "outputs": [
-        "{workspaceRoot}/reports/apps/test/pylint.txt",
+        "{workspaceRoot}/reports/{projectRoot}/pylint.txt",
       ],
     },
     "lock": {
@@ -886,7 +886,7 @@ exports[`application generator > individual package > should run successfully wi
       "options": {
         "bundleLocalDependencies": false,
         "lockedVersions": false,
-        "outputPath": "apps/test/dist",
+        "outputPath": "{projectRoot}/dist",
         "publish": false,
       },
       "outputs": [
@@ -907,10 +907,10 @@ exports[`application generator > individual package > should run successfully wi
       "cache": true,
       "executor": "@nxlv/python:flake8",
       "options": {
-        "outputFile": "reports/apps/test/pylint.txt",
+        "outputFile": "reports/{projectRoot}/pylint.txt",
       },
       "outputs": [
-        "{workspaceRoot}/reports/apps/test/pylint.txt",
+        "{workspaceRoot}/reports/{projectRoot}/pylint.txt",
       ],
     },
     "lock": {
@@ -935,8 +935,8 @@ exports[`application generator > individual package > should run successfully wi
         "cwd": "apps/test",
       },
       "outputs": [
-        "{workspaceRoot}/reports/apps/test/unittests",
-        "{workspaceRoot}/coverage/apps/test",
+        "{workspaceRoot}/reports/{projectRoot}/unittests",
+        "{workspaceRoot}/coverage/{projectRoot}",
       ],
     },
     "update": {
@@ -964,7 +964,10 @@ exclude_lines = ['if TYPE_CHECKING:']
 show_missing = true
 
 [tool.pytest.ini_options]
-addopts = "--cov --cov-report html:'../../coverage/apps/test/html'"
+addopts = """
+ --cov
+ --cov-report html:'../../coverage/apps/test/html'
+"""
 
 [tool.poetry]
 name = "test"
@@ -1060,7 +1063,7 @@ exports[`application generator > individual package > should run successfully wi
       "options": {
         "bundleLocalDependencies": false,
         "lockedVersions": false,
-        "outputPath": "apps/test/dist",
+        "outputPath": "{projectRoot}/dist",
         "publish": false,
       },
       "outputs": [
@@ -1081,10 +1084,10 @@ exports[`application generator > individual package > should run successfully wi
       "cache": true,
       "executor": "@nxlv/python:flake8",
       "options": {
-        "outputFile": "reports/apps/test/pylint.txt",
+        "outputFile": "reports/{projectRoot}/pylint.txt",
       },
       "outputs": [
-        "{workspaceRoot}/reports/apps/test/pylint.txt",
+        "{workspaceRoot}/reports/{projectRoot}/pylint.txt",
       ],
     },
     "lock": {
@@ -1109,8 +1112,8 @@ exports[`application generator > individual package > should run successfully wi
         "cwd": "apps/test",
       },
       "outputs": [
-        "{workspaceRoot}/reports/apps/test/unittests",
-        "{workspaceRoot}/coverage/apps/test",
+        "{workspaceRoot}/reports/{projectRoot}/unittests",
+        "{workspaceRoot}/coverage/{projectRoot}",
       ],
     },
     "update": {
@@ -1138,7 +1141,11 @@ exclude_lines = ['if TYPE_CHECKING:']
 show_missing = true
 
 [tool.pytest.ini_options]
-addopts = "--cov --cov-report html:'../../coverage/apps/test/html' --cov-report xml:'../../coverage/apps/test/coverage.xml'"
+addopts = """
+ --cov
+ --cov-report html:'../../coverage/apps/test/html'
+ --cov-report xml:'../../coverage/apps/test/coverage.xml'
+"""
 
 [tool.poetry]
 name = "test"
@@ -1234,7 +1241,7 @@ exports[`application generator > individual package > should run successfully wi
       "options": {
         "bundleLocalDependencies": false,
         "lockedVersions": false,
-        "outputPath": "apps/test/dist",
+        "outputPath": "{projectRoot}/dist",
         "publish": false,
       },
       "outputs": [
@@ -1255,10 +1262,10 @@ exports[`application generator > individual package > should run successfully wi
       "cache": true,
       "executor": "@nxlv/python:flake8",
       "options": {
-        "outputFile": "reports/apps/test/pylint.txt",
+        "outputFile": "reports/{projectRoot}/pylint.txt",
       },
       "outputs": [
-        "{workspaceRoot}/reports/apps/test/pylint.txt",
+        "{workspaceRoot}/reports/{projectRoot}/pylint.txt",
       ],
     },
     "lock": {
@@ -1283,8 +1290,8 @@ exports[`application generator > individual package > should run successfully wi
         "cwd": "apps/test",
       },
       "outputs": [
-        "{workspaceRoot}/reports/apps/test/unittests",
-        "{workspaceRoot}/coverage/apps/test",
+        "{workspaceRoot}/reports/{projectRoot}/unittests",
+        "{workspaceRoot}/coverage/{projectRoot}",
       ],
     },
     "update": {
@@ -1312,7 +1319,12 @@ exclude_lines = ['if TYPE_CHECKING:']
 show_missing = true
 
 [tool.pytest.ini_options]
-addopts = "--cov --cov-fail-under=100 --cov-report html:'../../coverage/apps/test/html' --cov-report xml:'../../coverage/apps/test/coverage.xml'"
+addopts = """
+ --cov
+ --cov-fail-under=100
+ --cov-report html:'../../coverage/apps/test/html'
+ --cov-report xml:'../../coverage/apps/test/coverage.xml'
+"""
 
 [tool.poetry]
 name = "test"
@@ -1408,7 +1420,7 @@ exports[`application generator > individual package > should run successfully wi
       "options": {
         "bundleLocalDependencies": false,
         "lockedVersions": false,
-        "outputPath": "apps/test/dist",
+        "outputPath": "{projectRoot}/dist",
         "publish": false,
       },
       "outputs": [
@@ -1429,10 +1441,10 @@ exports[`application generator > individual package > should run successfully wi
       "cache": true,
       "executor": "@nxlv/python:flake8",
       "options": {
-        "outputFile": "reports/apps/test/pylint.txt",
+        "outputFile": "reports/{projectRoot}/pylint.txt",
       },
       "outputs": [
-        "{workspaceRoot}/reports/apps/test/pylint.txt",
+        "{workspaceRoot}/reports/{projectRoot}/pylint.txt",
       ],
     },
     "lock": {
@@ -1457,8 +1469,8 @@ exports[`application generator > individual package > should run successfully wi
         "cwd": "apps/test",
       },
       "outputs": [
-        "{workspaceRoot}/reports/apps/test/unittests",
-        "{workspaceRoot}/coverage/apps/test",
+        "{workspaceRoot}/reports/{projectRoot}/unittests",
+        "{workspaceRoot}/coverage/{projectRoot}",
       ],
     },
     "update": {
@@ -1486,7 +1498,13 @@ exclude_lines = ['if TYPE_CHECKING:']
 show_missing = true
 
 [tool.pytest.ini_options]
-addopts = "--cov --cov-fail-under=100 --cov-report html:'../../coverage/apps/test/html' --cov-report xml:'../../coverage/apps/test/coverage.xml' --junitxml='../../reports/apps/test/unittests/junit.xml'"
+addopts = """
+ --cov
+ --cov-fail-under=100
+ --cov-report html:'../../coverage/apps/test/html'
+ --cov-report xml:'../../coverage/apps/test/coverage.xml'
+ --junitxml='../../reports/apps/test/unittests/junit.xml'
+"""
 
 [tool.poetry]
 name = "test"
@@ -1582,7 +1600,7 @@ exports[`application generator > individual package > should run successfully wi
       "options": {
         "bundleLocalDependencies": false,
         "lockedVersions": false,
-        "outputPath": "apps/test/dist",
+        "outputPath": "{projectRoot}/dist",
         "publish": false,
       },
       "outputs": [
@@ -1603,10 +1621,10 @@ exports[`application generator > individual package > should run successfully wi
       "cache": true,
       "executor": "@nxlv/python:flake8",
       "options": {
-        "outputFile": "reports/apps/test/pylint.txt",
+        "outputFile": "reports/{projectRoot}/pylint.txt",
       },
       "outputs": [
-        "{workspaceRoot}/reports/apps/test/pylint.txt",
+        "{workspaceRoot}/reports/{projectRoot}/pylint.txt",
       ],
     },
     "lock": {
@@ -1631,8 +1649,8 @@ exports[`application generator > individual package > should run successfully wi
         "cwd": "apps/test",
       },
       "outputs": [
-        "{workspaceRoot}/reports/apps/test/unittests",
-        "{workspaceRoot}/coverage/apps/test",
+        "{workspaceRoot}/reports/{projectRoot}/unittests",
+        "{workspaceRoot}/coverage/{projectRoot}",
       ],
     },
     "update": {
@@ -1660,7 +1678,14 @@ exclude_lines = ['if TYPE_CHECKING:']
 show_missing = true
 
 [tool.pytest.ini_options]
-addopts = "--cov --cov-fail-under=100 --cov-report html:'../../coverage/apps/test/html' --cov-report xml:'../../coverage/apps/test/coverage.xml' --html='../../reports/apps/test/unittests/html/index.html' --junitxml='../../reports/apps/test/unittests/junit.xml'"
+addopts = """
+ --cov
+ --cov-fail-under=100
+ --cov-report html:'../../coverage/apps/test/html'
+ --cov-report xml:'../../coverage/apps/test/coverage.xml'
+ --html='../../reports/apps/test/unittests/html/index.html'
+ --junitxml='../../reports/apps/test/unittests/junit.xml'
+"""
 
 [tool.poetry]
 name = "test"
@@ -1756,7 +1781,7 @@ exports[`application generator > individual package > should run successfully wi
       "options": {
         "bundleLocalDependencies": false,
         "lockedVersions": false,
-        "outputPath": "apps/test/dist",
+        "outputPath": "{projectRoot}/dist",
         "publish": false,
       },
       "outputs": [
@@ -1777,10 +1802,10 @@ exports[`application generator > individual package > should run successfully wi
       "cache": true,
       "executor": "@nxlv/python:flake8",
       "options": {
-        "outputFile": "reports/apps/test/pylint.txt",
+        "outputFile": "reports/{projectRoot}/pylint.txt",
       },
       "outputs": [
-        "{workspaceRoot}/reports/apps/test/pylint.txt",
+        "{workspaceRoot}/reports/{projectRoot}/pylint.txt",
       ],
     },
     "lock": {
@@ -1805,8 +1830,8 @@ exports[`application generator > individual package > should run successfully wi
         "cwd": "apps/test",
       },
       "outputs": [
-        "{workspaceRoot}/reports/apps/test/unittests",
-        "{workspaceRoot}/coverage/apps/test",
+        "{workspaceRoot}/reports/{projectRoot}/unittests",
+        "{workspaceRoot}/coverage/{projectRoot}",
       ],
     },
     "update": {
@@ -1917,7 +1942,7 @@ exports[`application generator > individual package > should run successfully wi
       "options": {
         "bundleLocalDependencies": false,
         "lockedVersions": false,
-        "outputPath": "apps/test/dist",
+        "outputPath": "{projectRoot}/dist",
         "publish": false,
       },
       "outputs": [
@@ -1938,10 +1963,10 @@ exports[`application generator > individual package > should run successfully wi
       "cache": true,
       "executor": "@nxlv/python:flake8",
       "options": {
-        "outputFile": "reports/apps/test/pylint.txt",
+        "outputFile": "reports/{projectRoot}/pylint.txt",
       },
       "outputs": [
-        "{workspaceRoot}/reports/apps/test/pylint.txt",
+        "{workspaceRoot}/reports/{projectRoot}/pylint.txt",
       ],
     },
     "lock": {
@@ -1966,8 +1991,8 @@ exports[`application generator > individual package > should run successfully wi
         "cwd": "apps/test",
       },
       "outputs": [
-        "{workspaceRoot}/reports/apps/test/unittests",
-        "{workspaceRoot}/coverage/apps/test",
+        "{workspaceRoot}/reports/{projectRoot}/unittests",
+        "{workspaceRoot}/coverage/{projectRoot}",
       ],
     },
     "update": {
@@ -1995,7 +2020,14 @@ exclude_lines = ['if TYPE_CHECKING:']
 show_missing = true
 
 [tool.pytest.ini_options]
-addopts = "--cov --cov-fail-under=100 --cov-report html:'../../coverage/apps/test/html' --cov-report xml:'../../coverage/apps/test/coverage.xml' --html='../../reports/apps/test/unittests/html/index.html' --junitxml='../../reports/apps/test/unittests/junit.xml'"
+addopts = """
+ --cov
+ --cov-fail-under=100
+ --cov-report html:'../../coverage/apps/test/html'
+ --cov-report xml:'../../coverage/apps/test/coverage.xml'
+ --html='../../reports/apps/test/unittests/html/index.html'
+ --junitxml='../../reports/apps/test/unittests/junit.xml'
+"""
 
 [tool.poetry]
 name = "test"
@@ -2136,7 +2168,7 @@ exports[`application generator > individual package > should run successfully wi
       "options": {
         "bundleLocalDependencies": false,
         "lockedVersions": false,
-        "outputPath": "apps/test/dist",
+        "outputPath": "{projectRoot}/dist",
         "publish": false,
       },
       "outputs": [
@@ -2197,8 +2229,8 @@ exports[`application generator > individual package > should run successfully wi
         "cwd": "apps/test",
       },
       "outputs": [
-        "{workspaceRoot}/reports/apps/test/unittests",
-        "{workspaceRoot}/coverage/apps/test",
+        "{workspaceRoot}/reports/{projectRoot}/unittests",
+        "{workspaceRoot}/coverage/{projectRoot}",
       ],
     },
     "update": {
@@ -2226,7 +2258,14 @@ exclude_lines = ['if TYPE_CHECKING:']
 show_missing = true
 
 [tool.pytest.ini_options]
-addopts = "--cov --cov-fail-under=100 --cov-report html:'../../coverage/apps/test/html' --cov-report xml:'../../coverage/apps/test/coverage.xml' --html='../../reports/apps/test/unittests/html/index.html' --junitxml='../../reports/apps/test/unittests/junit.xml'"
+addopts = """
+ --cov
+ --cov-fail-under=100
+ --cov-report html:'../../coverage/apps/test/html'
+ --cov-report xml:'../../coverage/apps/test/coverage.xml'
+ --html='../../reports/apps/test/unittests/html/index.html'
+ --junitxml='../../reports/apps/test/unittests/junit.xml'
+"""
 
 [tool.poetry]
 name = "test"
@@ -2338,7 +2377,14 @@ exclude_lines = ['if TYPE_CHECKING:']
 show_missing = true
 
 [tool.pytest.ini_options]
-addopts = "--cov --cov-fail-under=100 --cov-report html:'../../coverage/apps/test/html' --cov-report xml:'../../coverage/apps/test/coverage.xml' --html='../../reports/apps/test/unittests/html/index.html' --junitxml='../../reports/apps/test/unittests/junit.xml'"
+addopts = """
+ --cov
+ --cov-fail-under=100
+ --cov-report html:'../../coverage/apps/test/html'
+ --cov-report xml:'../../coverage/apps/test/coverage.xml'
+ --html='../../reports/apps/test/unittests/html/index.html'
+ --junitxml='../../reports/apps/test/unittests/junit.xml'
+"""
 
 [tool.poetry]
 name = "test"
@@ -2388,7 +2434,7 @@ exports[`application generator > individual package > should run successfully wi
       "options": {
         "bundleLocalDependencies": false,
         "lockedVersions": false,
-        "outputPath": "apps/test/dist",
+        "outputPath": "{projectRoot}/dist",
         "publish": false,
       },
       "outputs": [
@@ -2409,10 +2455,10 @@ exports[`application generator > individual package > should run successfully wi
       "cache": true,
       "executor": "@nxlv/python:flake8",
       "options": {
-        "outputFile": "reports/apps/test/pylint.txt",
+        "outputFile": "reports/{projectRoot}/pylint.txt",
       },
       "outputs": [
-        "{workspaceRoot}/reports/apps/test/pylint.txt",
+        "{workspaceRoot}/reports/{projectRoot}/pylint.txt",
       ],
     },
     "lock": {
@@ -2437,8 +2483,8 @@ exports[`application generator > individual package > should run successfully wi
         "cwd": "apps/test",
       },
       "outputs": [
-        "{workspaceRoot}/reports/apps/test/unittests",
-        "{workspaceRoot}/coverage/apps/test",
+        "{workspaceRoot}/reports/{projectRoot}/unittests",
+        "{workspaceRoot}/coverage/{projectRoot}",
       ],
     },
     "update": {
@@ -2466,7 +2512,14 @@ exclude_lines = ['if TYPE_CHECKING:']
 show_missing = true
 
 [tool.pytest.ini_options]
-addopts = "--cov --cov-fail-under=100 --cov-report html:'../../coverage/apps/test/html' --cov-report xml:'../../coverage/apps/test/coverage.xml' --html='../../reports/apps/test/unittests/html/index.html' --junitxml='../../reports/apps/test/unittests/junit.xml'"
+addopts = """
+ --cov
+ --cov-fail-under=100
+ --cov-report html:'../../coverage/apps/test/html'
+ --cov-report xml:'../../coverage/apps/test/coverage.xml'
+ --html='../../reports/apps/test/unittests/html/index.html'
+ --junitxml='../../reports/apps/test/unittests/junit.xml'
+"""
 
 [tool.poetry]
 name = "test"
@@ -2608,7 +2661,7 @@ exports[`application generator > individual package > should run successfully wi
       "options": {
         "bundleLocalDependencies": false,
         "lockedVersions": false,
-        "outputPath": "apps/test/dist",
+        "outputPath": "{projectRoot}/dist",
         "publish": false,
       },
       "outputs": [
@@ -2766,7 +2819,7 @@ exports[`application generator > individual package > should run successfully wi
       "options": {
         "bundleLocalDependencies": false,
         "lockedVersions": false,
-        "outputPath": "apps/test/dist",
+        "outputPath": "{projectRoot}/dist",
         "publish": false,
       },
       "outputs": [
@@ -2827,8 +2880,8 @@ exports[`application generator > individual package > should run successfully wi
         "cwd": "apps/test",
       },
       "outputs": [
-        "{workspaceRoot}/reports/apps/test/unittests",
-        "{workspaceRoot}/coverage/apps/test",
+        "{workspaceRoot}/reports/{projectRoot}/unittests",
+        "{workspaceRoot}/coverage/{projectRoot}",
       ],
     },
     "update": {
@@ -2956,7 +3009,7 @@ exports[`application generator > shared virtual environment > should run success
       "options": {
         "bundleLocalDependencies": false,
         "lockedVersions": false,
-        "outputPath": "apps/test/dist",
+        "outputPath": "{projectRoot}/dist",
         "publish": false,
       },
       "outputs": [
@@ -3082,7 +3135,7 @@ exports[`application generator > shared virtual environment > should run success
       "options": {
         "bundleLocalDependencies": false,
         "lockedVersions": false,
-        "outputPath": "apps/test/dist",
+        "outputPath": "{projectRoot}/dist",
         "publish": false,
       },
       "outputs": [
@@ -3208,7 +3261,7 @@ exports[`application generator > shared virtual environment > should run success
       "options": {
         "bundleLocalDependencies": false,
         "lockedVersions": false,
-        "outputPath": "apps/test/dist",
+        "outputPath": "{projectRoot}/dist",
         "publish": false,
       },
       "outputs": [
@@ -3334,7 +3387,7 @@ exports[`application generator > shared virtual environment > should run success
       "options": {
         "bundleLocalDependencies": false,
         "lockedVersions": false,
-        "outputPath": "apps/test/dist",
+        "outputPath": "{projectRoot}/dist",
         "publish": false,
       },
       "outputs": [
@@ -3461,7 +3514,7 @@ exports[`application generator > shared virtual environment > should run success
       "options": {
         "bundleLocalDependencies": false,
         "lockedVersions": false,
-        "outputPath": "apps/test/dist",
+        "outputPath": "{projectRoot}/dist",
         "publish": false,
       },
       "outputs": [

--- a/packages/nx-python/src/generators/poetry-project/files/base/pyproject.toml
+++ b/packages/nx-python/src/generators/poetry-project/files/base/pyproject.toml
@@ -10,7 +10,7 @@ show_missing = true
 <% } -%>
 <%if (unitTestRunner === 'pytest' && pythonAddopts) { -%>
 [tool.pytest.ini_options]
-addopts = "<%- pythonAddopts %>"
+addopts = """<%- pythonAddopts %>"""
 
 <% } -%>
 [tool.poetry]

--- a/packages/nx-python/src/generators/poetry-project/files/pytest/tests/conftest.py
+++ b/packages/nx-python/src/generators/poetry-project/files/pytest/tests/conftest.py
@@ -1,3 +1,1 @@
 """Unit tests configuration module."""
-
-pytest_plugins = []

--- a/packages/nx-python/src/generators/utils.ts
+++ b/packages/nx-python/src/generators/utils.ts
@@ -27,34 +27,38 @@ export function getPyTestAddopts(
     const args = [];
     const offset = offsetFromRoot(projectRoot);
     if (options.codeCoverage) {
-      args.push('--cov');
+      args.push(' --cov');
     }
     if (options.codeCoverageThreshold) {
-      args.push(`--cov-fail-under=${options.codeCoverageThreshold}`);
+      args.push(` --cov-fail-under=${options.codeCoverageThreshold}`);
     }
     if (options.codeCoverage && options.codeCoverageHtmlReport) {
-      args.push(`--cov-report html:'${offset}coverage/${projectRoot}/html'`);
+      args.push(` --cov-report html:'${offset}coverage/${projectRoot}/html'`);
     }
 
     if (options.codeCoverage && options.codeCoverageXmlReport) {
       args.push(
-        `--cov-report xml:'${offset}coverage/${projectRoot}/coverage.xml'`,
+        ` --cov-report xml:'${offset}coverage/${projectRoot}/coverage.xml'`,
       );
     }
 
     if (options.unitTestHtmlReport) {
       args.push(
-        `--html='${offset}reports/${projectRoot}/unittests/html/index.html'`,
+        ` --html='${offset}reports/${projectRoot}/unittests/html/index.html'`,
       );
     }
 
     if (options.unitTestJUnitReport) {
       args.push(
-        `--junitxml='${offset}reports/${projectRoot}/unittests/junit.xml'`,
+        ` --junitxml='${offset}reports/${projectRoot}/unittests/junit.xml'`,
       );
     }
 
-    return args.join(' ');
+    if (args.length === 0) {
+      return '';
+    }
+
+    return `\n${args.join('\n')}\n`;
   }
 }
 
@@ -237,7 +241,7 @@ export async function getDefaultPythonProjectTargets(
       executor: '@nxlv/python:build',
       outputs: ['{projectRoot}/dist'],
       options: {
-        outputPath: `${options.projectRoot}/dist`,
+        outputPath: `{projectRoot}/dist`,
         publish: options.publishable,
         lockedVersions: options.buildLockedVersions,
         bundleLocalDependencies: options.buildBundleLocalDependencies,
@@ -249,9 +253,9 @@ export async function getDefaultPythonProjectTargets(
   if (options.linter === 'flake8') {
     targets.lint = {
       executor: '@nxlv/python:flake8',
-      outputs: [`{workspaceRoot}/reports/${options.projectRoot}/pylint.txt`],
+      outputs: [`{workspaceRoot}/reports/{projectRoot}/pylint.txt`],
       options: {
-        outputFile: `reports/${options.projectRoot}/pylint.txt`,
+        outputFile: `reports/{projectRoot}/pylint.txt`,
       },
       cache: true,
     };
@@ -285,8 +289,8 @@ export async function getDefaultPythonProjectTargets(
     targets.test = {
       executor: '@nxlv/python:run-commands',
       outputs: [
-        `{workspaceRoot}/reports/${options.projectRoot}/unittests`,
-        `{workspaceRoot}/coverage/${options.projectRoot}`,
+        `{workspaceRoot}/reports/{projectRoot}/unittests`,
+        `{workspaceRoot}/coverage/{projectRoot}`,
       ],
       options: {
         command: await provider.getRunCommand(['pytest', 'tests/']),

--- a/packages/nx-python/src/generators/uv-project/__snapshots__/generator.spec.ts.snap
+++ b/packages/nx-python/src/generators/uv-project/__snapshots__/generator.spec.ts.snap
@@ -24,7 +24,7 @@ exports[`application generator > as-provided > should run successfully minimal c
       "options": {
         "bundleLocalDependencies": false,
         "lockedVersions": false,
-        "outputPath": "src/app/test/dist",
+        "outputPath": "{projectRoot}/dist",
         "publish": false,
       },
       "outputs": [
@@ -134,7 +134,7 @@ exports[`application generator > as-provided > should run successfully minimal c
       "options": {
         "bundleLocalDependencies": false,
         "lockedVersions": false,
-        "outputPath": "my-app-test/dist",
+        "outputPath": "{projectRoot}/dist",
         "publish": false,
       },
       "outputs": [
@@ -244,7 +244,7 @@ exports[`application generator > custom template dir > should run successfully w
       "options": {
         "bundleLocalDependencies": false,
         "lockedVersions": false,
-        "outputPath": "apps/test/dist",
+        "outputPath": "{projectRoot}/dist",
         "publish": false,
       },
       "outputs": [
@@ -329,7 +329,7 @@ exports[`application generator > project > should run successfully minimal confi
       "options": {
         "bundleLocalDependencies": false,
         "lockedVersions": false,
-        "outputPath": "libs/test/dist",
+        "outputPath": "{projectRoot}/dist",
         "publish": false,
       },
       "outputs": [
@@ -441,7 +441,7 @@ exports[`application generator > project > should run successfully minimal confi
       "options": {
         "bundleLocalDependencies": false,
         "lockedVersions": false,
-        "outputPath": "apps/subdir/test/dist",
+        "outputPath": "{projectRoot}/dist",
         "publish": false,
       },
       "outputs": [
@@ -556,7 +556,7 @@ exports[`application generator > project > should run successfully minimal confi
       "options": {
         "bundleLocalDependencies": false,
         "lockedVersions": false,
-        "outputPath": "apps/test/dist",
+        "outputPath": "{projectRoot}/dist",
         "publish": false,
       },
       "outputs": [
@@ -668,7 +668,7 @@ exports[`application generator > project > should run successfully with flake8 l
       "options": {
         "bundleLocalDependencies": false,
         "lockedVersions": false,
-        "outputPath": "apps/test/dist",
+        "outputPath": "{projectRoot}/dist",
         "publish": false,
       },
       "outputs": [
@@ -688,10 +688,10 @@ exports[`application generator > project > should run successfully with flake8 l
       "cache": true,
       "executor": "@nxlv/python:flake8",
       "options": {
-        "outputFile": "reports/apps/test/pylint.txt",
+        "outputFile": "reports/{projectRoot}/pylint.txt",
       },
       "outputs": [
-        "{workspaceRoot}/reports/apps/test/pylint.txt",
+        "{workspaceRoot}/reports/{projectRoot}/pylint.txt",
       ],
     },
     "lock": {
@@ -806,7 +806,7 @@ exports[`application generator > project > should run successfully with flake8 l
       "options": {
         "bundleLocalDependencies": false,
         "lockedVersions": false,
-        "outputPath": "apps/test/dist",
+        "outputPath": "{projectRoot}/dist",
         "publish": false,
       },
       "outputs": [
@@ -826,10 +826,10 @@ exports[`application generator > project > should run successfully with flake8 l
       "cache": true,
       "executor": "@nxlv/python:flake8",
       "options": {
-        "outputFile": "reports/apps/test/pylint.txt",
+        "outputFile": "reports/{projectRoot}/pylint.txt",
       },
       "outputs": [
-        "{workspaceRoot}/reports/apps/test/pylint.txt",
+        "{workspaceRoot}/reports/{projectRoot}/pylint.txt",
       ],
     },
     "lock": {
@@ -854,8 +854,8 @@ exports[`application generator > project > should run successfully with flake8 l
         "cwd": "apps/test",
       },
       "outputs": [
-        "{workspaceRoot}/reports/apps/test/unittests",
-        "{workspaceRoot}/coverage/apps/test",
+        "{workspaceRoot}/reports/{projectRoot}/unittests",
+        "{workspaceRoot}/coverage/{projectRoot}",
       ],
     },
     "update": {
@@ -883,7 +883,10 @@ exclude_lines = ['if TYPE_CHECKING:']
 show_missing = true
 
 [tool.pytest.ini_options]
-addopts = "--cov --cov-report html:'../../coverage/apps/test/html'"
+addopts = """
+ --cov
+ --cov-report html:'../../coverage/apps/test/html'
+"""
 
 [project]
 name = "test"
@@ -983,7 +986,7 @@ exports[`application generator > project > should run successfully with flake8 l
       "options": {
         "bundleLocalDependencies": false,
         "lockedVersions": false,
-        "outputPath": "apps/test/dist",
+        "outputPath": "{projectRoot}/dist",
         "publish": false,
       },
       "outputs": [
@@ -1003,10 +1006,10 @@ exports[`application generator > project > should run successfully with flake8 l
       "cache": true,
       "executor": "@nxlv/python:flake8",
       "options": {
-        "outputFile": "reports/apps/test/pylint.txt",
+        "outputFile": "reports/{projectRoot}/pylint.txt",
       },
       "outputs": [
-        "{workspaceRoot}/reports/apps/test/pylint.txt",
+        "{workspaceRoot}/reports/{projectRoot}/pylint.txt",
       ],
     },
     "lock": {
@@ -1031,8 +1034,8 @@ exports[`application generator > project > should run successfully with flake8 l
         "cwd": "apps/test",
       },
       "outputs": [
-        "{workspaceRoot}/reports/apps/test/unittests",
-        "{workspaceRoot}/coverage/apps/test",
+        "{workspaceRoot}/reports/{projectRoot}/unittests",
+        "{workspaceRoot}/coverage/{projectRoot}",
       ],
     },
     "update": {
@@ -1060,7 +1063,11 @@ exclude_lines = ['if TYPE_CHECKING:']
 show_missing = true
 
 [tool.pytest.ini_options]
-addopts = "--cov --cov-report html:'../../coverage/apps/test/html' --cov-report xml:'../../coverage/apps/test/coverage.xml'"
+addopts = """
+ --cov
+ --cov-report html:'../../coverage/apps/test/html'
+ --cov-report xml:'../../coverage/apps/test/coverage.xml'
+"""
 
 [project]
 name = "test"
@@ -1160,7 +1167,7 @@ exports[`application generator > project > should run successfully with flake8 l
       "options": {
         "bundleLocalDependencies": false,
         "lockedVersions": false,
-        "outputPath": "apps/test/dist",
+        "outputPath": "{projectRoot}/dist",
         "publish": false,
       },
       "outputs": [
@@ -1180,10 +1187,10 @@ exports[`application generator > project > should run successfully with flake8 l
       "cache": true,
       "executor": "@nxlv/python:flake8",
       "options": {
-        "outputFile": "reports/apps/test/pylint.txt",
+        "outputFile": "reports/{projectRoot}/pylint.txt",
       },
       "outputs": [
-        "{workspaceRoot}/reports/apps/test/pylint.txt",
+        "{workspaceRoot}/reports/{projectRoot}/pylint.txt",
       ],
     },
     "lock": {
@@ -1208,8 +1215,8 @@ exports[`application generator > project > should run successfully with flake8 l
         "cwd": "apps/test",
       },
       "outputs": [
-        "{workspaceRoot}/reports/apps/test/unittests",
-        "{workspaceRoot}/coverage/apps/test",
+        "{workspaceRoot}/reports/{projectRoot}/unittests",
+        "{workspaceRoot}/coverage/{projectRoot}",
       ],
     },
     "update": {
@@ -1237,7 +1244,12 @@ exclude_lines = ['if TYPE_CHECKING:']
 show_missing = true
 
 [tool.pytest.ini_options]
-addopts = "--cov --cov-fail-under=100 --cov-report html:'../../coverage/apps/test/html' --cov-report xml:'../../coverage/apps/test/coverage.xml'"
+addopts = """
+ --cov
+ --cov-fail-under=100
+ --cov-report html:'../../coverage/apps/test/html'
+ --cov-report xml:'../../coverage/apps/test/coverage.xml'
+"""
 
 [project]
 name = "test"
@@ -1337,7 +1349,7 @@ exports[`application generator > project > should run successfully with flake8 l
       "options": {
         "bundleLocalDependencies": false,
         "lockedVersions": false,
-        "outputPath": "apps/test/dist",
+        "outputPath": "{projectRoot}/dist",
         "publish": false,
       },
       "outputs": [
@@ -1357,10 +1369,10 @@ exports[`application generator > project > should run successfully with flake8 l
       "cache": true,
       "executor": "@nxlv/python:flake8",
       "options": {
-        "outputFile": "reports/apps/test/pylint.txt",
+        "outputFile": "reports/{projectRoot}/pylint.txt",
       },
       "outputs": [
-        "{workspaceRoot}/reports/apps/test/pylint.txt",
+        "{workspaceRoot}/reports/{projectRoot}/pylint.txt",
       ],
     },
     "lock": {
@@ -1385,8 +1397,8 @@ exports[`application generator > project > should run successfully with flake8 l
         "cwd": "apps/test",
       },
       "outputs": [
-        "{workspaceRoot}/reports/apps/test/unittests",
-        "{workspaceRoot}/coverage/apps/test",
+        "{workspaceRoot}/reports/{projectRoot}/unittests",
+        "{workspaceRoot}/coverage/{projectRoot}",
       ],
     },
     "update": {
@@ -1414,7 +1426,13 @@ exclude_lines = ['if TYPE_CHECKING:']
 show_missing = true
 
 [tool.pytest.ini_options]
-addopts = "--cov --cov-fail-under=100 --cov-report html:'../../coverage/apps/test/html' --cov-report xml:'../../coverage/apps/test/coverage.xml' --junitxml='../../reports/apps/test/unittests/junit.xml'"
+addopts = """
+ --cov
+ --cov-fail-under=100
+ --cov-report html:'../../coverage/apps/test/html'
+ --cov-report xml:'../../coverage/apps/test/coverage.xml'
+ --junitxml='../../reports/apps/test/unittests/junit.xml'
+"""
 
 [project]
 name = "test"
@@ -1514,7 +1532,7 @@ exports[`application generator > project > should run successfully with flake8 l
       "options": {
         "bundleLocalDependencies": false,
         "lockedVersions": false,
-        "outputPath": "apps/test/dist",
+        "outputPath": "{projectRoot}/dist",
         "publish": false,
       },
       "outputs": [
@@ -1534,10 +1552,10 @@ exports[`application generator > project > should run successfully with flake8 l
       "cache": true,
       "executor": "@nxlv/python:flake8",
       "options": {
-        "outputFile": "reports/apps/test/pylint.txt",
+        "outputFile": "reports/{projectRoot}/pylint.txt",
       },
       "outputs": [
-        "{workspaceRoot}/reports/apps/test/pylint.txt",
+        "{workspaceRoot}/reports/{projectRoot}/pylint.txt",
       ],
     },
     "lock": {
@@ -1562,8 +1580,8 @@ exports[`application generator > project > should run successfully with flake8 l
         "cwd": "apps/test",
       },
       "outputs": [
-        "{workspaceRoot}/reports/apps/test/unittests",
-        "{workspaceRoot}/coverage/apps/test",
+        "{workspaceRoot}/reports/{projectRoot}/unittests",
+        "{workspaceRoot}/coverage/{projectRoot}",
       ],
     },
     "update": {
@@ -1591,7 +1609,14 @@ exclude_lines = ['if TYPE_CHECKING:']
 show_missing = true
 
 [tool.pytest.ini_options]
-addopts = "--cov --cov-fail-under=100 --cov-report html:'../../coverage/apps/test/html' --cov-report xml:'../../coverage/apps/test/coverage.xml' --html='../../reports/apps/test/unittests/html/index.html' --junitxml='../../reports/apps/test/unittests/junit.xml'"
+addopts = """
+ --cov
+ --cov-fail-under=100
+ --cov-report html:'../../coverage/apps/test/html'
+ --cov-report xml:'../../coverage/apps/test/coverage.xml'
+ --html='../../reports/apps/test/unittests/html/index.html'
+ --junitxml='../../reports/apps/test/unittests/junit.xml'
+"""
 
 [project]
 name = "test"
@@ -1691,7 +1716,7 @@ exports[`application generator > project > should run successfully with flake8 l
       "options": {
         "bundleLocalDependencies": false,
         "lockedVersions": false,
-        "outputPath": "apps/test/dist",
+        "outputPath": "{projectRoot}/dist",
         "publish": false,
       },
       "outputs": [
@@ -1711,10 +1736,10 @@ exports[`application generator > project > should run successfully with flake8 l
       "cache": true,
       "executor": "@nxlv/python:flake8",
       "options": {
-        "outputFile": "reports/apps/test/pylint.txt",
+        "outputFile": "reports/{projectRoot}/pylint.txt",
       },
       "outputs": [
-        "{workspaceRoot}/reports/apps/test/pylint.txt",
+        "{workspaceRoot}/reports/{projectRoot}/pylint.txt",
       ],
     },
     "lock": {
@@ -1739,8 +1764,8 @@ exports[`application generator > project > should run successfully with flake8 l
         "cwd": "apps/test",
       },
       "outputs": [
-        "{workspaceRoot}/reports/apps/test/unittests",
-        "{workspaceRoot}/coverage/apps/test",
+        "{workspaceRoot}/reports/{projectRoot}/unittests",
+        "{workspaceRoot}/coverage/{projectRoot}",
       ],
     },
     "update": {
@@ -1855,7 +1880,7 @@ exports[`application generator > project > should run successfully with linting 
       "options": {
         "bundleLocalDependencies": false,
         "lockedVersions": false,
-        "outputPath": "apps/test/dist",
+        "outputPath": "{projectRoot}/dist",
         "publish": false,
       },
       "outputs": [
@@ -1875,10 +1900,10 @@ exports[`application generator > project > should run successfully with linting 
       "cache": true,
       "executor": "@nxlv/python:flake8",
       "options": {
-        "outputFile": "reports/apps/test/pylint.txt",
+        "outputFile": "reports/{projectRoot}/pylint.txt",
       },
       "outputs": [
-        "{workspaceRoot}/reports/apps/test/pylint.txt",
+        "{workspaceRoot}/reports/{projectRoot}/pylint.txt",
       ],
     },
     "lock": {
@@ -1903,8 +1928,8 @@ exports[`application generator > project > should run successfully with linting 
         "cwd": "apps/test",
       },
       "outputs": [
-        "{workspaceRoot}/reports/apps/test/unittests",
-        "{workspaceRoot}/coverage/apps/test",
+        "{workspaceRoot}/reports/{projectRoot}/unittests",
+        "{workspaceRoot}/coverage/{projectRoot}",
       ],
     },
     "update": {
@@ -1932,7 +1957,14 @@ exclude_lines = ['if TYPE_CHECKING:']
 show_missing = true
 
 [tool.pytest.ini_options]
-addopts = "--cov --cov-fail-under=100 --cov-report html:'../../coverage/apps/test/html' --cov-report xml:'../../coverage/apps/test/coverage.xml' --html='../../reports/apps/test/unittests/html/index.html' --junitxml='../../reports/apps/test/unittests/junit.xml'"
+addopts = """
+ --cov
+ --cov-fail-under=100
+ --cov-report html:'../../coverage/apps/test/html'
+ --cov-report xml:'../../coverage/apps/test/coverage.xml'
+ --html='../../reports/apps/test/unittests/html/index.html'
+ --junitxml='../../reports/apps/test/unittests/junit.xml'
+"""
 
 [project]
 name = "test"
@@ -2083,7 +2115,7 @@ exports[`application generator > project > should run successfully with linting 
       "options": {
         "bundleLocalDependencies": false,
         "lockedVersions": false,
-        "outputPath": "apps/test/dist",
+        "outputPath": "{projectRoot}/dist",
         "publish": false,
       },
       "outputs": [
@@ -2143,8 +2175,8 @@ exports[`application generator > project > should run successfully with linting 
         "cwd": "apps/test",
       },
       "outputs": [
-        "{workspaceRoot}/reports/apps/test/unittests",
-        "{workspaceRoot}/coverage/apps/test",
+        "{workspaceRoot}/reports/{projectRoot}/unittests",
+        "{workspaceRoot}/coverage/{projectRoot}",
       ],
     },
     "update": {
@@ -2172,7 +2204,14 @@ exclude_lines = ['if TYPE_CHECKING:']
 show_missing = true
 
 [tool.pytest.ini_options]
-addopts = "--cov --cov-fail-under=100 --cov-report html:'../../coverage/apps/test/html' --cov-report xml:'../../coverage/apps/test/coverage.xml' --html='../../reports/apps/test/unittests/html/index.html' --junitxml='../../reports/apps/test/unittests/junit.xml'"
+addopts = """
+ --cov
+ --cov-fail-under=100
+ --cov-report html:'../../coverage/apps/test/html'
+ --cov-report xml:'../../coverage/apps/test/coverage.xml'
+ --html='../../reports/apps/test/unittests/html/index.html'
+ --junitxml='../../reports/apps/test/unittests/junit.xml'
+"""
 
 [project]
 name = "test"
@@ -2326,7 +2365,14 @@ exclude_lines = ['if TYPE_CHECKING:']
 show_missing = true
 
 [tool.pytest.ini_options]
-addopts = "--cov --cov-fail-under=100 --cov-report html:'../../coverage/apps/test/html' --cov-report xml:'../../coverage/apps/test/coverage.xml' --html='../../reports/apps/test/unittests/html/index.html' --junitxml='../../reports/apps/test/unittests/junit.xml'"
+addopts = """
+ --cov
+ --cov-fail-under=100
+ --cov-report html:'../../coverage/apps/test/html'
+ --cov-report xml:'../../coverage/apps/test/coverage.xml'
+ --html='../../reports/apps/test/unittests/html/index.html'
+ --junitxml='../../reports/apps/test/unittests/junit.xml'
+"""
 
 [project]
 name = "test"
@@ -2382,7 +2428,7 @@ exports[`application generator > project > should run successfully with linting 
       "options": {
         "bundleLocalDependencies": false,
         "lockedVersions": false,
-        "outputPath": "apps/test/dist",
+        "outputPath": "{projectRoot}/dist",
         "publish": false,
       },
       "outputs": [
@@ -2402,10 +2448,10 @@ exports[`application generator > project > should run successfully with linting 
       "cache": true,
       "executor": "@nxlv/python:flake8",
       "options": {
-        "outputFile": "reports/apps/test/pylint.txt",
+        "outputFile": "reports/{projectRoot}/pylint.txt",
       },
       "outputs": [
-        "{workspaceRoot}/reports/apps/test/pylint.txt",
+        "{workspaceRoot}/reports/{projectRoot}/pylint.txt",
       ],
     },
     "lock": {
@@ -2430,8 +2476,8 @@ exports[`application generator > project > should run successfully with linting 
         "cwd": "apps/test",
       },
       "outputs": [
-        "{workspaceRoot}/reports/apps/test/unittests",
-        "{workspaceRoot}/coverage/apps/test",
+        "{workspaceRoot}/reports/{projectRoot}/unittests",
+        "{workspaceRoot}/coverage/{projectRoot}",
       ],
     },
     "update": {
@@ -2459,7 +2505,14 @@ exclude_lines = ['if TYPE_CHECKING:']
 show_missing = true
 
 [tool.pytest.ini_options]
-addopts = "--cov --cov-fail-under=100 --cov-report html:'../../coverage/apps/test/html' --cov-report xml:'../../coverage/apps/test/coverage.xml' --html='../../reports/apps/test/unittests/html/index.html' --junitxml='../../reports/apps/test/unittests/junit.xml'"
+addopts = """
+ --cov
+ --cov-fail-under=100
+ --cov-report html:'../../coverage/apps/test/html'
+ --cov-report xml:'../../coverage/apps/test/coverage.xml'
+ --html='../../reports/apps/test/unittests/html/index.html'
+ --junitxml='../../reports/apps/test/unittests/junit.xml'
+"""
 
 [project]
 name = "test"
@@ -2609,7 +2662,7 @@ exports[`application generator > project > should run successfully with ruff lin
       "options": {
         "bundleLocalDependencies": false,
         "lockedVersions": false,
-        "outputPath": "apps/test/dist",
+        "outputPath": "{projectRoot}/dist",
         "publish": false,
       },
       "outputs": [
@@ -2774,7 +2827,7 @@ exports[`application generator > project > should run successfully with ruff lin
       "options": {
         "bundleLocalDependencies": false,
         "lockedVersions": false,
-        "outputPath": "apps/test/dist",
+        "outputPath": "{projectRoot}/dist",
         "publish": false,
       },
       "outputs": [
@@ -2834,8 +2887,8 @@ exports[`application generator > project > should run successfully with ruff lin
         "cwd": "apps/test",
       },
       "outputs": [
-        "{workspaceRoot}/reports/apps/test/unittests",
-        "{workspaceRoot}/coverage/apps/test",
+        "{workspaceRoot}/reports/{projectRoot}/unittests",
+        "{workspaceRoot}/coverage/{projectRoot}",
       ],
     },
     "update": {
@@ -2967,7 +3020,7 @@ exports[`application generator > should run successfully with minimal options 1`
       "options": {
         "bundleLocalDependencies": false,
         "lockedVersions": false,
-        "outputPath": "apps/test/dist",
+        "outputPath": "{projectRoot}/dist",
         "publish": false,
       },
       "outputs": [
@@ -3079,7 +3132,7 @@ exports[`application generator > workspace > should run successfully with minima
       "options": {
         "bundleLocalDependencies": false,
         "lockedVersions": false,
-        "outputPath": "apps/test/dist",
+        "outputPath": "{projectRoot}/dist",
         "publish": false,
       },
       "outputs": [
@@ -3201,7 +3254,7 @@ exports[`application generator > workspace > should run successfully with minima
       "options": {
         "bundleLocalDependencies": false,
         "lockedVersions": false,
-        "outputPath": "apps/test/dist",
+        "outputPath": "{projectRoot}/dist",
         "publish": false,
       },
       "outputs": [
@@ -3323,7 +3376,7 @@ exports[`application generator > workspace > should run successfully with minima
       "options": {
         "bundleLocalDependencies": false,
         "lockedVersions": false,
-        "outputPath": "apps/test/dist",
+        "outputPath": "{projectRoot}/dist",
         "publish": false,
       },
       "outputs": [

--- a/packages/nx-python/src/generators/uv-project/files/base/pyproject.toml
+++ b/packages/nx-python/src/generators/uv-project/files/base/pyproject.toml
@@ -10,7 +10,7 @@ show_missing = true
 <% } -%>
 <%if (unitTestRunner === 'pytest' && pythonAddopts) { -%>
 [tool.pytest.ini_options]
-addopts = "<%- pythonAddopts %>"
+addopts = """<%- pythonAddopts %>"""
 
 <% } -%>
 [project]

--- a/packages/nx-python/src/generators/uv-project/files/pytest/tests/conftest.py
+++ b/packages/nx-python/src/generators/uv-project/files/pytest/tests/conftest.py
@@ -1,3 +1,1 @@
 """Unit tests configuration module."""
-
-pytest_plugins = []


### PR DESCRIPTION
This PR:

- Updated output paths in various generator configurations to use `{projectRoot}` for consistency.
- Reformatted `addopts` in `pyproject.toml` files to use multi-line strings for better readability.
- Adjusted pytest configuration in `conftest.py` files to remove unnecessary lines.