### PR TITLE
fix(nx-python): update pyenvPythonVersion type to accept string or number

### DIFF
--- a/packages/nx-python/src/generators/migrate-to-shared-venv/schema.d.ts
+++ b/packages/nx-python/src/generators/migrate-to-shared-venv/schema.d.ts
@@ -1,7 +1,7 @@
 export interface Schema {
   moveDevDependencies: boolean;
   pyprojectPythonDependency: string;
-  pyenvPythonVersion: string;
+  pyenvPythonVersion: string | number;
   autoActivate: boolean;
   packageManager: 'poetry' | 'uv';
 }

--- a/packages/nx-python/src/generators/migrate-to-shared-venv/schema.json
+++ b/packages/nx-python/src/generators/migrate-to-shared-venv/schema.json
@@ -15,7 +15,7 @@
       "default": ">=3.9,<3.11"
     },
     "pyenvPythonVersion": {
-      "type": "string",
+      "oneOf": [{ "type": "string" }, { "type": "number" }],
       "description": "Pyenv .python-version content",
       "default": "3.9.5"
     },

--- a/packages/nx-python/src/generators/poetry-project/schema.json
+++ b/packages/nx-python/src/generators/poetry-project/schema.json
@@ -41,7 +41,7 @@
       "default": ">=3.9,<3.11"
     },
     "pyenvPythonVersion": {
-      "type": "string",
+      "oneOf": [{ "type": "string" }, { "type": "number" }],
       "description": "Pyenv .python-version content",
       "default": "3.9.5"
     },

--- a/packages/nx-python/src/generators/types.ts
+++ b/packages/nx-python/src/generators/types.ts
@@ -24,7 +24,7 @@ export interface BasePythonProjectGeneratorSchema
   packageName?: string;
   description?: string;
   moduleName?: string;
-  pyenvPythonVersion?: string;
+  pyenvPythonVersion?: string | number;
   tags?: string;
   directory?: string;
 }

--- a/packages/nx-python/src/generators/uv-project/schema.json
+++ b/packages/nx-python/src/generators/uv-project/schema.json
@@ -41,7 +41,7 @@
       "default": ">=3.9,<4"
     },
     "pyenvPythonVersion": {
-      "type": "string",
+      "oneOf": [{ "type": "string" }, { "type": "number" }],
       "description": "Pyenv .python-version content (default to current python version)"
     },
     "publishable": {


### PR DESCRIPTION
## Current Behavior

When the `pyenvPythonVersion` is passed in the CLI as `3.10` Nx thinks it's a number and fails the generator with the following error:

```
NX   Property 'pyenvPythonVersion' does not match the schema. '3.12' should be a 'string'.
```

## Expected Behavior

The generator should work when the  `pyenvPythonVersion` argument is provided with the fully qualified version (3.12.9) or short version (`3.12`)

## Related Issue(s)

Fixes #289 
