### PR TITLE
fix(nx-python): preserve sorted-ness in `project.dependencies`

### DIFF
--- a/packages/nx-python/src/generators/uv-project/generator.ts
+++ b/packages/nx-python/src/generators/uv-project/generator.ts
@@ -80,7 +80,10 @@ function updateRootPyprojectToml(
 
   if (group === 'main') {
     rootPyprojectToml.project.dependencies ??= [];
-    rootPyprojectToml.project.dependencies.push(normalizedOptions.packageName);
+    sortPreservingInsert(
+      rootPyprojectToml.project.dependencies,
+      normalizedOptions.packageName,
+    );
   } else {
     rootPyprojectToml['dependency-groups'] ??= {};
     rootPyprojectToml['dependency-groups'][group] ??= [];


### PR DESCRIPTION
I missed a spot in https://github.com/lucasvieirasilva/nx-plugins/pull/286.

## Current Behavior

sorted-ness is not preserved in `project.dependencies`

## Expected Behavior

sorted-ness is preserved in `project.dependencies`