### PR TITLE
feat(nx-python): add lock args option to release-version generator

### DIFF
--- a/packages/nx-python/README.md
+++ b/packages/nx-python/README.md
@@ -721,3 +721,26 @@ If you are already using the `@nxlv/python` plugin and want to enable the releas
 ```bash
 nx generate @nxlv/python:enable-releases
 ```
+
+##### Release Lock arguments
+
+The `@nxlv/python:release-version` generator has a `lockArgs` option that allows you to pass additional arguments to the `lock` command.
+
+To use it, you need to update the `nx.json` file to add the `lockArgs` option in the `release.version.generatorOptions` object.
+
+Example:
+
+```json
+{
+  ...
+  "release": {
+    ...
+    "version": {
+      "generatorOptions": {
+        ...
+        "lockArgs": "--index-strategy unsafe-best-match"
+      }
+    }
+  }
+}
+```

--- a/packages/nx-python/src/generators/release-version/release-version.spec.ts
+++ b/packages/nx-python/src/generators/release-version/release-version.spec.ts
@@ -29,7 +29,7 @@ import { readPyprojectToml } from '../../provider/utils';
 import { PoetryPyprojectToml } from '../../provider/poetry/types';
 import { UVPyprojectToml } from '../../provider/uv/types';
 import { PoetryProvider } from '../../provider/poetry';
-import { ReleaseVersionGeneratorSchema } from './schema';
+import { PythonReleaseVersionGeneratorSchema } from './schema';
 
 process.env.NX_DAEMON = 'false';
 
@@ -131,7 +131,7 @@ describe('release-version', () => {
     });
 
     it('should not update the lock file if skipLockFileUpdate is true', async () => {
-      const generatorOptions: ReleaseVersionGeneratorSchema = {
+      const generatorOptions: PythonReleaseVersionGeneratorSchema = {
         projects: Object.values(projectGraph.nodes), // version all projects
         projectGraph,
         specifier: 'major',

--- a/packages/nx-python/src/generators/release-version/release-version.ts
+++ b/packages/nx-python/src/generators/release-version/release-version.ts
@@ -34,7 +34,7 @@ import {
 import { interpolate } from 'nx/src/tasks-runner/utils';
 import ora from 'ora';
 import { ReleaseType, gt, inc, prerelease } from 'semver';
-import { ReleaseVersionGeneratorSchema } from './schema';
+import { PythonReleaseVersionGeneratorSchema } from './schema';
 import {
   LocalPackageDependency,
   resolveLocalPackageDependencies,
@@ -46,7 +46,7 @@ import { PluginOptions } from '../../types';
 
 export async function releaseVersionGenerator(
   tree: Tree,
-  options: ReleaseVersionGeneratorSchema,
+  options: PythonReleaseVersionGeneratorSchema,
 ): Promise<ReleaseVersionGeneratorResult> {
   let logger: ProjectLogger | undefined;
   const nxJson = readJson<NxJsonConfiguration>(tree, 'nx.json');
@@ -748,7 +748,7 @@ To fix this you will either need to add a pyproject.toml file at that location, 
             const prefixMatch = currentDependencyVersion.match(/^[~^]/);
             if (prefixMatch) {
               versionPrefix =
-                prefixMatch[0] as ReleaseVersionGeneratorSchema['versionPrefix'];
+                prefixMatch[0] as PythonReleaseVersionGeneratorSchema['versionPrefix'];
             } else {
               versionPrefix = '';
             }
@@ -893,9 +893,12 @@ To fix this you will either need to add a pyproject.toml file at that location, 
               .filter((f) => !!f),
           );
         }
+        const lockArgs = opts.generatorOptions
+          ?.lockArgs as PythonReleaseVersionGeneratorSchema['lockArgs'];
+
         if (!opts.dryRun && !opts.generatorOptions?.skipLockFileUpdate) {
           for (const lockDir of updatedProjects) {
-            await provider.lock(lockDir);
+            await provider.lock(lockDir, false, lockArgs);
           }
 
           if (tree.exists('pyproject.toml')) {
@@ -905,7 +908,7 @@ To fix this you will either need to add a pyproject.toml file at that location, 
               changedFiles.push('uv.lock');
             }
 
-            await provider.lock(tree.root);
+            await provider.lock(tree.root, false, lockArgs);
           }
         }
 

--- a/packages/nx-python/src/generators/release-version/schema.d.ts
+++ b/packages/nx-python/src/generators/release-version/schema.d.ts
@@ -1,1 +1,6 @@
-export { ReleaseVersionGeneratorSchema } from 'nx/src/command-line/release/version';
+import { ReleaseVersionGeneratorSchema } from 'nx/src/command-line/release/version';
+
+export interface PythonReleaseVersionGeneratorSchema
+  extends ReleaseVersionGeneratorSchema {
+  lockArgs?: string;
+}

--- a/packages/nx-python/src/generators/release-version/schema.json
+++ b/packages/nx-python/src/generators/release-version/schema.json
@@ -61,6 +61,10 @@
     "installIgnoreScripts": {
       "type": "boolean",
       "description": "Whether to ignore install lifecycle scripts when updating the lock file with an install command."
+    },
+    "lockArgs": {
+      "type": "string",
+      "description": "Additional arguments to pass to the package manager when updating the lock file."
     }
   },
   "required": ["projects", "projectGraph", "releaseGroup"]

--- a/packages/nx-python/src/provider/base.ts
+++ b/packages/nx-python/src/provider/base.ts
@@ -84,7 +84,11 @@ export interface IProvider {
 
   lock(options?: LockExecutorSchema, context?: ExecutorContext): Promise<void>;
 
-  lock(projectRoot?: string, update?: boolean): Promise<void>;
+  lock(
+    projectRoot?: string,
+    update?: boolean,
+    args?: string[] | string,
+  ): Promise<void>;
 
   getLockCommand(projectRoot?: string, update?: boolean): Promise<string>;
 

--- a/packages/nx-python/src/provider/poetry/provider.ts
+++ b/packages/nx-python/src/provider/poetry/provider.ts
@@ -495,11 +495,16 @@ export class PoetryProvider implements IProvider {
     context?: ExecutorContext,
   ): Promise<void>;
 
-  public async lock(projectRoot?: string, update?: boolean): Promise<void>;
+  public async lock(
+    projectRoot?: string,
+    update?: boolean,
+    args?: string[] | string,
+  ): Promise<void>;
 
   public async lock(
     optionsOrprojectRoot?: LockExecutorSchema | string,
     contextOrUpdate?: ExecutorContext | boolean,
+    args?: string[] | string,
   ): Promise<void> {
     await this.checkPrerequisites();
 
@@ -562,8 +567,13 @@ export class PoetryProvider implements IProvider {
         updateOption,
       );
 
+      const lockArgs = lockCommand.split(' ').slice(1);
+      if (args) {
+        lockArgs.push(...(Array.isArray(args) ? args : args.split(' ')));
+      }
+
       runPoetry(
-        lockCommand.split(' ').slice(1),
+        lockArgs,
         optionsOrprojectRoot ? { cwd: optionsOrprojectRoot } : undefined,
       );
     } else {

--- a/packages/nx-python/src/provider/uv/provider.ts
+++ b/packages/nx-python/src/provider/uv/provider.ts
@@ -473,11 +473,16 @@ export class UVProvider implements IProvider {
     context?: ExecutorContext,
   ): Promise<void>;
 
-  public async lock(projectRoot?: string, update?: boolean): Promise<void>;
+  public async lock(
+    projectRoot?: string,
+    update?: boolean,
+    args?: string[] | string,
+  ): Promise<void>;
 
   public async lock(
     optionsOrprojectRoot?: LockExecutorSchema | string,
     contextOrUpdate?: ExecutorContext | boolean,
+    args?: string[] | string,
   ): Promise<void> {
     await this.checkPrerequisites();
 
@@ -535,8 +540,13 @@ export class UVProvider implements IProvider {
         updateOption,
       );
 
+      const lockArgs = lockCommand.split(' ').slice(1);
+      if (args) {
+        lockArgs.push(...(Array.isArray(args) ? args : args.split(' ')));
+      }
+
       runUv(
-        lockCommand.split(' ').slice(1),
+        lockArgs,
         optionsOrprojectRoot ? { cwd: optionsOrprojectRoot } : undefined,
       );
     } else {


### PR DESCRIPTION
## Current Behavior

Currently, when the release version generator calls the Package manager's lock operation, it does not pass anything.

## Expected Behavior

The release version should support `lockArgs` as a string, and it can be defined at the workspace level by updating the `nx.json` file.

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Reference #294 
