### PR TITLE
fix(nx-python): handle fix with boolean argument in ruff check

### DIFF
--- a/.cursor/mcp.json
+++ b/.cursor/mcp.json
@@ -1,0 +1,7 @@
+{
+  "mcpServers": {
+    "nx-mcp": {
+      "url": "http://localhost:9942/sse"
+    }
+  }
+}

--- a/packages/nx-python/src/executors/ruff-check/executor.spec.ts
+++ b/packages/nx-python/src/executors/ruff-check/executor.spec.ts
@@ -345,6 +345,108 @@ describe('Ruff Check Executor', () => {
       expect(output.success).toBe(true);
     });
 
+    it('should execute ruff check linting with unparsed args', async () => {
+      vi.mocked(spawn.sync).mockReturnValueOnce({
+        status: 0,
+        output: [''],
+        pid: 0,
+        signal: null,
+        stderr: null,
+        stdout: null,
+      });
+
+      const output = await executor(
+        {
+          lintFilePatterns: ['app'],
+          fix: true,
+          __unparsed__: ['--fix', 'True'],
+        },
+        {
+          cwd: '',
+          root: '.',
+          isVerbose: false,
+          projectName: 'app',
+          projectsConfigurations: {
+            version: 2,
+            projects: {
+              app: {
+                root: 'apps/app',
+                targets: {},
+              },
+            },
+          },
+          nxJsonConfiguration: {},
+          projectGraph: {
+            dependencies: {},
+            nodes: {},
+          },
+        },
+      );
+      expect(checkPrerequisites).toHaveBeenCalled();
+      expect(spawn.sync).toHaveBeenCalledTimes(1);
+      expect(spawn.sync).toHaveBeenCalledWith(
+        'uv',
+        ['run', 'ruff', 'check', 'app', '--fix'],
+        {
+          cwd: 'apps/app',
+          shell: true,
+          stdio: 'inherit',
+        },
+      );
+      expect(output.success).toBe(true);
+    });
+
+    it('should execute ruff check linting with unparsed args (false)', async () => {
+      vi.mocked(spawn.sync).mockReturnValueOnce({
+        status: 0,
+        output: [''],
+        pid: 0,
+        signal: null,
+        stderr: null,
+        stdout: null,
+      });
+
+      const output = await executor(
+        {
+          lintFilePatterns: ['app'],
+          fix: true,
+          __unparsed__: ['--fix', 'false'],
+        },
+        {
+          cwd: '',
+          root: '.',
+          isVerbose: false,
+          projectName: 'app',
+          projectsConfigurations: {
+            version: 2,
+            projects: {
+              app: {
+                root: 'apps/app',
+                targets: {},
+              },
+            },
+          },
+          nxJsonConfiguration: {},
+          projectGraph: {
+            dependencies: {},
+            nodes: {},
+          },
+        },
+      );
+      expect(checkPrerequisites).toHaveBeenCalled();
+      expect(spawn.sync).toHaveBeenCalledTimes(1);
+      expect(spawn.sync).toHaveBeenCalledWith(
+        'uv',
+        ['run', 'ruff', 'check', 'app'],
+        {
+          cwd: 'apps/app',
+          shell: true,
+          stdio: 'inherit',
+        },
+      );
+      expect(output.success).toBe(true);
+    });
+
     it('should fail to execute ruff check linting ', async () => {
       vi.mocked(spawn.sync).mockReturnValueOnce({
         status: 1,

--- a/packages/nx-python/src/executors/ruff-check/executor.ts
+++ b/packages/nx-python/src/executors/ruff-check/executor.ts
@@ -20,6 +20,17 @@ export default async function executor(
     const projectConfig =
       context.projectsConfigurations.projects[context.projectName];
 
+    const fixIndex = options.__unparsed__.findIndex(
+      (item, index, array) =>
+        item === '--fix' &&
+        ['true', 'false'].includes(array[index + 1]?.toLowerCase()),
+    );
+
+    if (fixIndex !== -1) {
+      const deletedArgs = options.__unparsed__.splice(fixIndex, 2);
+      options.fix = deletedArgs[1]?.toLowerCase() === 'true';
+    }
+
     const commandArgs = ['ruff', 'check']
       .concat(options.lintFilePatterns)
       .concat(options.__unparsed__);


### PR DESCRIPTION
## Current Behavior

Whenever the `--fix` argument is provided with a bool (e.g. `--fix true`), nx passes them in the unparsed argument, which makes the ruff-check executor run the check with 2 `--fix`

Also, the ruff check doesn't support --fix true|false, it only supports `--fix`

## Expected Behavior

The ruff-check executor should handle this scenario and only provide the `--fix` once, and use the `true` or `false` as a condition to send the `--fix` or not.

## Related Issue(s)

Fixes #299 
