### PR TITLE
feat(nx-python): add support for build format options in Python executor

### DIFF
--- a/packages/nx-python/README.md
+++ b/packages/nx-python/README.md
@@ -351,14 +351,15 @@ The `@nxlv/python:build` command handles the `sdist` and `wheel` build generatio
 
 ##### Options
 
-| Option                      |   Type    | Description                              | Required | Default                      |
-| --------------------------- | :-------: | ---------------------------------------- | -------- | ---------------------------- |
-| `--silent`                  | `boolean` | Hide output text                         | `false`  | `false`                      |
-| `--outputPath`              | `string`  | Output path for the python tar/whl files | `true`   |                              |
-| `--keepBuildFolder`         | `boolean` | Keep build folder                        | `false`  | `false`                      |
-| `--lockedVersions`          | `boolean` | Build with locked versions               | `false`  | `true`                       |
-| `--bundleLocalDependencies` | `boolean` | Bundle local dependencies                | `false`  | `true`                       |
-| `--ignorePaths`             |  `array`  | Ignore folder/files on build process     | `false`  | `[".venv", ".tox", "tests"]` |
+| Option                      |   Type    | Description                                      | Required | Default                      |
+| --------------------------- | :-------: | ------------------------------------------------ | -------- | ---------------------------- |
+| `--silent`                  | `boolean` | Hide output text                                 | `false`  | `false`                      |
+| `--outputPath`              | `string`  | Output path for the python tar/whl files         | `true`   |                              |
+| `--keepBuildFolder`         | `boolean` | Keep build folder                                | `false`  | `false`                      |
+| `--lockedVersions`          | `boolean` | Build with locked versions                       | `false`  | `true`                       |
+| `--bundleLocalDependencies` | `boolean` | Bundle local dependencies                        | `false`  | `true`                       |
+| `--ignorePaths`             |  `array`  | Ignore folder/files on build process             | `false`  | `[".venv", ".tox", "tests"]` |
+| `--format`                  | `string`  | Build format (allowed values `sdist` or `wheel`) | `false`  | `wheel`                      |
 
 ##### Locked Versions Build
 

--- a/packages/nx-python/src/executors/build/schema.d.ts
+++ b/packages/nx-python/src/executors/build/schema.d.ts
@@ -9,6 +9,7 @@ export interface BuildExecutorSchema {
   customSourceName?: string;
   customSourceUrl?: string;
   publish?: boolean;
+  format?: 'sdist' | 'wheel';
 }
 
 export interface BuildExecutorOutput {

--- a/packages/nx-python/src/executors/build/schema.json
+++ b/packages/nx-python/src/executors/build/schema.json
@@ -49,6 +49,11 @@
     "customSourceUrl": {
       "type": "string",
       "description": "URL for the custom source"
+    },
+    "format": {
+      "type": "string",
+      "description": "Format for the build",
+      "enum": ["sdist", "wheel"]
     }
   },
   "required": ["outputPath"]

--- a/packages/nx-python/src/provider/poetry/provider.ts
+++ b/packages/nx-python/src/provider/poetry/provider.ts
@@ -739,6 +739,10 @@ export class PoetryProvider implements IProvider {
 
     this.logger.info(chalk`  Generating sdist and wheel artifacts`);
     const buildArgs = ['build'];
+    if (options.format) {
+      buildArgs.push('--format', options.format);
+    }
+
     runPoetry(buildArgs, { cwd: buildFolderPath });
 
     removeSync(options.outputPath);

--- a/packages/nx-python/src/provider/uv/provider.ts
+++ b/packages/nx-python/src/provider/uv/provider.ts
@@ -644,6 +644,10 @@ export class UVProvider implements IProvider {
 
     this.logger.info(chalk`  Generating sdist and wheel artifacts`);
     const buildArgs = ['build'];
+    if (options.format) {
+      buildArgs.push(`--${options.format}`);
+    }
+
     runUv(buildArgs, { cwd: buildFolderPath });
 
     removeSync(options.outputPath);


### PR DESCRIPTION
- Updated README.md to include `--format` option for specifying build format (sdist or wheel).
- Enhanced BuildExecutorSchema to include `format` property.
- Modified build logic in Poetry and UV providers to handle the new `format` option.
- Added tests for building Python projects in both wheel and sdist formats.

## Current Behavior

The build executor does not support the `--format` argument.

## Expected Behavior

It should support `--format` argument with `wheel` or `sdist` value, when not provided, the package manager should generate both (default Poetry and Uv behavior)

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Ref #301 
