### PR TITLE
feat(nx-python): update activate venv to install when folder is not found

### DIFF
--- a/packages/nx-python/src/executors/add/executor.spec.ts
+++ b/packages/nx-python/src/executors/add/executor.spec.ts
@@ -4,6 +4,7 @@ import '../../utils/mocks/cross-spawn.mock';
 import '../../utils/mocks/fs.mock';
 import * as poetryUtils from '../../provider/poetry/utils';
 import { UVProvider } from '../../provider/uv/provider';
+import { PoetryProvider } from '../../provider/poetry/provider';
 import executor from './executor';
 import chalk from 'chalk';
 import { parseToml } from '../../provider/poetry/utils';
@@ -31,8 +32,8 @@ describe('Add Executor', () => {
         .mockResolvedValue(undefined);
       vi.spyOn(poetryUtils, 'getPoetryVersion').mockResolvedValue('1.8.2');
       activateVenvMock = vi
-        .spyOn(poetryUtils, 'activateVenv')
-        .mockReturnValue(undefined);
+        .spyOn(PoetryProvider.prototype, 'activateVenv')
+        .mockResolvedValue(undefined);
       vi.mocked(spawn.sync).mockReturnValue({
         status: 0,
         output: [''],
@@ -77,7 +78,7 @@ describe('Add Executor', () => {
 
       const output = await executor(options, context);
       expect(checkPoetryExecutableMock).toHaveBeenCalled();
-      expect(activateVenvMock).toHaveBeenCalledWith('.');
+      expect(activateVenvMock).toHaveBeenCalledWith('.', context);
       expect(spawn.sync).not.toHaveBeenCalled();
       expect(output.success).toBe(false);
     });
@@ -128,7 +129,7 @@ describe('Add Executor', () => {
 
       const output = await executor(options, context);
       expect(checkPoetryExecutableMock).toHaveBeenCalled();
-      expect(activateVenvMock).toHaveBeenCalledWith('.');
+      expect(activateVenvMock).toHaveBeenCalledWith('.', context);
       expect(spawn.sync).toHaveBeenCalledWith('poetry', ['add', 'numpy'], {
         cwd: 'apps/app',
         shell: false,
@@ -184,7 +185,7 @@ describe('Add Executor', () => {
 
       const output = await executor(options, context);
       expect(checkPoetryExecutableMock).toHaveBeenCalled();
-      expect(activateVenvMock).toHaveBeenCalledWith('.');
+      expect(activateVenvMock).toHaveBeenCalledWith('.', context);
       expect(spawn.sync).toHaveBeenCalledWith(
         'poetry',
         ['add', 'numpy', '--group', 'dev'],
@@ -244,7 +245,7 @@ describe('Add Executor', () => {
 
       const output = await executor(options, context);
       expect(checkPoetryExecutableMock).toHaveBeenCalled();
-      expect(activateVenvMock).toHaveBeenCalledWith('.');
+      expect(activateVenvMock).toHaveBeenCalledWith('.', context);
       expect(spawn.sync).toHaveBeenCalledWith(
         'poetry',
         ['add', 'numpy', '--extras=dev'],
@@ -300,7 +301,7 @@ describe('Add Executor', () => {
 
       const output = await executor(options, context);
       expect(checkPoetryExecutableMock).toHaveBeenCalled();
-      expect(activateVenvMock).toHaveBeenCalledWith('.');
+      expect(activateVenvMock).toHaveBeenCalledWith('.', context);
       expect(spawn.sync).not.toHaveBeenCalled();
       expect(output.success).toBe(false);
     });
@@ -352,7 +353,7 @@ describe('Add Executor', () => {
 
       const output = await executor(options, context);
       expect(checkPoetryExecutableMock).toHaveBeenCalled();
-      expect(activateVenvMock).toHaveBeenCalledWith('.');
+      expect(activateVenvMock).toHaveBeenCalledWith('.', context);
       expect(spawn.sync).toHaveBeenCalledWith('poetry', ['add', 'numpy'], {
         cwd: 'apps/app',
         shell: false,
@@ -457,7 +458,7 @@ describe('Add Executor', () => {
 
       const output = await executor(options, context);
       expect(checkPoetryExecutableMock).toHaveBeenCalled();
-      expect(activateVenvMock).toHaveBeenCalledWith('.');
+      expect(activateVenvMock).toHaveBeenCalledWith('.', context);
       expect(spawn.sync).toHaveBeenCalledTimes(7);
       expect(spawn.sync).toHaveBeenNthCalledWith(
         1,
@@ -629,7 +630,7 @@ describe('Add Executor', () => {
 
       const output = await executor(options, context);
       expect(checkPoetryExecutableMock).toHaveBeenCalled();
-      expect(activateVenvMock).toHaveBeenCalledWith('.');
+      expect(activateVenvMock).toHaveBeenCalledWith('.', context);
       expect(spawn.sync).toHaveBeenCalledTimes(7);
       expect(spawn.sync).toHaveBeenNthCalledWith(
         1,
@@ -785,7 +786,7 @@ describe('Add Executor', () => {
 
       const output = await executor(options, context);
       expect(checkPoetryExecutableMock).toHaveBeenCalled();
-      expect(activateVenvMock).toHaveBeenCalledWith('.');
+      expect(activateVenvMock).toHaveBeenCalledWith('.', context);
       expect(spawn.sync).toHaveBeenCalledTimes(7);
       expect(spawn.sync).toHaveBeenNthCalledWith(
         1,
@@ -917,7 +918,7 @@ describe('Add Executor', () => {
 
       const output = await executor(options, context);
       expect(checkPoetryExecutableMock).toHaveBeenCalled();
-      expect(activateVenvMock).toHaveBeenCalledWith('.');
+      expect(activateVenvMock).toHaveBeenCalledWith('.', context);
       expect(spawn.sync).toHaveBeenCalledTimes(2);
       expect(spawn.sync).toHaveBeenNthCalledWith(
         1,
@@ -1001,7 +1002,7 @@ describe('Add Executor', () => {
 
       const output = await executor(options, context);
       expect(checkPoetryExecutableMock).toHaveBeenCalled();
-      expect(activateVenvMock).toHaveBeenCalledWith('.');
+      expect(activateVenvMock).toHaveBeenCalledWith('.', context);
       expect(spawn.sync).toHaveBeenCalledTimes(2);
       expect(spawn.sync).toHaveBeenNthCalledWith(
         1,
@@ -1085,7 +1086,7 @@ describe('Add Executor', () => {
 
       const output = await executor(options, context);
       expect(checkPoetryExecutableMock).toHaveBeenCalled();
-      expect(activateVenvMock).toHaveBeenCalledWith('.');
+      expect(activateVenvMock).toHaveBeenCalledWith('.', context);
       expect(spawn.sync).toHaveBeenCalledTimes(2);
       expect(spawn.sync).toHaveBeenNthCalledWith(
         1,
@@ -1170,7 +1171,7 @@ describe('Add Executor', () => {
 
       const output = await executor(options, context);
       expect(checkPoetryExecutableMock).toHaveBeenCalled();
-      expect(activateVenvMock).toHaveBeenCalledWith('.');
+      expect(activateVenvMock).toHaveBeenCalledWith('.', context);
       expect(spawn.sync).toHaveBeenCalledTimes(2);
       expect(spawn.sync).toHaveBeenNthCalledWith(
         1,
@@ -1254,7 +1255,7 @@ describe('Add Executor', () => {
       const output = await executor(options, context);
       expect(output.success).toBe(true);
       expect(checkPoetryExecutableMock).toHaveBeenCalled();
-      expect(activateVenvMock).toHaveBeenCalledWith('.');
+      expect(activateVenvMock).toHaveBeenCalledWith('.', context);
       expect(spawn.sync).toHaveBeenCalledTimes(2);
       expect(spawn.sync).toHaveBeenNthCalledWith(
         1,
@@ -1333,7 +1334,7 @@ describe('Add Executor', () => {
 
       const output = await executor(options, context);
       expect(checkPoetryExecutableMock).toHaveBeenCalled();
-      expect(activateVenvMock).toHaveBeenCalledWith('.');
+      expect(activateVenvMock).toHaveBeenCalledWith('.', context);
       expect(spawn.sync).toHaveBeenCalledWith(
         'poetry',
         ['add', 'numpy', '--group', 'dev'],
@@ -1398,7 +1399,7 @@ describe('Add Executor', () => {
 
       const output = await executor(options, context);
       expect(checkPoetryExecutableMock).toHaveBeenCalled();
-      expect(activateVenvMock).toHaveBeenCalledWith('.');
+      expect(activateVenvMock).toHaveBeenCalledWith('.', context);
       expect(spawn.sync).toHaveBeenNthCalledWith(
         1,
         'poetry',
@@ -1485,7 +1486,7 @@ describe('Add Executor', () => {
 
       const output = await executor(options, context);
       expect(checkPoetryExecutableMock).toHaveBeenCalled();
-      expect(activateVenvMock).toHaveBeenCalledWith('.');
+      expect(activateVenvMock).toHaveBeenCalledWith('.', context);
       expect(spawn.sync).toHaveBeenNthCalledWith(
         1,
         'poetry',

--- a/packages/nx-python/src/executors/build/executor.spec.ts
+++ b/packages/nx-python/src/executors/build/executor.spec.ts
@@ -16,7 +16,7 @@ import dedent from 'string-dedent';
 import spawn from 'cross-spawn';
 import { SpawnSyncOptions } from 'child_process';
 import { ExecutorContext } from '@nx/devkit';
-import { PoetryPyprojectToml } from '../../provider/poetry';
+import { PoetryProvider, PoetryPyprojectToml } from '../../provider/poetry';
 import { UVProvider } from '../../provider/uv';
 import { getPyprojectData } from '../../provider/utils';
 import { UVPyprojectToml } from '../../provider/uv/types';
@@ -59,8 +59,8 @@ describe('Build Executor', () => {
         .mockResolvedValue(undefined);
 
       activateVenvMock = vi
-        .spyOn(poetryUtils, 'activateVenv')
-        .mockReturnValue(undefined);
+        .spyOn(PoetryProvider.prototype, 'activateVenv')
+        .mockResolvedValue(undefined);
     });
 
     it('should return success false when the poetry is not installed', async () => {
@@ -101,7 +101,7 @@ describe('Build Executor', () => {
 
       const output = await executor(options, context);
       expect(checkPoetryExecutableMock).toHaveBeenCalled();
-      expect(activateVenvMock).toHaveBeenCalledWith('.');
+      expect(activateVenvMock).toHaveBeenCalledWith('.', context);
       expect(spawn.sync).not.toHaveBeenCalled();
       expect(output.success).toBe(false);
     });
@@ -142,7 +142,7 @@ describe('Build Executor', () => {
 
       const output = await executor(options, context);
       expect(checkPoetryExecutableMock).toHaveBeenCalled();
-      expect(activateVenvMock).toHaveBeenCalledWith('.');
+      expect(activateVenvMock).toHaveBeenCalledWith('.', context);
       expect(spawn.sync).not.toHaveBeenCalled();
       expect(output.success).toBe(false);
     });
@@ -221,7 +221,7 @@ describe('Build Executor', () => {
           bundleLocalDependencies: true,
         };
 
-        const output = await executor(options, {
+        const context: ExecutorContext = {
           cwd: '',
           root: '.',
           isVerbose: false,
@@ -240,10 +240,12 @@ describe('Build Executor', () => {
             dependencies: {},
             nodes: {},
           },
-        });
+        };
+
+        const output = await executor(options, context);
 
         expect(checkPoetryExecutableMock).toHaveBeenCalled();
-        expect(activateVenvMock).toHaveBeenCalledWith('.');
+        expect(activateVenvMock).toHaveBeenCalledWith('.', context);
         expect(existsSync(buildPath)).toBeTruthy();
         expect(existsSync(`${buildPath}/app`)).toBeTruthy();
         expect(existsSync(`${buildPath}/dist/app.fake`)).toBeTruthy();
@@ -432,7 +434,7 @@ describe('Build Executor', () => {
           bundleLocalDependencies: true,
         };
 
-        const output = await executor(options, {
+        const context: ExecutorContext = {
           cwd: '',
           root: '.',
           isVerbose: false,
@@ -459,10 +461,12 @@ describe('Build Executor', () => {
             dependencies: {},
             nodes: {},
           },
-        });
+        };
+
+        const output = await executor(options, context);
 
         expect(checkPoetryExecutableMock).toHaveBeenCalled();
-        expect(activateVenvMock).toHaveBeenCalledWith('.');
+        expect(activateVenvMock).toHaveBeenCalledWith('.', context);
         expect(existsSync(buildPath)).toBeTruthy();
         expect(existsSync(`${buildPath}/app`)).toBeTruthy();
         expect(existsSync(`${buildPath}/dep1`)).toBeTruthy();
@@ -622,7 +626,7 @@ describe('Build Executor', () => {
           bundleLocalDependencies: true,
         };
 
-        const output = await executor(options, {
+        const context: ExecutorContext = {
           cwd: '',
           root: '.',
           isVerbose: false,
@@ -649,10 +653,12 @@ describe('Build Executor', () => {
             dependencies: {},
             nodes: {},
           },
-        });
+        };
+
+        const output = await executor(options, context);
 
         expect(checkPoetryExecutableMock).toHaveBeenCalled();
-        expect(activateVenvMock).toHaveBeenCalledWith('.');
+        expect(activateVenvMock).toHaveBeenCalledWith('.', context);
         expect(existsSync(buildPath)).toBeTruthy();
         expect(existsSync(`${buildPath}/app`)).toBeTruthy();
         expect(existsSync(`${buildPath}/dep1`)).toBeTruthy();
@@ -814,7 +820,7 @@ describe('Build Executor', () => {
           bundleLocalDependencies: true,
         };
 
-        const output = await executor(options, {
+        const context: ExecutorContext = {
           cwd: '',
           root: '.',
           isVerbose: false,
@@ -841,10 +847,12 @@ describe('Build Executor', () => {
             dependencies: {},
             nodes: {},
           },
-        });
+        };
+
+        const output = await executor(options, context);
 
         expect(checkPoetryExecutableMock).toHaveBeenCalled();
-        expect(activateVenvMock).toHaveBeenCalledWith('.');
+        expect(activateVenvMock).toHaveBeenCalledWith('.', context);
         expect(existsSync(buildPath)).toBeTruthy();
         expect(existsSync(`${buildPath}/app`)).toBeTruthy();
         expect(existsSync(`${buildPath}/dep1`)).toBeTruthy();
@@ -1102,7 +1110,7 @@ describe('Build Executor', () => {
           bundleLocalDependencies: true,
         };
 
-        const output = await executor(options, {
+        const context: ExecutorContext = {
           cwd: '',
           root: '.',
           isVerbose: false,
@@ -1121,10 +1129,12 @@ describe('Build Executor', () => {
             dependencies: {},
             nodes: {},
           },
-        });
+        };
+
+        const output = await executor(options, context);
 
         expect(checkPoetryExecutableMock).toHaveBeenCalled();
-        expect(activateVenvMock).toHaveBeenCalledWith('.');
+        expect(activateVenvMock).toHaveBeenCalledWith('.', context);
         expect(existsSync(buildPath)).toBeTruthy();
         expect(existsSync(`${buildPath}/app`)).toBeTruthy();
         expect(spawn.sync).toHaveBeenCalledWith('poetry', ['build'], {
@@ -1225,7 +1235,7 @@ describe('Build Executor', () => {
           bundleLocalDependencies: true,
         };
 
-        const output = await executor(options, {
+        const context: ExecutorContext = {
           cwd: '',
           root: '.',
           isVerbose: false,
@@ -1244,10 +1254,12 @@ describe('Build Executor', () => {
             dependencies: {},
             nodes: {},
           },
-        });
+        };
+
+        const output = await executor(options, context);
 
         expect(checkPoetryExecutableMock).toHaveBeenCalled();
-        expect(activateVenvMock).toHaveBeenCalledWith('.');
+        expect(activateVenvMock).toHaveBeenCalledWith('.', context);
         expect(existsSync(buildPath)).toBeTruthy();
         expect(existsSync(`${buildPath}/app`)).toBeTruthy();
         expect(spawn.sync).toHaveBeenCalledWith('poetry', ['build'], {
@@ -1346,7 +1358,7 @@ describe('Build Executor', () => {
           bundleLocalDependencies: true,
         };
 
-        const output = await executor(options, {
+        const context: ExecutorContext = {
           cwd: '',
           root: '.',
           isVerbose: false,
@@ -1365,11 +1377,13 @@ describe('Build Executor', () => {
             dependencies: {},
             nodes: {},
           },
-        });
+        };
+
+        const output = await executor(options, context);
 
         expect(output.success).toBe(true);
         expect(checkPoetryExecutableMock).toHaveBeenCalled();
-        expect(activateVenvMock).toHaveBeenCalledWith('.');
+        expect(activateVenvMock).toHaveBeenCalledWith('.', context);
         expect(existsSync(buildPath)).toBeTruthy();
         expect(existsSync(`${buildPath}/app`)).toBeTruthy();
         expect(spawn.sync).toHaveBeenCalledWith('poetry', ['build'], {
@@ -1458,7 +1472,7 @@ describe('Build Executor', () => {
           bundleLocalDependencies: true,
         };
 
-        const output = await executor(options, {
+        const context: ExecutorContext = {
           cwd: '',
           root: '.',
           isVerbose: false,
@@ -1477,10 +1491,12 @@ describe('Build Executor', () => {
             dependencies: {},
             nodes: {},
           },
-        });
+        };
+
+        const output = await executor(options, context);
 
         expect(checkPoetryExecutableMock).toHaveBeenCalled();
-        expect(activateVenvMock).toHaveBeenCalledWith('.');
+        expect(activateVenvMock).toHaveBeenCalledWith('.', context);
         expect(output.success).toBe(false);
       });
 
@@ -1603,7 +1619,7 @@ describe('Build Executor', () => {
           bundleLocalDependencies: true,
         };
 
-        const output = await executor(options, {
+        const context: ExecutorContext = {
           cwd: '',
           root: '.',
           isVerbose: false,
@@ -1630,10 +1646,12 @@ describe('Build Executor', () => {
             dependencies: {},
             nodes: {},
           },
-        });
+        };
+
+        const output = await executor(options, context);
 
         expect(checkPoetryExecutableMock).toHaveBeenCalled();
-        expect(activateVenvMock).toHaveBeenCalledWith('.');
+        expect(activateVenvMock).toHaveBeenCalledWith('.', context);
         expect(existsSync(buildPath)).toBeTruthy();
         expect(existsSync(`${buildPath}/app`)).toBeTruthy();
         expect(existsSync(`${buildPath}/dep1`)).toBeTruthy();
@@ -1760,7 +1778,7 @@ describe('Build Executor', () => {
           bundleLocalDependencies: true,
         };
 
-        const output = await executor(options, {
+        const context: ExecutorContext = {
           cwd: '',
           root: '.',
           isVerbose: false,
@@ -1783,10 +1801,12 @@ describe('Build Executor', () => {
             dependencies: {},
             nodes: {},
           },
-        });
+        };
+
+        const output = await executor(options, context);
 
         expect(checkPoetryExecutableMock).toHaveBeenCalled();
-        expect(activateVenvMock).toHaveBeenCalledWith('.');
+        expect(activateVenvMock).toHaveBeenCalledWith('.', context);
         expect(existsSync(buildPath)).toBeTruthy();
         expect(existsSync(`${buildPath}/app`)).toBeTruthy();
         expect(existsSync(`${buildPath}/dep1`)).toBeTruthy();
@@ -1932,7 +1952,7 @@ describe('Build Executor', () => {
           bundleLocalDependencies: true,
         };
 
-        const output = await executor(options, {
+        const context: ExecutorContext = {
           cwd: '',
           root: '.',
           isVerbose: false,
@@ -1955,10 +1975,12 @@ describe('Build Executor', () => {
             dependencies: {},
             nodes: {},
           },
-        });
+        };
+
+        const output = await executor(options, context);
 
         expect(checkPoetryExecutableMock).toHaveBeenCalled();
-        expect(activateVenvMock).toHaveBeenCalledWith('.');
+        expect(activateVenvMock).toHaveBeenCalledWith('.', context);
         expect(output.success).toBe(true);
         expect(existsSync(buildPath)).toBeTruthy();
         expect(existsSync(`${buildPath}/app`)).toBeTruthy();
@@ -2092,7 +2114,7 @@ describe('Build Executor', () => {
           bundleLocalDependencies: true,
         };
 
-        const output = await executor(options, {
+        const context: ExecutorContext = {
           cwd: '',
           root: '.',
           isVerbose: false,
@@ -2111,10 +2133,12 @@ describe('Build Executor', () => {
             dependencies: {},
             nodes: {},
           },
-        });
+        };
+
+        const output = await executor(options, context);
 
         expect(checkPoetryExecutableMock).toHaveBeenCalled();
-        expect(activateVenvMock).toHaveBeenCalledWith('.');
+        expect(activateVenvMock).toHaveBeenCalledWith('.', context);
         expect(existsSync(buildPath)).toBeTruthy();
         expect(existsSync(`${buildPath}/app`)).toBeTruthy();
         expect(existsSync(`${buildPath}/dist/app.fake`)).toBeTruthy();
@@ -2199,7 +2223,7 @@ describe('Build Executor', () => {
           bundleLocalDependencies: true,
         };
 
-        const output = await executor(options, {
+        const context: ExecutorContext = {
           cwd: '',
           root: '.',
           isVerbose: false,
@@ -2218,9 +2242,12 @@ describe('Build Executor', () => {
             dependencies: {},
             nodes: {},
           },
-        });
+        };
+
+        const output = await executor(options, context);
+
         expect(checkPoetryExecutableMock).toHaveBeenCalled();
-        expect(activateVenvMock).toHaveBeenCalledWith('.');
+        expect(activateVenvMock).toHaveBeenCalledWith('.', context);
         expect(output.success).toBe(false);
       });
 
@@ -2279,7 +2306,7 @@ describe('Build Executor', () => {
           bundleLocalDependencies: true,
         };
 
-        const output = await executor(options, {
+        const context: ExecutorContext = {
           cwd: '',
           root: '.',
           isVerbose: false,
@@ -2298,10 +2325,12 @@ describe('Build Executor', () => {
             dependencies: {},
             nodes: {},
           },
-        });
+        };
+
+        const output = await executor(options, context);
 
         expect(checkPoetryExecutableMock).toHaveBeenCalled();
-        expect(activateVenvMock).toHaveBeenCalledWith('.');
+        expect(activateVenvMock).toHaveBeenCalledWith('.', context);
         expect(existsSync(buildPath)).not.toBeTruthy();
         expect(spawn.sync).toHaveBeenCalledWith('poetry', ['build'], {
           cwd: buildPath,
@@ -2373,7 +2402,7 @@ describe('Build Executor', () => {
           format: 'wheel',
         };
 
-        const output = await executor(options, {
+        const context: ExecutorContext = {
           cwd: '',
           root: '.',
           isVerbose: false,
@@ -2392,10 +2421,12 @@ describe('Build Executor', () => {
             dependencies: {},
             nodes: {},
           },
-        });
+        };
+
+        const output = await executor(options, context);
 
         expect(checkPoetryExecutableMock).toHaveBeenCalled();
-        expect(activateVenvMock).toHaveBeenCalledWith('.');
+        expect(activateVenvMock).toHaveBeenCalledWith('.', context);
         expect(spawn.sync).toHaveBeenCalledWith(
           'poetry',
           ['build', '--format', 'wheel'],
@@ -2471,7 +2502,7 @@ describe('Build Executor', () => {
           format: 'sdist',
         };
 
-        const output = await executor(options, {
+        const context: ExecutorContext = {
           cwd: '',
           root: '.',
           isVerbose: false,
@@ -2490,10 +2521,12 @@ describe('Build Executor', () => {
             dependencies: {},
             nodes: {},
           },
-        });
+        };
+
+        const output = await executor(options, context);
 
         expect(checkPoetryExecutableMock).toHaveBeenCalled();
-        expect(activateVenvMock).toHaveBeenCalledWith('.');
+        expect(activateVenvMock).toHaveBeenCalledWith('.', context);
         expect(spawn.sync).toHaveBeenCalledWith(
           'poetry',
           ['build', '--format', 'sdist'],
@@ -2551,7 +2584,7 @@ describe('Build Executor', () => {
           bundleLocalDependencies: true,
         };
 
-        const output = await executor(options, {
+        const context: ExecutorContext = {
           cwd: '',
           root: '.',
           isVerbose: false,
@@ -2570,10 +2603,12 @@ describe('Build Executor', () => {
             dependencies: {},
             nodes: {},
           },
-        });
+        };
+
+        const output = await executor(options, context);
 
         expect(checkPoetryExecutableMock).toHaveBeenCalled();
-        expect(activateVenvMock).toHaveBeenCalledWith('.');
+        expect(activateVenvMock).toHaveBeenCalledWith('.', context);
         expect(output.success).toBe(false);
       });
     });
@@ -2639,7 +2674,7 @@ describe('Build Executor', () => {
           bundleLocalDependencies: false,
         };
 
-        const output = await executor(options, {
+        const context: ExecutorContext = {
           cwd: '',
           root: '.',
           isVerbose: false,
@@ -2658,10 +2693,12 @@ describe('Build Executor', () => {
             dependencies: {},
             nodes: {},
           },
-        });
+        };
+
+        const output = await executor(options, context);
 
         expect(checkPoetryExecutableMock).toHaveBeenCalled();
-        expect(activateVenvMock).toHaveBeenCalledWith('.');
+        expect(activateVenvMock).toHaveBeenCalledWith('.', context);
         expect(output.success).toBe(false);
         expect(existsSync(buildPath)).toBeTruthy();
       });
@@ -2726,7 +2763,7 @@ describe('Build Executor', () => {
           bundleLocalDependencies: false,
         };
 
-        const output = await executor(options, {
+        const context: ExecutorContext = {
           cwd: '',
           root: '.',
           isVerbose: false,
@@ -2748,10 +2785,12 @@ describe('Build Executor', () => {
             dependencies: {},
             nodes: {},
           },
-        });
+        };
+
+        const output = await executor(options, context);
 
         expect(checkPoetryExecutableMock).toHaveBeenCalled();
-        expect(activateVenvMock).toHaveBeenCalledWith('.');
+        expect(activateVenvMock).toHaveBeenCalledWith('.', context);
         expect(output.success).toBe(true);
         expect(existsSync(buildPath)).toBeTruthy();
         expect(existsSync(`${buildPath}/app`)).toBeTruthy();
@@ -2843,7 +2882,7 @@ describe('Build Executor', () => {
           bundleLocalDependencies: false,
         };
 
-        const output = await executor(options, {
+        const context: ExecutorContext = {
           cwd: '',
           root: '.',
           isVerbose: false,
@@ -2872,10 +2911,12 @@ describe('Build Executor', () => {
             dependencies: {},
             nodes: {},
           },
-        });
+        };
+
+        const output = await executor(options, context);
 
         expect(checkPoetryExecutableMock).toHaveBeenCalled();
-        expect(activateVenvMock).toHaveBeenCalledWith('.');
+        expect(activateVenvMock).toHaveBeenCalledWith('.', context);
         expect(output.success).toBe(true);
         expect(existsSync(buildPath)).toBeTruthy();
         expect(existsSync(`${buildPath}/app`)).toBeTruthy();
@@ -2986,7 +3027,7 @@ describe('Build Executor', () => {
           bundleLocalDependencies: false,
         };
 
-        const output = await executor(options, {
+        const context: ExecutorContext = {
           cwd: '',
           root: '.',
           isVerbose: false,
@@ -3025,10 +3066,12 @@ describe('Build Executor', () => {
             dependencies: {},
             nodes: {},
           },
-        });
+        };
+
+        const output = await executor(options, context);
 
         expect(checkPoetryExecutableMock).toHaveBeenCalled();
-        expect(activateVenvMock).toHaveBeenCalledWith('.');
+        expect(activateVenvMock).toHaveBeenCalledWith('.', context);
         expect(output.success).toBe(true);
         expect(existsSync(buildPath)).toBeTruthy();
         expect(existsSync(`${buildPath}/app`)).toBeTruthy();
@@ -3141,7 +3184,7 @@ describe('Build Executor', () => {
           bundleLocalDependencies: false,
         };
 
-        const output = await executor(options, {
+        const context: ExecutorContext = {
           cwd: '',
           root: '.',
           isVerbose: false,
@@ -3182,10 +3225,12 @@ describe('Build Executor', () => {
             dependencies: {},
             nodes: {},
           },
-        });
+        };
+
+        const output = await executor(options, context);
 
         expect(checkPoetryExecutableMock).toHaveBeenCalled();
-        expect(activateVenvMock).toHaveBeenCalledWith('.');
+        expect(activateVenvMock).toHaveBeenCalledWith('.', context);
         expect(output.success).toBe(true);
         expect(existsSync(buildPath)).toBeTruthy();
         expect(existsSync(`${buildPath}/app`)).toBeTruthy();
@@ -3360,7 +3405,7 @@ describe('Build Executor', () => {
           bundleLocalDependencies: false,
         };
 
-        const output = await executor(options, {
+        const context: ExecutorContext = {
           cwd: '',
           root: '.',
           isVerbose: false,
@@ -3439,10 +3484,12 @@ describe('Build Executor', () => {
             dependencies: {},
             nodes: {},
           },
-        });
+        };
+
+        const output = await executor(options, context);
 
         expect(checkPoetryExecutableMock).toHaveBeenCalled();
-        expect(activateVenvMock).toHaveBeenCalledWith('.');
+        expect(activateVenvMock).toHaveBeenCalledWith('.', context);
         expect(output.success).toBe(true);
         expect(existsSync(buildPath)).toBeTruthy();
         expect(existsSync(`${buildPath}/app`)).toBeTruthy();

--- a/packages/nx-python/src/executors/flake8/executor.spec.ts
+++ b/packages/nx-python/src/executors/flake8/executor.spec.ts
@@ -12,6 +12,7 @@ import { mkdirsSync, writeFileSync } from 'fs-extra';
 import spawn from 'cross-spawn';
 import { ExecutorContext } from '@nx/devkit';
 import { UVProvider } from '../../provider/uv';
+import { PoetryProvider } from '../../provider/poetry/provider';
 
 describe('Flake8 Executor', () => {
   let tmppath = null;
@@ -36,8 +37,8 @@ describe('Flake8 Executor', () => {
         .mockResolvedValue(undefined);
 
       activateVenvMock = vi
-        .spyOn(poetryUtils, 'activateVenv')
-        .mockReturnValue(undefined);
+        .spyOn(PoetryProvider.prototype, 'activateVenv')
+        .mockResolvedValue(undefined);
 
       vi.mocked(spawn.sync).mockReturnValue({
         status: 0,
@@ -84,7 +85,7 @@ describe('Flake8 Executor', () => {
 
       const output = await executor(options, context);
       expect(checkPoetryExecutableMock).toHaveBeenCalled();
-      expect(activateVenvMock).toHaveBeenCalledWith('.');
+      expect(activateVenvMock).toHaveBeenCalledWith('.', context);
       expect(spawn.sync).not.toHaveBeenCalled();
       expect(output.success).toBe(false);
     });
@@ -103,34 +104,36 @@ describe('Flake8 Executor', () => {
         };
       });
 
+      const context: ExecutorContext = {
+        cwd: '',
+        root: '.',
+        isVerbose: false,
+        projectName: 'app',
+        projectsConfigurations: {
+          version: 2,
+          projects: {
+            app: {
+              root: 'apps/app',
+              targets: {},
+            },
+          },
+        },
+        nxJsonConfiguration: {},
+        projectGraph: {
+          dependencies: {},
+          nodes: {},
+        },
+      };
+
       const output = await executor(
         {
           outputFile,
           silent: false,
         },
-        {
-          cwd: '',
-          root: '.',
-          isVerbose: false,
-          projectName: 'app',
-          projectsConfigurations: {
-            version: 2,
-            projects: {
-              app: {
-                root: 'apps/app',
-                targets: {},
-              },
-            },
-          },
-          nxJsonConfiguration: {},
-          projectGraph: {
-            dependencies: {},
-            nodes: {},
-          },
-        },
+        context,
       );
       expect(checkPoetryExecutableMock).toHaveBeenCalled();
-      expect(activateVenvMock).toHaveBeenCalledWith('.');
+      expect(activateVenvMock).toHaveBeenCalledWith('.', context);
       expect(spawn.sync).toHaveBeenCalledTimes(1);
       expect(output.success).toBe(true);
     });
@@ -151,34 +154,36 @@ describe('Flake8 Executor', () => {
         };
       });
 
+      const context: ExecutorContext = {
+        cwd: '',
+        root: '.',
+        isVerbose: false,
+        projectName: 'app',
+        projectsConfigurations: {
+          version: 2,
+          projects: {
+            app: {
+              root: 'apps/app',
+              targets: {},
+            },
+          },
+        },
+        nxJsonConfiguration: {},
+        projectGraph: {
+          dependencies: {},
+          nodes: {},
+        },
+      };
+
       const output = await executor(
         {
           outputFile,
           silent: false,
         },
-        {
-          cwd: '',
-          root: '.',
-          isVerbose: false,
-          projectName: 'app',
-          projectsConfigurations: {
-            version: 2,
-            projects: {
-              app: {
-                root: 'apps/app',
-                targets: {},
-              },
-            },
-          },
-          nxJsonConfiguration: {},
-          projectGraph: {
-            dependencies: {},
-            nodes: {},
-          },
-        },
+        context,
       );
       expect(checkPoetryExecutableMock).toHaveBeenCalled();
-      expect(activateVenvMock).toHaveBeenCalledWith('.');
+      expect(activateVenvMock).toHaveBeenCalledWith('.', context);
       expect(spawn.sync).toHaveBeenCalledTimes(1);
       expect(output.success).toBe(true);
     });
@@ -188,34 +193,36 @@ describe('Flake8 Executor', () => {
         throw new Error('Some error');
       });
 
+      const context: ExecutorContext = {
+        cwd: '',
+        root: '.',
+        isVerbose: false,
+        projectName: 'app',
+        projectsConfigurations: {
+          version: 2,
+          projects: {
+            app: {
+              root: 'apps/app',
+              targets: {},
+            },
+          },
+        },
+        nxJsonConfiguration: {},
+        projectGraph: {
+          dependencies: {},
+          nodes: {},
+        },
+      };
+
       const output = await executor(
         {
           outputFile: join(tmppath, 'reports/apps/app/pylint.txt'),
           silent: false,
         },
-        {
-          cwd: '',
-          root: '.',
-          isVerbose: false,
-          projectName: 'app',
-          projectsConfigurations: {
-            version: 2,
-            projects: {
-              app: {
-                root: 'apps/app',
-                targets: {},
-              },
-            },
-          },
-          nxJsonConfiguration: {},
-          projectGraph: {
-            dependencies: {},
-            nodes: {},
-          },
-        },
+        context,
       );
       expect(checkPoetryExecutableMock).toHaveBeenCalled();
-      expect(activateVenvMock).toHaveBeenCalledWith('.');
+      expect(activateVenvMock).toHaveBeenCalledWith('.', context);
       expect(spawn.sync).toHaveBeenCalledTimes(1);
       expect(output.success).toBe(false);
     });
@@ -235,34 +242,36 @@ describe('Flake8 Executor', () => {
         };
       });
 
+      const context: ExecutorContext = {
+        cwd: '',
+        root: '.',
+        isVerbose: false,
+        projectName: 'app',
+        projectsConfigurations: {
+          version: 2,
+          projects: {
+            app: {
+              root: 'apps/app',
+              targets: {},
+            },
+          },
+        },
+        nxJsonConfiguration: {},
+        projectGraph: {
+          dependencies: {},
+          nodes: {},
+        },
+      };
+
       const output = await executor(
         {
           outputFile,
           silent: false,
         },
-        {
-          cwd: '',
-          root: '.',
-          isVerbose: false,
-          projectName: 'app',
-          projectsConfigurations: {
-            version: 2,
-            projects: {
-              app: {
-                root: 'apps/app',
-                targets: {},
-              },
-            },
-          },
-          nxJsonConfiguration: {},
-          projectGraph: {
-            dependencies: {},
-            nodes: {},
-          },
-        },
+        context,
       );
       expect(checkPoetryExecutableMock).toHaveBeenCalled();
-      expect(activateVenvMock).toHaveBeenCalledWith('.');
+      expect(activateVenvMock).toHaveBeenCalledWith('.', context);
       expect(spawn.sync).toHaveBeenCalledTimes(1);
       expect(output.success).toBe(false);
     });
@@ -270,12 +279,17 @@ describe('Flake8 Executor', () => {
 
   describe('uv', () => {
     let checkPrerequisites: MockInstance;
+    let activateVenvMock: MockInstance;
 
     beforeEach(() => {
       tmppath = join(tmpdir(), 'nx-python', 'flake8', uuid());
 
       checkPrerequisites = vi
         .spyOn(UVProvider.prototype, 'checkPrerequisites')
+        .mockResolvedValue(undefined);
+
+      activateVenvMock = vi
+        .spyOn(UVProvider.prototype, 'activateVenv')
         .mockResolvedValue(undefined);
 
       vi.mocked(spawn.sync).mockReturnValue({
@@ -326,6 +340,7 @@ describe('Flake8 Executor', () => {
 
       const output = await executor(options, context);
       expect(checkPrerequisites).toHaveBeenCalled();
+      expect(activateVenvMock).toHaveBeenCalledWith('.', context);
       expect(spawn.sync).not.toHaveBeenCalled();
       expect(output.success).toBe(false);
     });
@@ -344,33 +359,36 @@ describe('Flake8 Executor', () => {
         };
       });
 
+      const context: ExecutorContext = {
+        cwd: '',
+        root: '.',
+        isVerbose: false,
+        projectName: 'app',
+        projectsConfigurations: {
+          version: 2,
+          projects: {
+            app: {
+              root: 'apps/app',
+              targets: {},
+            },
+          },
+        },
+        nxJsonConfiguration: {},
+        projectGraph: {
+          dependencies: {},
+          nodes: {},
+        },
+      };
+
       const output = await executor(
         {
           outputFile,
           silent: false,
         },
-        {
-          cwd: '',
-          root: '.',
-          isVerbose: false,
-          projectName: 'app',
-          projectsConfigurations: {
-            version: 2,
-            projects: {
-              app: {
-                root: 'apps/app',
-                targets: {},
-              },
-            },
-          },
-          nxJsonConfiguration: {},
-          projectGraph: {
-            dependencies: {},
-            nodes: {},
-          },
-        },
+        context,
       );
       expect(checkPrerequisites).toHaveBeenCalled();
+      expect(activateVenvMock).toHaveBeenCalledWith('.', context);
       expect(spawn.sync).toHaveBeenCalledTimes(1);
       expect(spawn.sync).toHaveBeenCalledWith(
         'uv',
@@ -401,33 +419,36 @@ describe('Flake8 Executor', () => {
         };
       });
 
+      const context: ExecutorContext = {
+        cwd: '',
+        root: '.',
+        isVerbose: false,
+        projectName: 'app',
+        projectsConfigurations: {
+          version: 2,
+          projects: {
+            app: {
+              root: 'apps/app',
+              targets: {},
+            },
+          },
+        },
+        nxJsonConfiguration: {},
+        projectGraph: {
+          dependencies: {},
+          nodes: {},
+        },
+      };
+
       const output = await executor(
         {
           outputFile,
           silent: false,
         },
-        {
-          cwd: '',
-          root: '.',
-          isVerbose: false,
-          projectName: 'app',
-          projectsConfigurations: {
-            version: 2,
-            projects: {
-              app: {
-                root: 'apps/app',
-                targets: {},
-              },
-            },
-          },
-          nxJsonConfiguration: {},
-          projectGraph: {
-            dependencies: {},
-            nodes: {},
-          },
-        },
+        context,
       );
       expect(checkPrerequisites).toHaveBeenCalled();
+      expect(activateVenvMock).toHaveBeenCalledWith('.', context);
       expect(spawn.sync).toHaveBeenCalledTimes(1);
       expect(spawn.sync).toHaveBeenCalledWith(
         'uv',
@@ -446,34 +467,37 @@ describe('Flake8 Executor', () => {
         throw new Error('Some error');
       });
 
+      const context: ExecutorContext = {
+        cwd: '',
+        root: '.',
+        isVerbose: false,
+        projectName: 'app',
+        projectsConfigurations: {
+          version: 2,
+          projects: {
+            app: {
+              root: 'apps/app',
+              targets: {},
+            },
+          },
+        },
+        nxJsonConfiguration: {},
+        projectGraph: {
+          dependencies: {},
+          nodes: {},
+        },
+      };
+
       const outputFile = join(tmppath, 'reports/apps/app/pylint.txt');
       const output = await executor(
         {
           outputFile,
           silent: false,
         },
-        {
-          cwd: '',
-          root: '.',
-          isVerbose: false,
-          projectName: 'app',
-          projectsConfigurations: {
-            version: 2,
-            projects: {
-              app: {
-                root: 'apps/app',
-                targets: {},
-              },
-            },
-          },
-          nxJsonConfiguration: {},
-          projectGraph: {
-            dependencies: {},
-            nodes: {},
-          },
-        },
+        context,
       );
       expect(checkPrerequisites).toHaveBeenCalled();
+      expect(activateVenvMock).toHaveBeenCalledWith('.', context);
       expect(spawn.sync).toHaveBeenCalledTimes(1);
       expect(spawn.sync).toHaveBeenCalledWith(
         'uv',

--- a/packages/nx-python/src/executors/flake8/executor.ts
+++ b/packages/nx-python/src/executors/flake8/executor.ts
@@ -41,11 +41,16 @@ export default async function executor(
       undefined,
       context,
     );
-    await provider.run(lintingArgs, workspaceRoot, {
-      cwd,
-      log: false,
-      error: false,
-    });
+    await provider.run(
+      lintingArgs,
+      workspaceRoot,
+      {
+        cwd,
+        log: false,
+        error: false,
+      },
+      context,
+    );
 
     const output = readFileSync(absPath, 'utf8');
     const lines = output.split('\n').length;

--- a/packages/nx-python/src/executors/publish/executor.spec.ts
+++ b/packages/nx-python/src/executors/publish/executor.spec.ts
@@ -61,6 +61,7 @@ import { EventEmitter } from 'events';
 import { ExecutorContext } from '@nx/devkit';
 import { UVProvider } from '../../provider/uv';
 import spawn from 'cross-spawn';
+import { PoetryProvider } from '../../provider/poetry/provider';
 
 describe('Publish Executor', () => {
   beforeAll(() => {
@@ -102,8 +103,8 @@ describe('Publish Executor', () => {
         .mockResolvedValue(undefined);
 
       activateVenvMock = vi
-        .spyOn(poetryUtils, 'activateVenv')
-        .mockReturnValue(undefined);
+        .spyOn(PoetryProvider.prototype, 'activateVenv')
+        .mockResolvedValue(undefined);
 
       vi.spyOn(process, 'chdir').mockReturnValue(undefined);
     });
@@ -121,7 +122,7 @@ describe('Publish Executor', () => {
 
       const output = await executor(options, context);
       expect(checkPoetryExecutableMock).toHaveBeenCalled();
-      expect(activateVenvMock).toHaveBeenCalledWith('.');
+      expect(activateVenvMock).toHaveBeenCalledWith('.', context);
       expect(childProcessMocks.spawn).not.toHaveBeenCalled();
       expect(output.success).toBe(false);
     });
@@ -137,7 +138,7 @@ describe('Publish Executor', () => {
 
       const output = await executor(options, context);
       expect(checkPoetryExecutableMock).toHaveBeenCalled();
-      expect(activateVenvMock).toHaveBeenCalledWith('.');
+      expect(activateVenvMock).toHaveBeenCalledWith('.', context);
       expect(childProcessMocks.spawn).not.toHaveBeenCalled();
       expect(output.success).toBe(false);
     });
@@ -154,7 +155,7 @@ describe('Publish Executor', () => {
 
       const output = await executor(options, context);
       expect(checkPoetryExecutableMock).toHaveBeenCalled();
-      expect(activateVenvMock).toHaveBeenCalledWith('.');
+      expect(activateVenvMock).toHaveBeenCalledWith('.', context);
       expect(childProcessMocks.spawn).not.toHaveBeenCalled();
       expect(output.success).toBe(false);
     });
@@ -183,7 +184,7 @@ describe('Publish Executor', () => {
 
       const output = await executor(options, context);
       expect(checkPoetryExecutableMock).toHaveBeenCalled();
-      expect(activateVenvMock).toHaveBeenCalledWith('.');
+      expect(activateVenvMock).toHaveBeenCalledWith('.', context);
       expect(childProcessMocks.spawn).toHaveBeenCalledWith('poetry publish', {
         cwd: 'tmp',
         env: { ...process.env, FORCE_COLOR: 'true' },
@@ -230,7 +231,7 @@ describe('Publish Executor', () => {
 
       const output = await executor(options, context);
       expect(checkPoetryExecutableMock).toHaveBeenCalled();
-      expect(activateVenvMock).toHaveBeenCalledWith('.');
+      expect(activateVenvMock).toHaveBeenCalledWith('.', context);
       expect(childProcessMocks.spawn).toHaveBeenCalledWith(
         'poetry publish --repository aws',
         {
@@ -280,7 +281,7 @@ describe('Publish Executor', () => {
 
       const output = await executor(options, context);
       expect(checkPoetryExecutableMock).toHaveBeenCalled();
-      expect(activateVenvMock).toHaveBeenCalledWith('.');
+      expect(activateVenvMock).toHaveBeenCalledWith('.', context);
       expect(childProcessMocks.spawn).toHaveBeenCalledWith(
         'poetry publish -vvv --dry-run',
         {
@@ -335,7 +336,7 @@ describe('Publish Executor', () => {
 
       const output = await executor(options, context);
       expect(checkPoetryExecutableMock).toHaveBeenCalled();
-      expect(activateVenvMock).toHaveBeenCalledWith('.');
+      expect(activateVenvMock).toHaveBeenCalledWith('.', context);
       expect(childProcessMocks.spawn).toHaveBeenCalledWith('poetry publish', {
         cwd: 'tmp',
         env: { ...process.env, FORCE_COLOR: 'true' },
@@ -387,7 +388,7 @@ describe('Publish Executor', () => {
 
       const output = await executor(options, context);
       expect(checkPoetryExecutableMock).toHaveBeenCalled();
-      expect(activateVenvMock).toHaveBeenCalledWith('.');
+      expect(activateVenvMock).toHaveBeenCalledWith('.', context);
       expect(childProcessMocks.spawn).toHaveBeenCalledWith('poetry publish', {
         cwd: 'tmp',
         env: { ...process.env, FORCE_COLOR: 'true' },

--- a/packages/nx-python/src/executors/remove/executor.spec.ts
+++ b/packages/nx-python/src/executors/remove/executor.spec.ts
@@ -9,6 +9,7 @@ import dedent from 'string-dedent';
 import spawn from 'cross-spawn';
 import { ExecutorContext } from '@nx/devkit';
 import { UVProvider } from '../../provider/uv';
+import { PoetryProvider } from '../../provider/poetry/provider';
 
 describe('Delete Executor', () => {
   afterEach(() => {
@@ -33,8 +34,8 @@ describe('Delete Executor', () => {
         .spyOn(poetryUtils, 'getPoetryVersion')
         .mockResolvedValue('1.5.0');
       activateVenvMock = vi
-        .spyOn(poetryUtils, 'activateVenv')
-        .mockReturnValue(undefined);
+        .spyOn(PoetryProvider.prototype, 'activateVenv')
+        .mockResolvedValue(undefined);
       vi.mocked(spawn.sync).mockReturnValue({
         status: 0,
         output: [''],
@@ -79,7 +80,7 @@ describe('Delete Executor', () => {
 
       const output = await executor(options, context);
       expect(checkPoetryExecutableMock).toHaveBeenCalled();
-      expect(activateVenvMock).toHaveBeenCalledWith('.');
+      expect(activateVenvMock).toHaveBeenCalledWith('.', context);
       expect(spawn.sync).not.toHaveBeenCalled();
       expect(output.success).toBe(false);
     });
@@ -180,7 +181,7 @@ describe('Delete Executor', () => {
 
       const output = await executor(options, context);
       expect(checkPoetryExecutableMock).toHaveBeenCalled();
-      expect(activateVenvMock).toHaveBeenCalledWith('.');
+      expect(activateVenvMock).toHaveBeenCalledWith('.', context);
       expect(spawn.sync).toHaveBeenCalledTimes(5);
       expect(spawn.sync).toHaveBeenNthCalledWith(
         1,
@@ -332,7 +333,7 @@ describe('Delete Executor', () => {
 
       const output = await executor(options, context);
       expect(checkPoetryExecutableMock).toHaveBeenCalled();
-      expect(activateVenvMock).toHaveBeenCalledWith('.');
+      expect(activateVenvMock).toHaveBeenCalledWith('.', context);
       expect(spawn.sync).toHaveBeenCalledTimes(5);
       expect(spawn.sync).toHaveBeenNthCalledWith(
         1,
@@ -469,7 +470,7 @@ describe('Delete Executor', () => {
 
       const output = await executor(options, context);
       expect(checkPoetryExecutableMock).toHaveBeenCalled();
-      expect(activateVenvMock).toHaveBeenCalledWith('.');
+      expect(activateVenvMock).toHaveBeenCalledWith('.', context);
       expect(spawn.sync).toHaveBeenCalledTimes(7);
       expect(spawn.sync).toHaveBeenNthCalledWith(
         1,
@@ -587,7 +588,7 @@ describe('Delete Executor', () => {
 
       const output = await executor(options, context);
       expect(checkPoetryExecutableMock).toHaveBeenCalled();
-      expect(activateVenvMock).toHaveBeenCalledWith('.');
+      expect(activateVenvMock).toHaveBeenCalledWith('.', context);
       expect(spawn.sync).toHaveBeenCalledTimes(1);
       expect(spawn.sync).toHaveBeenNthCalledWith(
         1,
@@ -648,7 +649,7 @@ describe('Delete Executor', () => {
 
       const output = await executor(options, context);
       expect(checkPoetryExecutableMock).toHaveBeenCalled();
-      expect(activateVenvMock).toHaveBeenCalledWith('.');
+      expect(activateVenvMock).toHaveBeenCalledWith('.', context);
       expect(spawn.sync).toHaveBeenCalledTimes(1);
       expect(spawn.sync).toHaveBeenNthCalledWith(
         1,
@@ -715,7 +716,7 @@ describe('Delete Executor', () => {
 
       const output = await executor(options, context);
       expect(checkPoetryExecutableMock).toHaveBeenCalled();
-      expect(activateVenvMock).toHaveBeenCalledWith('.');
+      expect(activateVenvMock).toHaveBeenCalledWith('.', context);
       expect(spawn.sync).toHaveBeenNthCalledWith(
         1,
         'poetry',
@@ -801,7 +802,7 @@ describe('Delete Executor', () => {
 
       const output = await executor(options, context);
       expect(checkPoetryExecutableMock).toHaveBeenCalled();
-      expect(activateVenvMock).toHaveBeenCalledWith('.');
+      expect(activateVenvMock).toHaveBeenCalledWith('.', context);
       expect(spawn.sync).toHaveBeenNthCalledWith(
         1,
         'poetry',

--- a/packages/nx-python/src/executors/ruff-check/executor.spec.ts
+++ b/packages/nx-python/src/executors/ruff-check/executor.spec.ts
@@ -8,6 +8,7 @@ import executor from './executor';
 import spawn from 'cross-spawn';
 import { ExecutorContext } from '@nx/devkit';
 import { UVProvider } from '../../provider/uv';
+import { PoetryProvider } from '../../provider/poetry/provider';
 
 describe('Ruff Check Executor', () => {
   beforeAll(() => {
@@ -29,8 +30,8 @@ describe('Ruff Check Executor', () => {
         .mockResolvedValue(undefined);
 
       activateVenvMock = vi
-        .spyOn(poetryUtils, 'activateVenv')
-        .mockReturnValue(undefined);
+        .spyOn(PoetryProvider.prototype, 'activateVenv')
+        .mockResolvedValue(undefined);
 
       vi.mocked(spawn.sync).mockReturnValue({
         status: 0,
@@ -76,7 +77,7 @@ describe('Ruff Check Executor', () => {
 
       const output = await executor(options, context);
       expect(checkPoetryExecutableMock).toHaveBeenCalled();
-      expect(activateVenvMock).toHaveBeenCalledWith('.');
+      expect(activateVenvMock).toHaveBeenCalledWith('.', context);
       expect(spawn.sync).not.toHaveBeenCalled();
       expect(output.success).toBe(false);
     });
@@ -91,34 +92,36 @@ describe('Ruff Check Executor', () => {
         stdout: null,
       });
 
+      const context: ExecutorContext = {
+        cwd: '',
+        root: '.',
+        isVerbose: false,
+        projectName: 'app',
+        projectsConfigurations: {
+          version: 2,
+          projects: {
+            app: {
+              root: 'apps/app',
+              targets: {},
+            },
+          },
+        },
+        nxJsonConfiguration: {},
+        projectGraph: {
+          dependencies: {},
+          nodes: {},
+        },
+      };
+
       const output = await executor(
         {
           lintFilePatterns: ['app'],
           __unparsed__: [],
         },
-        {
-          cwd: '',
-          root: '.',
-          isVerbose: false,
-          projectName: 'app',
-          projectsConfigurations: {
-            version: 2,
-            projects: {
-              app: {
-                root: 'apps/app',
-                targets: {},
-              },
-            },
-          },
-          nxJsonConfiguration: {},
-          projectGraph: {
-            dependencies: {},
-            nodes: {},
-          },
-        },
+        context,
       );
       expect(checkPoetryExecutableMock).toHaveBeenCalled();
-      expect(activateVenvMock).toHaveBeenCalledWith('.');
+      expect(activateVenvMock).toHaveBeenCalledWith('.', context);
       expect(spawn.sync).toHaveBeenCalledTimes(1);
       expect(spawn.sync).toHaveBeenCalledWith(
         'poetry',
@@ -142,34 +145,36 @@ describe('Ruff Check Executor', () => {
         stdout: null,
       });
 
+      const context: ExecutorContext = {
+        cwd: '',
+        root: '.',
+        isVerbose: false,
+        projectName: 'app',
+        projectsConfigurations: {
+          version: 2,
+          projects: {
+            app: {
+              root: 'apps/app',
+              targets: {},
+            },
+          },
+        },
+        nxJsonConfiguration: {},
+        projectGraph: {
+          dependencies: {},
+          nodes: {},
+        },
+      };
+
       const output = await executor(
         {
           lintFilePatterns: ['app'],
           __unparsed__: [],
         },
-        {
-          cwd: '',
-          root: '.',
-          isVerbose: false,
-          projectName: 'app',
-          projectsConfigurations: {
-            version: 2,
-            projects: {
-              app: {
-                root: 'apps/app',
-                targets: {},
-              },
-            },
-          },
-          nxJsonConfiguration: {},
-          projectGraph: {
-            dependencies: {},
-            nodes: {},
-          },
-        },
+        context,
       );
       expect(checkPoetryExecutableMock).toHaveBeenCalled();
-      expect(activateVenvMock).toHaveBeenCalledWith('.');
+      expect(activateVenvMock).toHaveBeenCalledWith('.', context);
       expect(spawn.sync).toHaveBeenCalledTimes(1);
       expect(spawn.sync).toHaveBeenCalledWith(
         'poetry',
@@ -186,10 +191,15 @@ describe('Ruff Check Executor', () => {
 
   describe('uv', () => {
     let checkPrerequisites: MockInstance;
+    let activateVenvMock: MockInstance;
 
     beforeEach(() => {
       checkPrerequisites = vi
         .spyOn(UVProvider.prototype, 'checkPrerequisites')
+        .mockResolvedValue(undefined);
+
+      activateVenvMock = vi
+        .spyOn(UVProvider.prototype, 'activateVenv')
         .mockResolvedValue(undefined);
 
       vi.mocked(spawn.sync).mockReturnValue({
@@ -240,6 +250,7 @@ describe('Ruff Check Executor', () => {
 
       const output = await executor(options, context);
       expect(checkPrerequisites).toHaveBeenCalled();
+      expect(activateVenvMock).toHaveBeenCalledWith('.', context);
       expect(spawn.sync).not.toHaveBeenCalled();
       expect(output.success).toBe(false);
     });
@@ -254,33 +265,36 @@ describe('Ruff Check Executor', () => {
         stdout: null,
       });
 
+      const context: ExecutorContext = {
+        cwd: '',
+        root: '.',
+        isVerbose: false,
+        projectName: 'app',
+        projectsConfigurations: {
+          version: 2,
+          projects: {
+            app: {
+              root: 'apps/app',
+              targets: {},
+            },
+          },
+        },
+        nxJsonConfiguration: {},
+        projectGraph: {
+          dependencies: {},
+          nodes: {},
+        },
+      };
+
       const output = await executor(
         {
           lintFilePatterns: ['app'],
           __unparsed__: [],
         },
-        {
-          cwd: '',
-          root: '.',
-          isVerbose: false,
-          projectName: 'app',
-          projectsConfigurations: {
-            version: 2,
-            projects: {
-              app: {
-                root: 'apps/app',
-                targets: {},
-              },
-            },
-          },
-          nxJsonConfiguration: {},
-          projectGraph: {
-            dependencies: {},
-            nodes: {},
-          },
-        },
+        context,
       );
       expect(checkPrerequisites).toHaveBeenCalled();
+      expect(activateVenvMock).toHaveBeenCalledWith('.', context);
       expect(spawn.sync).toHaveBeenCalledTimes(1);
       expect(spawn.sync).toHaveBeenCalledWith(
         'uv',
@@ -304,34 +318,37 @@ describe('Ruff Check Executor', () => {
         stdout: null,
       });
 
+      const context: ExecutorContext = {
+        cwd: '',
+        root: '.',
+        isVerbose: false,
+        projectName: 'app',
+        projectsConfigurations: {
+          version: 2,
+          projects: {
+            app: {
+              root: 'apps/app',
+              targets: {},
+            },
+          },
+        },
+        nxJsonConfiguration: {},
+        projectGraph: {
+          dependencies: {},
+          nodes: {},
+        },
+      };
+
       const output = await executor(
         {
           lintFilePatterns: ['app'],
           fix: true,
           __unparsed__: [],
         },
-        {
-          cwd: '',
-          root: '.',
-          isVerbose: false,
-          projectName: 'app',
-          projectsConfigurations: {
-            version: 2,
-            projects: {
-              app: {
-                root: 'apps/app',
-                targets: {},
-              },
-            },
-          },
-          nxJsonConfiguration: {},
-          projectGraph: {
-            dependencies: {},
-            nodes: {},
-          },
-        },
+        context,
       );
       expect(checkPrerequisites).toHaveBeenCalled();
+      expect(activateVenvMock).toHaveBeenCalledWith('.', context);
       expect(spawn.sync).toHaveBeenCalledTimes(1);
       expect(spawn.sync).toHaveBeenCalledWith(
         'uv',
@@ -355,34 +372,37 @@ describe('Ruff Check Executor', () => {
         stdout: null,
       });
 
+      const context: ExecutorContext = {
+        cwd: '',
+        root: '.',
+        isVerbose: false,
+        projectName: 'app',
+        projectsConfigurations: {
+          version: 2,
+          projects: {
+            app: {
+              root: 'apps/app',
+              targets: {},
+            },
+          },
+        },
+        nxJsonConfiguration: {},
+        projectGraph: {
+          dependencies: {},
+          nodes: {},
+        },
+      };
+
       const output = await executor(
         {
           lintFilePatterns: ['app'],
           fix: true,
           __unparsed__: ['--fix', 'True'],
         },
-        {
-          cwd: '',
-          root: '.',
-          isVerbose: false,
-          projectName: 'app',
-          projectsConfigurations: {
-            version: 2,
-            projects: {
-              app: {
-                root: 'apps/app',
-                targets: {},
-              },
-            },
-          },
-          nxJsonConfiguration: {},
-          projectGraph: {
-            dependencies: {},
-            nodes: {},
-          },
-        },
+        context,
       );
       expect(checkPrerequisites).toHaveBeenCalled();
+      expect(activateVenvMock).toHaveBeenCalledWith('.', context);
       expect(spawn.sync).toHaveBeenCalledTimes(1);
       expect(spawn.sync).toHaveBeenCalledWith(
         'uv',

--- a/packages/nx-python/src/executors/ruff-check/executor.ts
+++ b/packages/nx-python/src/executors/ruff-check/executor.ts
@@ -49,12 +49,17 @@ export default async function executor(
       undefined,
       context,
     );
-    await provider.run(commandArgs, workspaceRoot, {
-      cwd: projectConfig.root,
-      log: false,
-      error: true,
-      shell: true,
-    });
+    await provider.run(
+      commandArgs,
+      workspaceRoot,
+      {
+        cwd: projectConfig.root,
+        log: false,
+        error: true,
+        shell: true,
+      },
+      context,
+    );
 
     return {
       success: true,

--- a/packages/nx-python/src/executors/ruff-format/executor.spec.ts
+++ b/packages/nx-python/src/executors/ruff-format/executor.spec.ts
@@ -8,6 +8,7 @@ import executor from './executor';
 import spawn from 'cross-spawn';
 import { ExecutorContext } from '@nx/devkit';
 import { UVProvider } from '../../provider/uv';
+import { PoetryProvider } from '../../provider/poetry/provider';
 
 describe('Ruff Format Executor', () => {
   beforeAll(() => {
@@ -29,8 +30,8 @@ describe('Ruff Format Executor', () => {
         .mockResolvedValue(undefined);
 
       activateVenvMock = vi
-        .spyOn(poetryUtils, 'activateVenv')
-        .mockReturnValue(undefined);
+        .spyOn(PoetryProvider.prototype, 'activateVenv')
+        .mockResolvedValue(undefined);
 
       vi.mocked(spawn.sync).mockReturnValue({
         status: 0,
@@ -77,7 +78,7 @@ describe('Ruff Format Executor', () => {
 
       const output = await executor(options, context);
       expect(checkPoetryExecutableMock).toHaveBeenCalled();
-      expect(activateVenvMock).toHaveBeenCalledWith('.');
+      expect(activateVenvMock).toHaveBeenCalledWith('.', context);
       expect(spawn.sync).not.toHaveBeenCalled();
       expect(output.success).toBe(false);
     });
@@ -92,35 +93,37 @@ describe('Ruff Format Executor', () => {
         stdout: null,
       });
 
+      const context: ExecutorContext = {
+        cwd: '',
+        root: '.',
+        isVerbose: false,
+        projectName: 'app',
+        projectsConfigurations: {
+          version: 2,
+          projects: {
+            app: {
+              root: 'apps/app',
+              targets: {},
+            },
+          },
+        },
+        nxJsonConfiguration: {},
+        projectGraph: {
+          dependencies: {},
+          nodes: {},
+        },
+      };
+
       const output = await executor(
         {
           filePatterns: ['app'],
           check: false,
           __unparsed__: [],
         },
-        {
-          cwd: '',
-          root: '.',
-          isVerbose: false,
-          projectName: 'app',
-          projectsConfigurations: {
-            version: 2,
-            projects: {
-              app: {
-                root: 'apps/app',
-                targets: {},
-              },
-            },
-          },
-          nxJsonConfiguration: {},
-          projectGraph: {
-            dependencies: {},
-            nodes: {},
-          },
-        },
+        context,
       );
       expect(checkPoetryExecutableMock).toHaveBeenCalled();
-      expect(activateVenvMock).toHaveBeenCalledWith('.');
+      expect(activateVenvMock).toHaveBeenCalledWith('.', context);
       expect(spawn.sync).toHaveBeenCalledTimes(1);
       expect(spawn.sync).toHaveBeenCalledWith(
         'poetry',
@@ -144,35 +147,37 @@ describe('Ruff Format Executor', () => {
         stdout: null,
       });
 
+      const context: ExecutorContext = {
+        cwd: '',
+        root: '.',
+        isVerbose: false,
+        projectName: 'app',
+        projectsConfigurations: {
+          version: 2,
+          projects: {
+            app: {
+              root: 'apps/app',
+              targets: {},
+            },
+          },
+        },
+        nxJsonConfiguration: {},
+        projectGraph: {
+          dependencies: {},
+          nodes: {},
+        },
+      };
+
       const output = await executor(
         {
           filePatterns: ['app'],
           check: true,
           __unparsed__: [],
         },
-        {
-          cwd: '',
-          root: '.',
-          isVerbose: false,
-          projectName: 'app',
-          projectsConfigurations: {
-            version: 2,
-            projects: {
-              app: {
-                root: 'apps/app',
-                targets: {},
-              },
-            },
-          },
-          nxJsonConfiguration: {},
-          projectGraph: {
-            dependencies: {},
-            nodes: {},
-          },
-        },
+        context,
       );
       expect(checkPoetryExecutableMock).toHaveBeenCalled();
-      expect(activateVenvMock).toHaveBeenCalledWith('.');
+      expect(activateVenvMock).toHaveBeenCalledWith('.', context);
       expect(spawn.sync).toHaveBeenCalledTimes(1);
       expect(spawn.sync).toHaveBeenCalledWith(
         'poetry',
@@ -196,35 +201,37 @@ describe('Ruff Format Executor', () => {
         stdout: null,
       });
 
+      const context: ExecutorContext = {
+        cwd: '',
+        root: '.',
+        isVerbose: false,
+        projectName: 'app',
+        projectsConfigurations: {
+          version: 2,
+          projects: {
+            app: {
+              root: 'apps/app',
+              targets: {},
+            },
+          },
+        },
+        nxJsonConfiguration: {},
+        projectGraph: {
+          dependencies: {},
+          nodes: {},
+        },
+      };
+
       const output = await executor(
         {
           filePatterns: ['app'],
           check: false,
           __unparsed__: [],
         },
-        {
-          cwd: '',
-          root: '.',
-          isVerbose: false,
-          projectName: 'app',
-          projectsConfigurations: {
-            version: 2,
-            projects: {
-              app: {
-                root: 'apps/app',
-                targets: {},
-              },
-            },
-          },
-          nxJsonConfiguration: {},
-          projectGraph: {
-            dependencies: {},
-            nodes: {},
-          },
-        },
+        context,
       );
       expect(checkPoetryExecutableMock).toHaveBeenCalled();
-      expect(activateVenvMock).toHaveBeenCalledWith('.');
+      expect(activateVenvMock).toHaveBeenCalledWith('.', context);
       expect(spawn.sync).toHaveBeenCalledTimes(1);
       expect(spawn.sync).toHaveBeenCalledWith(
         'poetry',
@@ -241,10 +248,15 @@ describe('Ruff Format Executor', () => {
 
   describe('uv', () => {
     let checkPrerequisites: MockInstance;
+    let activateVenvMock: MockInstance;
 
     beforeEach(() => {
       checkPrerequisites = vi
         .spyOn(UVProvider.prototype, 'checkPrerequisites')
+        .mockResolvedValue(undefined);
+
+      activateVenvMock = vi
+        .spyOn(UVProvider.prototype, 'activateVenv')
         .mockResolvedValue(undefined);
 
       vi.mocked(spawn.sync).mockReturnValue({
@@ -296,6 +308,7 @@ describe('Ruff Format Executor', () => {
 
       const output = await executor(options, context);
       expect(checkPrerequisites).toHaveBeenCalled();
+      expect(activateVenvMock).toHaveBeenCalledWith('.', context);
       expect(spawn.sync).not.toHaveBeenCalled();
       expect(output.success).toBe(false);
     });
@@ -310,34 +323,37 @@ describe('Ruff Format Executor', () => {
         stdout: null,
       });
 
+      const context: ExecutorContext = {
+        cwd: '',
+        root: '.',
+        isVerbose: false,
+        projectName: 'app',
+        projectsConfigurations: {
+          version: 2,
+          projects: {
+            app: {
+              root: 'apps/app',
+              targets: {},
+            },
+          },
+        },
+        nxJsonConfiguration: {},
+        projectGraph: {
+          dependencies: {},
+          nodes: {},
+        },
+      };
+
       const output = await executor(
         {
           filePatterns: ['app'],
           check: false,
           __unparsed__: [],
         },
-        {
-          cwd: '',
-          root: '.',
-          isVerbose: false,
-          projectName: 'app',
-          projectsConfigurations: {
-            version: 2,
-            projects: {
-              app: {
-                root: 'apps/app',
-                targets: {},
-              },
-            },
-          },
-          nxJsonConfiguration: {},
-          projectGraph: {
-            dependencies: {},
-            nodes: {},
-          },
-        },
+        context,
       );
       expect(checkPrerequisites).toHaveBeenCalled();
+      expect(activateVenvMock).toHaveBeenCalledWith('.', context);
       expect(spawn.sync).toHaveBeenCalledTimes(1);
       expect(spawn.sync).toHaveBeenCalledWith(
         'uv',
@@ -361,34 +377,37 @@ describe('Ruff Format Executor', () => {
         stdout: null,
       });
 
+      const context: ExecutorContext = {
+        cwd: '',
+        root: '.',
+        isVerbose: false,
+        projectName: 'app',
+        projectsConfigurations: {
+          version: 2,
+          projects: {
+            app: {
+              root: 'apps/app',
+              targets: {},
+            },
+          },
+        },
+        nxJsonConfiguration: {},
+        projectGraph: {
+          dependencies: {},
+          nodes: {},
+        },
+      };
+
       const output = await executor(
         {
           filePatterns: ['app'],
           check: true,
           __unparsed__: [],
         },
-        {
-          cwd: '',
-          root: '.',
-          isVerbose: false,
-          projectName: 'app',
-          projectsConfigurations: {
-            version: 2,
-            projects: {
-              app: {
-                root: 'apps/app',
-                targets: {},
-              },
-            },
-          },
-          nxJsonConfiguration: {},
-          projectGraph: {
-            dependencies: {},
-            nodes: {},
-          },
-        },
+        context,
       );
       expect(checkPrerequisites).toHaveBeenCalled();
+      expect(activateVenvMock).toHaveBeenCalledWith('.', context);
       expect(spawn.sync).toHaveBeenCalledTimes(1);
       expect(spawn.sync).toHaveBeenCalledWith(
         'uv',
@@ -412,34 +431,37 @@ describe('Ruff Format Executor', () => {
         stdout: null,
       });
 
+      const context: ExecutorContext = {
+        cwd: '',
+        root: '.',
+        isVerbose: false,
+        projectName: 'app',
+        projectsConfigurations: {
+          version: 2,
+          projects: {
+            app: {
+              root: 'apps/app',
+              targets: {},
+            },
+          },
+        },
+        nxJsonConfiguration: {},
+        projectGraph: {
+          dependencies: {},
+          nodes: {},
+        },
+      };
+
       const output = await executor(
         {
           filePatterns: ['app'],
           check: false,
           __unparsed__: [],
         },
-        {
-          cwd: '',
-          root: '.',
-          isVerbose: false,
-          projectName: 'app',
-          projectsConfigurations: {
-            version: 2,
-            projects: {
-              app: {
-                root: 'apps/app',
-                targets: {},
-              },
-            },
-          },
-          nxJsonConfiguration: {},
-          projectGraph: {
-            dependencies: {},
-            nodes: {},
-          },
-        },
+        context,
       );
       expect(checkPrerequisites).toHaveBeenCalled();
+      expect(activateVenvMock).toHaveBeenCalledWith('.', context);
       expect(spawn.sync).toHaveBeenCalledTimes(1);
       expect(spawn.sync).toHaveBeenCalledWith(
         'uv',

--- a/packages/nx-python/src/executors/ruff-format/executor.ts
+++ b/packages/nx-python/src/executors/ruff-format/executor.ts
@@ -34,12 +34,17 @@ export default async function executor(
       undefined,
       context,
     );
-    await provider.run(commandArgs, workspaceRoot, {
-      cwd: projectConfig.root,
-      log: false,
-      error: true,
-      shell: true,
-    });
+    await provider.run(
+      commandArgs,
+      workspaceRoot,
+      {
+        cwd: projectConfig.root,
+        log: false,
+        error: true,
+        shell: true,
+      },
+      context,
+    );
 
     return {
       success: true,

--- a/packages/nx-python/src/executors/run-commands/executor.ts
+++ b/packages/nx-python/src/executors/run-commands/executor.ts
@@ -14,6 +14,6 @@ export default async function executor(
     undefined,
     context,
   );
-  provider.activateVenv(context.root, context);
+  await provider.activateVenv(context.root, context);
   return baseExecutor(options, context);
 }

--- a/packages/nx-python/src/executors/sls-deploy/executor.spec.ts
+++ b/packages/nx-python/src/executors/sls-deploy/executor.spec.ts
@@ -7,6 +7,7 @@ import * as poetryUtils from '../../provider/poetry/utils';
 import executor from './executor';
 import spawn from 'cross-spawn';
 import { ExecutorContext } from '@nx/devkit';
+import { PoetryProvider } from '../../provider/poetry/provider';
 
 describe('Serverless Framework Deploy Executor', () => {
   let activateVenvMock: MockInstance;
@@ -44,8 +45,8 @@ describe('Serverless Framework Deploy Executor', () => {
   describe('poetry', () => {
     beforeEach(() => {
       activateVenvMock = vi
-        .spyOn(poetryUtils, 'activateVenv')
-        .mockReturnValue(undefined);
+        .spyOn(PoetryProvider.prototype, 'activateVenv')
+        .mockResolvedValue(undefined);
       vi.spyOn(process, 'chdir').mockReturnValue(undefined);
 
       vi.spyOn(poetryUtils, 'checkPoetryExecutable').mockReturnValue(undefined);
@@ -60,7 +61,7 @@ describe('Serverless Framework Deploy Executor', () => {
         },
         context,
       );
-      expect(activateVenvMock).toHaveBeenCalledWith('.');
+      expect(activateVenvMock).toHaveBeenCalledWith('.', context);
       expect(spawn.sync).not.toHaveBeenCalled();
       expect(output.success).toBe(false);
     });
@@ -78,7 +79,7 @@ describe('Serverless Framework Deploy Executor', () => {
         },
         context,
       );
-      expect(activateVenvMock).toHaveBeenCalledWith('.');
+      expect(activateVenvMock).toHaveBeenCalledWith('.', context);
       expect(spawn.sync).not.toHaveBeenCalled();
       expect(output.success).toBe(false);
     });
@@ -104,7 +105,7 @@ describe('Serverless Framework Deploy Executor', () => {
         },
         context,
       );
-      expect(activateVenvMock).toHaveBeenCalledWith('.');
+      expect(activateVenvMock).toHaveBeenCalledWith('.', context);
       expect(spawn.sync).toHaveBeenCalledWith(
         'npx',
         ['sls', 'deploy', '--stage', 'dev'],
@@ -138,7 +139,7 @@ describe('Serverless Framework Deploy Executor', () => {
         },
         context,
       );
-      expect(activateVenvMock).toHaveBeenCalledWith('.');
+      expect(activateVenvMock).toHaveBeenCalledWith('.', context);
       expect(spawn.sync).toHaveBeenCalledWith(
         'npx',
         ['sls', 'deploy', '--stage', 'dev'],
@@ -172,7 +173,7 @@ describe('Serverless Framework Deploy Executor', () => {
         },
         context,
       );
-      expect(activateVenvMock).toHaveBeenCalledWith('.');
+      expect(activateVenvMock).toHaveBeenCalledWith('.', context);
       expect(spawn.sync).toHaveBeenCalledWith(
         'npx',
         ['sls', 'deploy', '--stage', 'dev', '--verbose', '--force'],

--- a/packages/nx-python/src/executors/sls-deploy/executor.ts
+++ b/packages/nx-python/src/executors/sls-deploy/executor.ts
@@ -21,7 +21,7 @@ export default async function executor(
     undefined,
     context,
   );
-  provider.activateVenv(workspaceRoot);
+  await provider.activateVenv(workspaceRoot, context);
 
   const projectConfig =
     context.projectsConfigurations.projects[context.projectName];

--- a/packages/nx-python/src/executors/sls-package/executor.spec.ts
+++ b/packages/nx-python/src/executors/sls-package/executor.spec.ts
@@ -7,6 +7,7 @@ import * as poetryUtils from '../../provider/poetry/utils';
 import executor from './executor';
 import spawn from 'cross-spawn';
 import { ExecutorContext } from '@nx/devkit';
+import { PoetryProvider } from '../../provider/poetry/provider';
 
 describe('Serverless Framework Package Executor', () => {
   let activateVenvMock: MockInstance;
@@ -44,8 +45,8 @@ describe('Serverless Framework Package Executor', () => {
   describe('poetry', () => {
     beforeEach(() => {
       activateVenvMock = vi
-        .spyOn(poetryUtils, 'activateVenv')
-        .mockReturnValue(undefined);
+        .spyOn(PoetryProvider.prototype, 'activateVenv')
+        .mockResolvedValue(undefined);
       vi.spyOn(process, 'chdir').mockReturnValue(undefined);
 
       vi.spyOn(poetryUtils, 'checkPoetryExecutable').mockReturnValue(undefined);
@@ -58,7 +59,7 @@ describe('Serverless Framework Package Executor', () => {
         },
         context,
       );
-      expect(activateVenvMock).toHaveBeenCalledWith('.');
+      expect(activateVenvMock).toHaveBeenCalledWith('.', context);
       expect(spawn.sync).not.toHaveBeenCalled();
       expect(output.success).toBe(false);
     });
@@ -74,7 +75,7 @@ describe('Serverless Framework Package Executor', () => {
         },
         context,
       );
-      expect(activateVenvMock).toHaveBeenCalledWith('.');
+      expect(activateVenvMock).toHaveBeenCalledWith('.', context);
       expect(spawn.sync).not.toHaveBeenCalled();
       expect(output.success).toBe(false);
     });
@@ -98,7 +99,7 @@ describe('Serverless Framework Package Executor', () => {
         },
         context,
       );
-      expect(activateVenvMock).toHaveBeenCalledWith('.');
+      expect(activateVenvMock).toHaveBeenCalledWith('.', context);
       expect(spawn.sync).toHaveBeenCalledWith(
         'npx',
         ['sls', 'package', '--stage', 'dev'],
@@ -130,7 +131,7 @@ describe('Serverless Framework Package Executor', () => {
         },
         context,
       );
-      expect(activateVenvMock).toHaveBeenCalledWith('.');
+      expect(activateVenvMock).toHaveBeenCalledWith('.', context);
       expect(spawn.sync).toHaveBeenCalledWith(
         'npx',
         ['sls', 'package', '--stage', 'dev'],

--- a/packages/nx-python/src/executors/sls-package/executor.ts
+++ b/packages/nx-python/src/executors/sls-package/executor.ts
@@ -21,7 +21,7 @@ export default async function executor(
     undefined,
     context,
   );
-  provider.activateVenv(workspaceRoot);
+  await provider.activateVenv(workspaceRoot, context);
 
   const projectConfig =
     context.projectsConfigurations.projects[context.projectName];

--- a/packages/nx-python/src/executors/tox/executor.spec.ts
+++ b/packages/nx-python/src/executors/tox/executor.spec.ts
@@ -10,6 +10,7 @@ import chalk from 'chalk';
 import spawn from 'cross-spawn';
 import { ExecutorContext } from '@nx/devkit';
 import { UVProvider } from '../../provider/uv';
+import { PoetryProvider } from '../../provider/poetry/provider';
 
 const options: ToxExecutorSchema = {
   silent: false,
@@ -61,8 +62,8 @@ describe('Tox Executor', () => {
         .spyOn(poetryUtils, 'checkPoetryExecutable')
         .mockResolvedValue(undefined);
       activateVenvMock = vi
-        .spyOn(poetryUtils, 'activateVenv')
-        .mockReturnValue(undefined);
+        .spyOn(PoetryProvider.prototype, 'activateVenv')
+        .mockResolvedValue(undefined);
 
       vi.mocked(spawn.sync).mockReturnValue({
         status: 0,
@@ -120,7 +121,7 @@ describe('Tox Executor', () => {
 
       const output = await executor(options, context);
       expect(checkPoetryExecutableMock).toHaveBeenCalled();
-      expect(activateVenvMock).toHaveBeenCalledWith('.');
+      expect(activateVenvMock).toHaveBeenCalledWith('.', context);
       expect(buildExecutorMock).toBeCalledWith(
         {
           silent: options.silent,
@@ -163,7 +164,7 @@ describe('Tox Executor', () => {
       );
 
       expect(checkPoetryExecutableMock).toHaveBeenCalled();
-      expect(activateVenvMock).toHaveBeenCalledWith('.');
+      expect(activateVenvMock).toHaveBeenCalledWith('.', context);
       expect(buildExecutorMock).toBeCalledWith(
         {
           silent: options.silent,

--- a/packages/nx-python/src/executors/tox/executor.ts
+++ b/packages/nx-python/src/executors/tox/executor.ts
@@ -69,9 +69,14 @@ export default async function executor(
       options.args ? options.args.split(' ') : [],
     );
 
-    await provider.run(toxArgs, workspaceRoot, {
-      cwd: projectConfig.root,
-    });
+    await provider.run(
+      toxArgs,
+      workspaceRoot,
+      {
+        cwd: projectConfig.root,
+      },
+      context,
+    );
 
     return {
       success: true,

--- a/packages/nx-python/src/executors/update/executor.spec.ts
+++ b/packages/nx-python/src/executors/update/executor.spec.ts
@@ -10,6 +10,7 @@ import dedent from 'string-dedent';
 import spawn from 'cross-spawn';
 import { ExecutorContext } from '@nx/devkit';
 import { UVProvider } from '../../provider/uv';
+import { PoetryProvider } from '../../provider/poetry/provider';
 
 describe('Update Executor', () => {
   afterEach(() => {
@@ -31,8 +32,8 @@ describe('Update Executor', () => {
         .mockResolvedValue(undefined);
       vi.spyOn(poetryUtils, 'getPoetryVersion').mockResolvedValue('1.8.2');
       activateVenvMock = vi
-        .spyOn(poetryUtils, 'activateVenv')
-        .mockReturnValue(undefined);
+        .spyOn(PoetryProvider.prototype, 'activateVenv')
+        .mockResolvedValue(undefined);
       vi.mocked(spawn.sync).mockReturnValue({
         status: 0,
         output: [''],
@@ -77,7 +78,7 @@ describe('Update Executor', () => {
 
       const output = await executor(options, context);
       expect(checkPoetryExecutableMock).toHaveBeenCalled();
-      expect(activateVenvMock).toHaveBeenCalledWith('.');
+      expect(activateVenvMock).toHaveBeenCalledWith('.', context);
       expect(spawn.sync).not.toHaveBeenCalled();
       expect(output.success).toBe(false);
     });
@@ -125,7 +126,7 @@ describe('Update Executor', () => {
 
       const output = await executor(options, context);
       expect(checkPoetryExecutableMock).toHaveBeenCalled();
-      expect(activateVenvMock).toHaveBeenCalledWith('.');
+      expect(activateVenvMock).toHaveBeenCalledWith('.', context);
       expect(spawn.sync).toHaveBeenCalledWith('poetry', ['update', 'numpy'], {
         cwd: 'apps/app',
         shell: false,
@@ -177,7 +178,7 @@ describe('Update Executor', () => {
 
       const output = await executor(options, context);
       expect(checkPoetryExecutableMock).toHaveBeenCalled();
-      expect(activateVenvMock).toHaveBeenCalledWith('.');
+      expect(activateVenvMock).toHaveBeenCalledWith('.', context);
       expect(spawn.sync).not.toHaveBeenCalled();
       expect(output.success).toBe(false);
     });
@@ -229,7 +230,7 @@ describe('Update Executor', () => {
 
       const output = await executor(options, context);
       expect(checkPoetryExecutableMock).toHaveBeenCalled();
-      expect(activateVenvMock).toHaveBeenCalledWith('.');
+      expect(activateVenvMock).toHaveBeenCalledWith('.', context);
       expect(spawn.sync).toHaveBeenCalledWith('poetry', ['update', 'numpy'], {
         cwd: 'apps/app',
         shell: false,
@@ -331,7 +332,7 @@ describe('Update Executor', () => {
 
       const output = await executor(options, context);
       expect(checkPoetryExecutableMock).toHaveBeenCalled();
-      expect(activateVenvMock).toHaveBeenCalledWith('.');
+      expect(activateVenvMock).toHaveBeenCalledWith('.', context);
       expect(spawn.sync).toHaveBeenCalledTimes(7);
       expect(spawn.sync).toHaveBeenNthCalledWith(
         1,
@@ -500,7 +501,7 @@ describe('Update Executor', () => {
 
       const output = await executor(options, context);
       expect(checkPoetryExecutableMock).toHaveBeenCalled();
-      expect(activateVenvMock).toHaveBeenCalledWith('.');
+      expect(activateVenvMock).toHaveBeenCalledWith('.', context);
       expect(spawn.sync).toHaveBeenCalledTimes(7);
       expect(spawn.sync).toHaveBeenNthCalledWith(
         1,
@@ -618,7 +619,7 @@ describe('Update Executor', () => {
 
       const output = await executor(options, context);
       expect(checkPoetryExecutableMock).toHaveBeenCalled();
-      expect(activateVenvMock).toHaveBeenCalledWith('.');
+      expect(activateVenvMock).toHaveBeenCalledWith('.', context);
       expect(spawn.sync).toHaveBeenCalledTimes(2);
       expect(spawn.sync).toHaveBeenNthCalledWith(
         1,
@@ -701,7 +702,7 @@ describe('Update Executor', () => {
 
       const output = await executor(options, context);
       expect(checkPoetryExecutableMock).toHaveBeenCalled();
-      expect(activateVenvMock).toHaveBeenCalledWith('.');
+      expect(activateVenvMock).toHaveBeenCalledWith('.', context);
       expect(spawn.sync).toHaveBeenCalledTimes(2);
       expect(spawn.sync).toHaveBeenNthCalledWith(
         1,
@@ -781,7 +782,7 @@ describe('Update Executor', () => {
 
       const output = await executor(options, context);
       expect(checkPoetryExecutableMock).toHaveBeenCalled();
-      expect(activateVenvMock).toHaveBeenCalledWith('.');
+      expect(activateVenvMock).toHaveBeenCalledWith('.', context);
       expect(spawn.sync).toHaveBeenCalledWith(
         'poetry',
         ['update', 'numpy', '--group', 'dev'],
@@ -836,7 +837,7 @@ describe('Update Executor', () => {
 
       const output = await executor(options, context);
       expect(checkPoetryExecutableMock).toHaveBeenCalled();
-      expect(activateVenvMock).toHaveBeenCalledWith('.');
+      expect(activateVenvMock).toHaveBeenCalledWith('.', context);
       expect(spawn.sync).toHaveBeenCalledWith('poetry', ['update'], {
         cwd: 'apps/app',
         shell: false,
@@ -897,7 +898,7 @@ describe('Update Executor', () => {
 
       const output = await executor(options, context);
       expect(checkPoetryExecutableMock).toHaveBeenCalled();
-      expect(activateVenvMock).toHaveBeenCalledWith('.');
+      expect(activateVenvMock).toHaveBeenCalledWith('.', context);
       expect(spawn.sync).toHaveBeenNthCalledWith(
         1,
         'poetry',
@@ -1034,7 +1035,7 @@ describe('Update Executor', () => {
 
       const output = await executor(options, context);
       expect(checkPoetryExecutableMock).toHaveBeenCalled();
-      expect(activateVenvMock).toHaveBeenCalledWith('.');
+      expect(activateVenvMock).toHaveBeenCalledWith('.', context);
       expect(spawn.sync).toHaveBeenCalledTimes(6);
       expect(spawn.sync).toHaveBeenNthCalledWith(
         1,

--- a/packages/nx-python/src/generators/migrate-to-shared-venv/generator.ts
+++ b/packages/nx-python/src/generators/migrate-to-shared-venv/generator.ts
@@ -13,7 +13,7 @@ import chalk from 'chalk';
 import { PoetryPyprojectToml } from '../../provider/poetry';
 import { UVPyprojectToml } from '../../provider/uv/types';
 import { getProvider } from '../../provider';
-import { IProvider } from '../../provider/base';
+import { BaseProvider } from '../../provider/base';
 
 async function addFiles(host: Tree, options: Schema) {
   const packageJson = await readJsonFile('package.json');
@@ -55,7 +55,7 @@ type LockUpdateTask = () => Promise<void>;
 function updatePoetryPyprojectRoot(
   host: Tree,
   options: Schema,
-  provider: IProvider,
+  provider: BaseProvider,
 ): LockUpdateTask[] {
   const postGeneratorTasks = [];
 
@@ -103,7 +103,7 @@ function movePoetryDevDependencies(
   host: Tree,
   pyprojectTomlPath: string,
   projectConfig: ProjectConfiguration,
-  provider: IProvider,
+  provider: BaseProvider,
 ) {
   const devDependencies =
     pyprojectToml.tool.poetry.group?.dev?.dependencies || {};

--- a/packages/nx-python/src/generators/poetry-project/generator.ts
+++ b/packages/nx-python/src/generators/poetry-project/generator.ts
@@ -25,7 +25,7 @@ import {
   getPyprojectTomlByProjectName,
 } from '../utils';
 import { DEV_DEPENDENCIES_VERSION_MAP } from '../consts';
-import { IProvider } from '../../provider/base';
+import { BaseProvider } from '../../provider/base';
 import { sortPreservingSet } from '../../utils/toml';
 
 interface NormalizedSchema extends BaseNormalizedSchema {
@@ -195,7 +195,7 @@ function addTestDependencies(
   };
 }
 
-async function updateRootPoetryLock(tree: Tree, provider: IProvider) {
+async function updateRootPoetryLock(tree: Tree, provider: BaseProvider) {
   if (tree.exists('./pyproject.toml')) {
     console.log(chalk`  Updating root {bgBlue poetry.lock}...`);
     await provider.lock();

--- a/packages/nx-python/src/generators/release-version/utils/package.ts
+++ b/packages/nx-python/src/generators/release-version/utils/package.ts
@@ -1,5 +1,5 @@
 import { joinPathFragments } from '@nx/devkit';
-import { IProvider } from '../../../provider/base';
+import { BaseProvider } from '../../../provider/base';
 
 export class Package {
   name: string;
@@ -7,7 +7,7 @@ export class Package {
   location: string;
 
   constructor(
-    private readonly provider: IProvider,
+    private readonly provider: BaseProvider,
     workspaceRoot: string,
     private workspaceRelativeLocation: string,
   ) {

--- a/packages/nx-python/src/generators/release-version/utils/resolve-local-package-dependencies.ts
+++ b/packages/nx-python/src/generators/release-version/utils/resolve-local-package-dependencies.ts
@@ -6,7 +6,7 @@ import {
 } from '@nx/devkit';
 import { satisfies } from 'semver';
 import { Package } from './package';
-import { IProvider } from '../../../provider/base';
+import { BaseProvider } from '../../../provider/base';
 
 export interface LocalPackageDependency extends ProjectGraphDependency {
   /**
@@ -24,7 +24,7 @@ export function resolveLocalPackageDependencies(
   projectGraph: ProjectGraph,
   filteredProjects: ProjectGraphProjectNode[],
   projectNameToPackageRootMap: Map<string, string>,
-  provider: IProvider,
+  provider: BaseProvider,
   resolvePackageRoot: (projectNode: ProjectGraphProjectNode) => string,
   includeAll = false,
 ): Record<string, LocalPackageDependency[]> {

--- a/packages/nx-python/src/generators/utils.ts
+++ b/packages/nx-python/src/generators/utils.ts
@@ -17,7 +17,7 @@ import _ from 'lodash';
 import path from 'path';
 import { parse } from '@iarna/toml';
 import { DEV_DEPENDENCIES_VERSION_MAP } from './consts';
-import { IProvider } from '../provider/base';
+import { BaseProvider } from '../provider/base';
 
 export function getPyTestAddopts(
   options: PytestGeneratorSchema,
@@ -212,7 +212,7 @@ export function addFiles(
 
 export async function getDefaultPythonProjectTargets(
   options: BaseNormalizedSchema,
-  provider: IProvider,
+  provider: BaseProvider,
 ): Promise<ProjectConfiguration['targets']> {
   const targets: ProjectConfiguration['targets'] = {
     lock: {

--- a/packages/nx-python/src/generators/uv-project/generator.ts
+++ b/packages/nx-python/src/generators/uv-project/generator.ts
@@ -22,7 +22,7 @@ import {
   BasePythonProjectGeneratorSchema,
 } from '../types';
 import { UVProvider } from '../../provider/uv';
-import { IProvider } from '../../provider/base';
+import { BaseProvider } from '../../provider/base';
 import { sortPreservingInsert, sortPreservingSet } from '../../utils/toml';
 
 interface NormalizedSchema extends BaseNormalizedSchema {
@@ -228,7 +228,7 @@ function addTestDependencies(
   };
 }
 
-async function updateRootUvLock(tree: Tree, provider: IProvider) {
+async function updateRootUvLock(tree: Tree, provider: BaseProvider) {
   if (tree.exists('pyproject.toml')) {
     console.log(chalk`  Updating root {bgBlue uv.lock}...`);
     await provider.install();

--- a/packages/nx-python/src/provider/base.spec.ts
+++ b/packages/nx-python/src/provider/base.spec.ts
@@ -1,0 +1,72 @@
+import { BaseProvider } from './base';
+import { PoetryProvider } from './poetry';
+import { Logger } from '../executors/utils/logger';
+import chalk from 'chalk';
+import { ExecutorContext } from '@nx/devkit';
+import { MockInstance } from 'vitest';
+import path from 'path';
+
+describe('Activate Venv', () => {
+  const originalEnv = process.env;
+  let provider: BaseProvider;
+  let installMock: MockInstance;
+
+  beforeAll(() => {
+    console.log(chalk`init chalk`);
+  });
+
+  beforeEach(() => {
+    process.env = { ...originalEnv };
+    provider = new PoetryProvider('.', new Logger(), undefined);
+    installMock = vi.spyOn(provider, 'install').mockResolvedValue(undefined);
+  });
+
+  afterEach(() => {
+    vi.resetAllMocks();
+  });
+
+  it('should not activate venv when it is already activated', async () => {
+    process.env.VIRTUAL_ENV = 'venv';
+
+    await provider.activateVenv('.');
+
+    expect(process.env).toStrictEqual({
+      ...originalEnv,
+      VIRTUAL_ENV: 'venv',
+    });
+
+    expect(installMock).not.toHaveBeenCalled();
+  });
+
+  it('should install venv before activating it', async () => {
+    delete process.env.VIRTUAL_ENV;
+
+    const context: ExecutorContext = {
+      root: '.',
+      cwd: '.',
+      projectName: 'app',
+      isVerbose: false,
+      nxJsonConfiguration: {},
+      projectGraph: {
+        dependencies: {},
+        nodes: {},
+      },
+      projectsConfigurations: {
+        version: 1,
+        projects: {
+          app: {
+            root: 'apps/app',
+          },
+        },
+      },
+    };
+    await provider.activateVenv('.', context);
+
+    expect(process.env).toStrictEqual({
+      ...originalEnv,
+      VIRTUAL_ENV: path.resolve('apps/app/.venv'),
+      PATH: `${path.resolve('apps/app/.venv')}/bin:${originalEnv.PATH}`,
+    });
+    expect(installMock).toHaveBeenCalled();
+  });
+});

--- a/packages/nx-python/src/provider/poetry/utils.spec.ts
+++ b/packages/nx-python/src/provider/poetry/utils.spec.ts
@@ -11,9 +11,7 @@ vi.mock('command-exists', () => {
 });
 
 import * as poetryUtils from './utils';
-import dedent from 'string-dedent';
 import chalk from 'chalk';
-import path from 'path';
 import spawn from 'cross-spawn';
 import commandExists from 'command-exists';
 
@@ -253,76 +251,6 @@ describe('Poetry Utils', () => {
       });
 
       await expect(poetryUtils.getPoetryVersion()).rejects.toThrowError();
-    });
-  });
-
-  describe('Activate Venv', () => {
-    const originalEnv = process.env;
-
-    beforeEach(() => {
-      process.env = { ...originalEnv };
-    });
-
-    it('should not activate venv when it is already activated', () => {
-      process.env.VIRTUAL_ENV = 'venv';
-
-      poetryUtils.activateVenv('.');
-
-      expect(process.env).toStrictEqual({
-        ...originalEnv,
-        VIRTUAL_ENV: 'venv',
-      });
-    });
-
-    it('should not activate venv when the root pyproject.toml does not exists', () => {
-      delete process.env.VIRTUAL_ENV;
-
-      poetryUtils.activateVenv('.');
-
-      expect(process.env).toEqual(originalEnv);
-    });
-
-    it('should not activate venv when the root pyproject.toml exists and the autoActivate property is not defined', () => {
-      delete process.env.VIRTUAL_ENV;
-
-      vol.fromJSON({
-        'pyproject.toml': dedent`
-        [tool.poetry]
-        name = "app"
-        version = "1.0.0"
-          [tool.poetry.dependencies]
-          python = "^3.8"
-        `,
-      });
-
-      poetryUtils.activateVenv('.');
-
-      expect(process.env).toEqual(originalEnv);
-    });
-
-    it('should activate venv when the root pyproject.toml exists and the autoActivate property is defined', () => {
-      delete process.env.VIRTUAL_ENV;
-
-      vol.fromJSON({
-        'pyproject.toml': dedent`
-        [tool.nx]
-        autoActivate = true
-
-        [tool.poetry]
-        name = "app"
-        version = "1.0.0"
-          [tool.poetry.dependencies]
-          python = "^3.8"
-        `,
-      });
-
-      poetryUtils.activateVenv('.');
-
-      expect(process.env).toEqual({
-        ...originalEnv,
-        VIRTUAL_ENV: path.resolve('.venv'),
-        PATH: `${path.resolve('.venv')}/bin:${originalEnv.PATH}`,
-      });
     });
   });
 });

--- a/packages/nx-python/src/provider/poetry/utils.ts
+++ b/packages/nx-python/src/provider/poetry/utils.ts
@@ -2,7 +2,7 @@ import { ExecutorContext, ProjectConfiguration } from '@nx/devkit';
 import chalk from 'chalk';
 import spawn from 'cross-spawn';
 import path from 'path';
-import toml, { parse } from '@iarna/toml';
+import toml from '@iarna/toml';
 import fs from 'fs';
 import commandExists from 'command-exists';
 import {
@@ -150,28 +150,6 @@ export function runPoetry(
     throw new Error(
       chalk`{bold ${commandStr}} command failed with exit code {bold ${result.status}}`,
     );
-  }
-}
-
-export function activateVenv(workspaceRoot: string) {
-  if (!process.env.VIRTUAL_ENV) {
-    const rootPyproject = path.join(workspaceRoot, 'pyproject.toml');
-
-    if (fs.existsSync(rootPyproject)) {
-      const rootConfig = parse(
-        fs.readFileSync(rootPyproject, 'utf-8'),
-      ) as PoetryPyprojectToml;
-      const autoActivate = rootConfig.tool.nx?.autoActivate ?? false;
-      if (autoActivate) {
-        console.log(
-          chalk`\n{bold shared virtual environment detected and not activated, activating...}\n\n`,
-        );
-        const virtualEnv = path.resolve(workspaceRoot, '.venv');
-        process.env.VIRTUAL_ENV = virtualEnv;
-        process.env.PATH = `${virtualEnv}/bin:${process.env.PATH}`;
-        delete process.env.PYTHONHOME;
-      }
-    }
   }
 }
 

--- a/packages/nx-python/src/provider/resolver.ts
+++ b/packages/nx-python/src/provider/resolver.ts
@@ -1,6 +1,6 @@
 import fs from 'fs';
 import path from 'path';
-import { IProvider } from './base';
+import { BaseProvider } from './base';
 import { UVProvider } from './uv';
 import { PoetryProvider, PoetryPyprojectToml } from './poetry';
 import { Logger } from '../executors/utils/logger';
@@ -15,7 +15,7 @@ export const getProvider = async (
   tree?: Tree,
   context?: ExecutorContext,
   options?: PluginOptions,
-): Promise<IProvider> => {
+): Promise<BaseProvider> => {
   const loggerInstance = logger ?? new Logger();
 
   if (options?.packageManager) {


### PR DESCRIPTION
## Current Behavior

Currently, when using the `@nxlv/python:run-commands` with `python` commands (e.g. `python myproject/hello.py`) if the virtual environment is not created, the command might fail if it's using local packages or external packages that are not available.

## Expected Behavior

The  `@nxlv/python:run-commands` should identify if the virtual environment exists, and if not, run the install command before activating the virtual environment.

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #303 
