### PR TITLE
fix(nx-python): check if hatch package exists before include

### DIFF
--- a/packages/nx-python/src/provider/uv/build/resolvers/utils.ts
+++ b/packages/nx-python/src/provider/uv/build/resolvers/utils.ts
@@ -9,18 +9,22 @@ export function includeDependencyPackage(
   buildTomlData: UVPyprojectToml,
   workspaceRoot: string,
 ) {
+  buildTomlData.tool ??= {};
+  buildTomlData.tool.hatch ??= {};
+  buildTomlData.tool.hatch.build ??= {};
+  buildTomlData.tool.hatch.build.targets ??= {};
+  buildTomlData.tool.hatch.build.targets.wheel ??= {
+    packages: [],
+  };
+
+  const packages = buildTomlData.tool.hatch.build.targets.wheel.packages;
   for (const pkg of projectData.tool?.hatch?.build?.targets?.wheel?.packages ??
     []) {
     const pkgFolder = join(workspaceRoot, projectRoot, pkg);
     copySync(pkgFolder, join(buildFolderPath, pkg));
 
-    buildTomlData.tool ??= {};
-    buildTomlData.tool.hatch ??= {};
-    buildTomlData.tool.hatch.build ??= {};
-    buildTomlData.tool.hatch.build.targets ??= {};
-    buildTomlData.tool.hatch.build.targets.wheel ??= {
-      packages: [],
-    };
-    buildTomlData.tool.hatch.build.targets.wheel.packages.push(pkg);
+    if (!packages.includes(pkg)) {
+      packages.push(pkg);
+    }
   }
 }


### PR DESCRIPTION
### Current Behavior

When building a Python project with @nxlv/python using

```
"lockedVersions": false,
"bundleLocalDependencies": true
```

—and a local dependency that is both a direct requirement and a transitive requirement—nx run <proj>:build fails during uv build with:

```
ValueError: Duplicate path in field `tool.hatch.build.only-include`: <package>
```

## Expected Behavior

The `@nxlv/python` should only include the package once.

## Related Issue(s)

Fixes #305 
