### PR TITLE
fix(nx-python): check for existence of project lock files before processing

### DIFF
--- a/packages/nx-python/src/release/version-actions.ts
+++ b/packages/nx-python/src/release/version-actions.ts
@@ -16,7 +16,7 @@ import { PluginOptions } from '../types';
 import { BaseProvider } from '../provider/base';
 import path from 'node:path';
 import fs from 'node:fs/promises';
-import { existsSync } from 'node:fs';
+import { checkPathExists } from '../utils/path';
 
 let updatedProjects: string[] = [];
 
@@ -62,7 +62,8 @@ export const afterAllProjectsVersioned: AfterAllProjectsVersioned = async (
   const changedFiles: string[] = [];
   for (const project of updatedProjects) {
     const projectLockFile = path.join(project, provider.lockFileName);
-    if (existsSync(projectLockFile)) {
+
+    if (await checkPathExists(projectLockFile)) {
       changedFiles.push(projectLockFile);
 
       if (!opts.dryRun) {

--- a/packages/nx-python/src/release/version-actions.ts
+++ b/packages/nx-python/src/release/version-actions.ts
@@ -16,6 +16,7 @@ import { PluginOptions } from '../types';
 import { BaseProvider } from '../provider/base';
 import path from 'node:path';
 import fs from 'node:fs/promises';
+import { existsSync } from 'node:fs';
 
 let updatedProjects: string[] = [];
 
@@ -60,12 +61,15 @@ export const afterAllProjectsVersioned: AfterAllProjectsVersioned = async (
 
   const changedFiles: string[] = [];
   for (const project of updatedProjects) {
-    changedFiles.push(path.join(project, provider.lockFileName));
+    const projectLockFile = path.join(project, provider.lockFileName);
+    if (existsSync(projectLockFile)) {
+      changedFiles.push(projectLockFile);
 
-    if (!opts.dryRun) {
-      await provider.lock(project, false, lockArgs);
-    } else {
-      console.log(`Would run lock for ${project}`);
+      if (!opts.dryRun) {
+        await provider.lock(project, false, lockArgs);
+      } else {
+        console.log(`Would run lock for ${project}`);
+      }
     }
   }
 

--- a/packages/nx-python/src/utils/path.ts
+++ b/packages/nx-python/src/utils/path.ts
@@ -1,0 +1,10 @@
+import fs from 'node:fs/promises';
+
+export async function checkPathExists(path: string): Promise<boolean> {
+  try {
+    await fs.access(path);
+    return true; // Path exists and is accessible
+  } catch (error) {
+    return false; // Path does not exist or is not accessible
+  }
+}


### PR DESCRIPTION
## Current Behavior

When UV workspaces are used with `nx release`, the @nxlv/python plugins attempt to add project-level lock files to the git staging files, but UV workspaces only have one single lock file in the root of the repo, which makes the nx release to fail with the following error:

```
 NX   fatal: pathspec 'foo/uv.lock' did not match any files
```

## Expected Behavior

The @nxlv/python plugin should check if the lock exists before processing it.

## Related Issue(s)

Fixes #309 
