### PR TITLE
fix(nx-python): enhance error logging in publish executor to include error message

### DIFF
--- a/packages/nx-python/src/executors/publish/executor.ts
+++ b/packages/nx-python/src/executors/publish/executor.ts
@@ -28,7 +28,7 @@ export default async function executor(
     };
   } catch (error) {
     logger.info(
-      chalk`\n  {bgRed.bold  ERROR } {bold The publish command failed}\n`,
+      chalk`\n  {bgRed.bold  ERROR } {bold The publish command failed}:\n\n  {bold ${error.message}}\n`,
     );
 
     return {


### PR DESCRIPTION
## Current Behavior

Errors are not being logged when the publish executor fails.

```log
   ERROR  The publish command failed


———————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————

 NX   Ran target nx-release-publish for project lib1 (487ms)

      With additional flags:
        --dryRun=true

   ✖  1/1 failed
   ✔  0/1 succeeded [0 read from cache]
```

## Expected Behavior

The publish executor should log the error message in the console.

```log
 ERROR  The publish command failed:

  UV is not installed. Please install UV before running this command.


———————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————

 NX   Ran target nx-release-publish for project lib1 (448ms)

      With additional flags:
        --dryRun=true

   ✖  1/1 failed
   ✔  0/1 succeeded [0 read from cache]
```

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #311 
