### PR TITLE
fix(nx-python): update activate venv to make install optional (default false)

### DIFF
--- a/packages/nx-python/src/executors/add/executor.spec.ts
+++ b/packages/nx-python/src/executors/add/executor.spec.ts
@@ -78,7 +78,7 @@ describe('Add Executor', () => {
 
       const output = await executor(options, context);
       expect(checkPoetryExecutableMock).toHaveBeenCalled();
-      expect(activateVenvMock).toHaveBeenCalledWith('.', context);
+      expect(activateVenvMock).toHaveBeenCalledWith('.', false, context);
       expect(spawn.sync).not.toHaveBeenCalled();
       expect(output.success).toBe(false);
     });
@@ -129,7 +129,7 @@ describe('Add Executor', () => {
 
       const output = await executor(options, context);
       expect(checkPoetryExecutableMock).toHaveBeenCalled();
-      expect(activateVenvMock).toHaveBeenCalledWith('.', context);
+      expect(activateVenvMock).toHaveBeenCalledWith('.', false, context);
       expect(spawn.sync).toHaveBeenCalledWith('poetry', ['add', 'numpy'], {
         cwd: 'apps/app',
         shell: false,
@@ -185,7 +185,7 @@ describe('Add Executor', () => {
 
       const output = await executor(options, context);
       expect(checkPoetryExecutableMock).toHaveBeenCalled();
-      expect(activateVenvMock).toHaveBeenCalledWith('.', context);
+      expect(activateVenvMock).toHaveBeenCalledWith('.', false, context);
       expect(spawn.sync).toHaveBeenCalledWith(
         'poetry',
         ['add', 'numpy', '--group', 'dev'],
@@ -245,7 +245,7 @@ describe('Add Executor', () => {
 
       const output = await executor(options, context);
       expect(checkPoetryExecutableMock).toHaveBeenCalled();
-      expect(activateVenvMock).toHaveBeenCalledWith('.', context);
+      expect(activateVenvMock).toHaveBeenCalledWith('.', false, context);
       expect(spawn.sync).toHaveBeenCalledWith(
         'poetry',
         ['add', 'numpy', '--extras=dev'],
@@ -301,7 +301,7 @@ describe('Add Executor', () => {
 
       const output = await executor(options, context);
       expect(checkPoetryExecutableMock).toHaveBeenCalled();
-      expect(activateVenvMock).toHaveBeenCalledWith('.', context);
+      expect(activateVenvMock).toHaveBeenCalledWith('.', false, context);
       expect(spawn.sync).not.toHaveBeenCalled();
       expect(output.success).toBe(false);
     });
@@ -353,7 +353,7 @@ describe('Add Executor', () => {
 
       const output = await executor(options, context);
       expect(checkPoetryExecutableMock).toHaveBeenCalled();
-      expect(activateVenvMock).toHaveBeenCalledWith('.', context);
+      expect(activateVenvMock).toHaveBeenCalledWith('.', false, context);
       expect(spawn.sync).toHaveBeenCalledWith('poetry', ['add', 'numpy'], {
         cwd: 'apps/app',
         shell: false,
@@ -458,7 +458,7 @@ describe('Add Executor', () => {
 
       const output = await executor(options, context);
       expect(checkPoetryExecutableMock).toHaveBeenCalled();
-      expect(activateVenvMock).toHaveBeenCalledWith('.', context);
+      expect(activateVenvMock).toHaveBeenCalledWith('.', false, context);
       expect(spawn.sync).toHaveBeenCalledTimes(7);
       expect(spawn.sync).toHaveBeenNthCalledWith(
         1,
@@ -630,7 +630,7 @@ describe('Add Executor', () => {
 
       const output = await executor(options, context);
       expect(checkPoetryExecutableMock).toHaveBeenCalled();
-      expect(activateVenvMock).toHaveBeenCalledWith('.', context);
+      expect(activateVenvMock).toHaveBeenCalledWith('.', false, context);
       expect(spawn.sync).toHaveBeenCalledTimes(7);
       expect(spawn.sync).toHaveBeenNthCalledWith(
         1,
@@ -786,7 +786,7 @@ describe('Add Executor', () => {
 
       const output = await executor(options, context);
       expect(checkPoetryExecutableMock).toHaveBeenCalled();
-      expect(activateVenvMock).toHaveBeenCalledWith('.', context);
+      expect(activateVenvMock).toHaveBeenCalledWith('.', false, context);
       expect(spawn.sync).toHaveBeenCalledTimes(7);
       expect(spawn.sync).toHaveBeenNthCalledWith(
         1,
@@ -918,7 +918,7 @@ describe('Add Executor', () => {
 
       const output = await executor(options, context);
       expect(checkPoetryExecutableMock).toHaveBeenCalled();
-      expect(activateVenvMock).toHaveBeenCalledWith('.', context);
+      expect(activateVenvMock).toHaveBeenCalledWith('.', false, context);
       expect(spawn.sync).toHaveBeenCalledTimes(2);
       expect(spawn.sync).toHaveBeenNthCalledWith(
         1,
@@ -1002,7 +1002,7 @@ describe('Add Executor', () => {
 
       const output = await executor(options, context);
       expect(checkPoetryExecutableMock).toHaveBeenCalled();
-      expect(activateVenvMock).toHaveBeenCalledWith('.', context);
+      expect(activateVenvMock).toHaveBeenCalledWith('.', false, context);
       expect(spawn.sync).toHaveBeenCalledTimes(2);
       expect(spawn.sync).toHaveBeenNthCalledWith(
         1,
@@ -1086,7 +1086,7 @@ describe('Add Executor', () => {
 
       const output = await executor(options, context);
       expect(checkPoetryExecutableMock).toHaveBeenCalled();
-      expect(activateVenvMock).toHaveBeenCalledWith('.', context);
+      expect(activateVenvMock).toHaveBeenCalledWith('.', false, context);
       expect(spawn.sync).toHaveBeenCalledTimes(2);
       expect(spawn.sync).toHaveBeenNthCalledWith(
         1,
@@ -1171,7 +1171,7 @@ describe('Add Executor', () => {
 
       const output = await executor(options, context);
       expect(checkPoetryExecutableMock).toHaveBeenCalled();
-      expect(activateVenvMock).toHaveBeenCalledWith('.', context);
+      expect(activateVenvMock).toHaveBeenCalledWith('.', false, context);
       expect(spawn.sync).toHaveBeenCalledTimes(2);
       expect(spawn.sync).toHaveBeenNthCalledWith(
         1,
@@ -1255,7 +1255,7 @@ describe('Add Executor', () => {
       const output = await executor(options, context);
       expect(output.success).toBe(true);
       expect(checkPoetryExecutableMock).toHaveBeenCalled();
-      expect(activateVenvMock).toHaveBeenCalledWith('.', context);
+      expect(activateVenvMock).toHaveBeenCalledWith('.', false, context);
       expect(spawn.sync).toHaveBeenCalledTimes(2);
       expect(spawn.sync).toHaveBeenNthCalledWith(
         1,
@@ -1334,7 +1334,7 @@ describe('Add Executor', () => {
 
       const output = await executor(options, context);
       expect(checkPoetryExecutableMock).toHaveBeenCalled();
-      expect(activateVenvMock).toHaveBeenCalledWith('.', context);
+      expect(activateVenvMock).toHaveBeenCalledWith('.', false, context);
       expect(spawn.sync).toHaveBeenCalledWith(
         'poetry',
         ['add', 'numpy', '--group', 'dev'],
@@ -1399,7 +1399,7 @@ describe('Add Executor', () => {
 
       const output = await executor(options, context);
       expect(checkPoetryExecutableMock).toHaveBeenCalled();
-      expect(activateVenvMock).toHaveBeenCalledWith('.', context);
+      expect(activateVenvMock).toHaveBeenCalledWith('.', false, context);
       expect(spawn.sync).toHaveBeenNthCalledWith(
         1,
         'poetry',
@@ -1486,7 +1486,7 @@ describe('Add Executor', () => {
 
       const output = await executor(options, context);
       expect(checkPoetryExecutableMock).toHaveBeenCalled();
-      expect(activateVenvMock).toHaveBeenCalledWith('.', context);
+      expect(activateVenvMock).toHaveBeenCalledWith('.', false, context);
       expect(spawn.sync).toHaveBeenNthCalledWith(
         1,
         'poetry',

--- a/packages/nx-python/src/executors/add/schema.d.ts
+++ b/packages/nx-python/src/executors/add/schema.d.ts
@@ -1,4 +1,6 @@
-export interface AddExecutorSchema {
+import { BaseExecutorSchema } from '../base-schema';
+
+export interface AddExecutorSchema extends BaseExecutorSchema {
   name: string;
   local: boolean;
   args?: string;

--- a/packages/nx-python/src/executors/add/schema.json
+++ b/packages/nx-python/src/executors/add/schema.json
@@ -32,6 +32,11 @@
       "items": {
         "type": "string"
       }
+    },
+    "installDependenciesIfNotExists": {
+      "type": "boolean",
+      "description": "Run the package manager install command if the virtual environment is not activated (default: false)",
+      "default": false
     }
   },
   "required": ["name"]

--- a/packages/nx-python/src/executors/base-schema.ts
+++ b/packages/nx-python/src/executors/base-schema.ts
@@ -1,0 +1,3 @@
+export interface BaseExecutorSchema {
+  installDependenciesIfNotExists?: boolean;
+}

--- a/packages/nx-python/src/executors/build/executor.spec.ts
+++ b/packages/nx-python/src/executors/build/executor.spec.ts
@@ -101,7 +101,7 @@ describe('Build Executor', () => {
 
       const output = await executor(options, context);
       expect(checkPoetryExecutableMock).toHaveBeenCalled();
-      expect(activateVenvMock).toHaveBeenCalledWith('.', context);
+      expect(activateVenvMock).toHaveBeenCalledWith('.', false, context);
       expect(spawn.sync).not.toHaveBeenCalled();
       expect(output.success).toBe(false);
     });
@@ -142,7 +142,7 @@ describe('Build Executor', () => {
 
       const output = await executor(options, context);
       expect(checkPoetryExecutableMock).toHaveBeenCalled();
-      expect(activateVenvMock).toHaveBeenCalledWith('.', context);
+      expect(activateVenvMock).toHaveBeenCalledWith('.', false, context);
       expect(spawn.sync).not.toHaveBeenCalled();
       expect(output.success).toBe(false);
     });
@@ -245,7 +245,7 @@ describe('Build Executor', () => {
         const output = await executor(options, context);
 
         expect(checkPoetryExecutableMock).toHaveBeenCalled();
-        expect(activateVenvMock).toHaveBeenCalledWith('.', context);
+        expect(activateVenvMock).toHaveBeenCalledWith('.', false, context);
         expect(existsSync(buildPath)).toBeTruthy();
         expect(existsSync(`${buildPath}/app`)).toBeTruthy();
         expect(existsSync(`${buildPath}/dist/app.fake`)).toBeTruthy();
@@ -466,7 +466,7 @@ describe('Build Executor', () => {
         const output = await executor(options, context);
 
         expect(checkPoetryExecutableMock).toHaveBeenCalled();
-        expect(activateVenvMock).toHaveBeenCalledWith('.', context);
+        expect(activateVenvMock).toHaveBeenCalledWith('.', false, context);
         expect(existsSync(buildPath)).toBeTruthy();
         expect(existsSync(`${buildPath}/app`)).toBeTruthy();
         expect(existsSync(`${buildPath}/dep1`)).toBeTruthy();
@@ -658,7 +658,7 @@ describe('Build Executor', () => {
         const output = await executor(options, context);
 
         expect(checkPoetryExecutableMock).toHaveBeenCalled();
-        expect(activateVenvMock).toHaveBeenCalledWith('.', context);
+        expect(activateVenvMock).toHaveBeenCalledWith('.', false, context);
         expect(existsSync(buildPath)).toBeTruthy();
         expect(existsSync(`${buildPath}/app`)).toBeTruthy();
         expect(existsSync(`${buildPath}/dep1`)).toBeTruthy();
@@ -852,7 +852,7 @@ describe('Build Executor', () => {
         const output = await executor(options, context);
 
         expect(checkPoetryExecutableMock).toHaveBeenCalled();
-        expect(activateVenvMock).toHaveBeenCalledWith('.', context);
+        expect(activateVenvMock).toHaveBeenCalledWith('.', false, context);
         expect(existsSync(buildPath)).toBeTruthy();
         expect(existsSync(`${buildPath}/app`)).toBeTruthy();
         expect(existsSync(`${buildPath}/dep1`)).toBeTruthy();
@@ -1134,7 +1134,7 @@ describe('Build Executor', () => {
         const output = await executor(options, context);
 
         expect(checkPoetryExecutableMock).toHaveBeenCalled();
-        expect(activateVenvMock).toHaveBeenCalledWith('.', context);
+        expect(activateVenvMock).toHaveBeenCalledWith('.', false, context);
         expect(existsSync(buildPath)).toBeTruthy();
         expect(existsSync(`${buildPath}/app`)).toBeTruthy();
         expect(spawn.sync).toHaveBeenCalledWith('poetry', ['build'], {
@@ -1259,7 +1259,7 @@ describe('Build Executor', () => {
         const output = await executor(options, context);
 
         expect(checkPoetryExecutableMock).toHaveBeenCalled();
-        expect(activateVenvMock).toHaveBeenCalledWith('.', context);
+        expect(activateVenvMock).toHaveBeenCalledWith('.', false, context);
         expect(existsSync(buildPath)).toBeTruthy();
         expect(existsSync(`${buildPath}/app`)).toBeTruthy();
         expect(spawn.sync).toHaveBeenCalledWith('poetry', ['build'], {
@@ -1383,7 +1383,7 @@ describe('Build Executor', () => {
 
         expect(output.success).toBe(true);
         expect(checkPoetryExecutableMock).toHaveBeenCalled();
-        expect(activateVenvMock).toHaveBeenCalledWith('.', context);
+        expect(activateVenvMock).toHaveBeenCalledWith('.', false, context);
         expect(existsSync(buildPath)).toBeTruthy();
         expect(existsSync(`${buildPath}/app`)).toBeTruthy();
         expect(spawn.sync).toHaveBeenCalledWith('poetry', ['build'], {
@@ -1496,7 +1496,7 @@ describe('Build Executor', () => {
         const output = await executor(options, context);
 
         expect(checkPoetryExecutableMock).toHaveBeenCalled();
-        expect(activateVenvMock).toHaveBeenCalledWith('.', context);
+        expect(activateVenvMock).toHaveBeenCalledWith('.', false, context);
         expect(output.success).toBe(false);
       });
 
@@ -1651,7 +1651,7 @@ describe('Build Executor', () => {
         const output = await executor(options, context);
 
         expect(checkPoetryExecutableMock).toHaveBeenCalled();
-        expect(activateVenvMock).toHaveBeenCalledWith('.', context);
+        expect(activateVenvMock).toHaveBeenCalledWith('.', false, context);
         expect(existsSync(buildPath)).toBeTruthy();
         expect(existsSync(`${buildPath}/app`)).toBeTruthy();
         expect(existsSync(`${buildPath}/dep1`)).toBeTruthy();
@@ -1806,7 +1806,7 @@ describe('Build Executor', () => {
         const output = await executor(options, context);
 
         expect(checkPoetryExecutableMock).toHaveBeenCalled();
-        expect(activateVenvMock).toHaveBeenCalledWith('.', context);
+        expect(activateVenvMock).toHaveBeenCalledWith('.', false, context);
         expect(existsSync(buildPath)).toBeTruthy();
         expect(existsSync(`${buildPath}/app`)).toBeTruthy();
         expect(existsSync(`${buildPath}/dep1`)).toBeTruthy();
@@ -1980,7 +1980,7 @@ describe('Build Executor', () => {
         const output = await executor(options, context);
 
         expect(checkPoetryExecutableMock).toHaveBeenCalled();
-        expect(activateVenvMock).toHaveBeenCalledWith('.', context);
+        expect(activateVenvMock).toHaveBeenCalledWith('.', false, context);
         expect(output.success).toBe(true);
         expect(existsSync(buildPath)).toBeTruthy();
         expect(existsSync(`${buildPath}/app`)).toBeTruthy();
@@ -2138,7 +2138,7 @@ describe('Build Executor', () => {
         const output = await executor(options, context);
 
         expect(checkPoetryExecutableMock).toHaveBeenCalled();
-        expect(activateVenvMock).toHaveBeenCalledWith('.', context);
+        expect(activateVenvMock).toHaveBeenCalledWith('.', false, context);
         expect(existsSync(buildPath)).toBeTruthy();
         expect(existsSync(`${buildPath}/app`)).toBeTruthy();
         expect(existsSync(`${buildPath}/dist/app.fake`)).toBeTruthy();
@@ -2247,7 +2247,7 @@ describe('Build Executor', () => {
         const output = await executor(options, context);
 
         expect(checkPoetryExecutableMock).toHaveBeenCalled();
-        expect(activateVenvMock).toHaveBeenCalledWith('.', context);
+        expect(activateVenvMock).toHaveBeenCalledWith('.', false, context);
         expect(output.success).toBe(false);
       });
 
@@ -2330,7 +2330,7 @@ describe('Build Executor', () => {
         const output = await executor(options, context);
 
         expect(checkPoetryExecutableMock).toHaveBeenCalled();
-        expect(activateVenvMock).toHaveBeenCalledWith('.', context);
+        expect(activateVenvMock).toHaveBeenCalledWith('.', false, context);
         expect(existsSync(buildPath)).not.toBeTruthy();
         expect(spawn.sync).toHaveBeenCalledWith('poetry', ['build'], {
           cwd: buildPath,
@@ -2426,7 +2426,7 @@ describe('Build Executor', () => {
         const output = await executor(options, context);
 
         expect(checkPoetryExecutableMock).toHaveBeenCalled();
-        expect(activateVenvMock).toHaveBeenCalledWith('.', context);
+        expect(activateVenvMock).toHaveBeenCalledWith('.', false, context);
         expect(spawn.sync).toHaveBeenCalledWith(
           'poetry',
           ['build', '--format', 'wheel'],
@@ -2526,7 +2526,7 @@ describe('Build Executor', () => {
         const output = await executor(options, context);
 
         expect(checkPoetryExecutableMock).toHaveBeenCalled();
-        expect(activateVenvMock).toHaveBeenCalledWith('.', context);
+        expect(activateVenvMock).toHaveBeenCalledWith('.', false, context);
         expect(spawn.sync).toHaveBeenCalledWith(
           'poetry',
           ['build', '--format', 'sdist'],
@@ -2608,7 +2608,7 @@ describe('Build Executor', () => {
         const output = await executor(options, context);
 
         expect(checkPoetryExecutableMock).toHaveBeenCalled();
-        expect(activateVenvMock).toHaveBeenCalledWith('.', context);
+        expect(activateVenvMock).toHaveBeenCalledWith('.', false, context);
         expect(output.success).toBe(false);
       });
     });
@@ -2698,7 +2698,7 @@ describe('Build Executor', () => {
         const output = await executor(options, context);
 
         expect(checkPoetryExecutableMock).toHaveBeenCalled();
-        expect(activateVenvMock).toHaveBeenCalledWith('.', context);
+        expect(activateVenvMock).toHaveBeenCalledWith('.', false, context);
         expect(output.success).toBe(false);
         expect(existsSync(buildPath)).toBeTruthy();
       });
@@ -2790,7 +2790,7 @@ describe('Build Executor', () => {
         const output = await executor(options, context);
 
         expect(checkPoetryExecutableMock).toHaveBeenCalled();
-        expect(activateVenvMock).toHaveBeenCalledWith('.', context);
+        expect(activateVenvMock).toHaveBeenCalledWith('.', false, context);
         expect(output.success).toBe(true);
         expect(existsSync(buildPath)).toBeTruthy();
         expect(existsSync(`${buildPath}/app`)).toBeTruthy();
@@ -2916,7 +2916,7 @@ describe('Build Executor', () => {
         const output = await executor(options, context);
 
         expect(checkPoetryExecutableMock).toHaveBeenCalled();
-        expect(activateVenvMock).toHaveBeenCalledWith('.', context);
+        expect(activateVenvMock).toHaveBeenCalledWith('.', false, context);
         expect(output.success).toBe(true);
         expect(existsSync(buildPath)).toBeTruthy();
         expect(existsSync(`${buildPath}/app`)).toBeTruthy();
@@ -3071,7 +3071,7 @@ describe('Build Executor', () => {
         const output = await executor(options, context);
 
         expect(checkPoetryExecutableMock).toHaveBeenCalled();
-        expect(activateVenvMock).toHaveBeenCalledWith('.', context);
+        expect(activateVenvMock).toHaveBeenCalledWith('.', false, context);
         expect(output.success).toBe(true);
         expect(existsSync(buildPath)).toBeTruthy();
         expect(existsSync(`${buildPath}/app`)).toBeTruthy();
@@ -3230,7 +3230,7 @@ describe('Build Executor', () => {
         const output = await executor(options, context);
 
         expect(checkPoetryExecutableMock).toHaveBeenCalled();
-        expect(activateVenvMock).toHaveBeenCalledWith('.', context);
+        expect(activateVenvMock).toHaveBeenCalledWith('.', false, context);
         expect(output.success).toBe(true);
         expect(existsSync(buildPath)).toBeTruthy();
         expect(existsSync(`${buildPath}/app`)).toBeTruthy();
@@ -3489,7 +3489,7 @@ describe('Build Executor', () => {
         const output = await executor(options, context);
 
         expect(checkPoetryExecutableMock).toHaveBeenCalled();
-        expect(activateVenvMock).toHaveBeenCalledWith('.', context);
+        expect(activateVenvMock).toHaveBeenCalledWith('.', false, context);
         expect(output.success).toBe(true);
         expect(existsSync(buildPath)).toBeTruthy();
         expect(existsSync(`${buildPath}/app`)).toBeTruthy();

--- a/packages/nx-python/src/executors/build/schema.d.ts
+++ b/packages/nx-python/src/executors/build/schema.d.ts
@@ -1,4 +1,6 @@
-export interface BuildExecutorSchema {
+import { BaseExecutorSchema } from '../base-schema';
+
+export interface BuildExecutorSchema extends BaseExecutorSchema {
   silent: boolean;
   ignorePaths: string[];
   outputPath: string;

--- a/packages/nx-python/src/executors/build/schema.json
+++ b/packages/nx-python/src/executors/build/schema.json
@@ -54,6 +54,11 @@
       "type": "string",
       "description": "Format for the build",
       "enum": ["sdist", "wheel"]
+    },
+    "installDependenciesIfNotExists": {
+      "type": "boolean",
+      "description": "Run the package manager install command if the virtual environment is not activated (default: false)",
+      "default": false
     }
   },
   "required": ["outputPath"]

--- a/packages/nx-python/src/executors/flake8/executor.spec.ts
+++ b/packages/nx-python/src/executors/flake8/executor.spec.ts
@@ -85,7 +85,7 @@ describe('Flake8 Executor', () => {
 
       const output = await executor(options, context);
       expect(checkPoetryExecutableMock).toHaveBeenCalled();
-      expect(activateVenvMock).toHaveBeenCalledWith('.', context);
+      expect(activateVenvMock).toHaveBeenCalledWith('.', false, context);
       expect(spawn.sync).not.toHaveBeenCalled();
       expect(output.success).toBe(false);
     });
@@ -133,7 +133,7 @@ describe('Flake8 Executor', () => {
         context,
       );
       expect(checkPoetryExecutableMock).toHaveBeenCalled();
-      expect(activateVenvMock).toHaveBeenCalledWith('.', context);
+      expect(activateVenvMock).toHaveBeenCalledWith('.', false, context);
       expect(spawn.sync).toHaveBeenCalledTimes(1);
       expect(output.success).toBe(true);
     });
@@ -183,7 +183,7 @@ describe('Flake8 Executor', () => {
         context,
       );
       expect(checkPoetryExecutableMock).toHaveBeenCalled();
-      expect(activateVenvMock).toHaveBeenCalledWith('.', context);
+      expect(activateVenvMock).toHaveBeenCalledWith('.', false, context);
       expect(spawn.sync).toHaveBeenCalledTimes(1);
       expect(output.success).toBe(true);
     });
@@ -222,7 +222,7 @@ describe('Flake8 Executor', () => {
         context,
       );
       expect(checkPoetryExecutableMock).toHaveBeenCalled();
-      expect(activateVenvMock).toHaveBeenCalledWith('.', context);
+      expect(activateVenvMock).toHaveBeenCalledWith('.', false, context);
       expect(spawn.sync).toHaveBeenCalledTimes(1);
       expect(output.success).toBe(false);
     });
@@ -271,7 +271,7 @@ describe('Flake8 Executor', () => {
         context,
       );
       expect(checkPoetryExecutableMock).toHaveBeenCalled();
-      expect(activateVenvMock).toHaveBeenCalledWith('.', context);
+      expect(activateVenvMock).toHaveBeenCalledWith('.', false, context);
       expect(spawn.sync).toHaveBeenCalledTimes(1);
       expect(output.success).toBe(false);
     });
@@ -340,7 +340,7 @@ describe('Flake8 Executor', () => {
 
       const output = await executor(options, context);
       expect(checkPrerequisites).toHaveBeenCalled();
-      expect(activateVenvMock).toHaveBeenCalledWith('.', context);
+      expect(activateVenvMock).toHaveBeenCalledWith('.', false, context);
       expect(spawn.sync).not.toHaveBeenCalled();
       expect(output.success).toBe(false);
     });
@@ -388,7 +388,7 @@ describe('Flake8 Executor', () => {
         context,
       );
       expect(checkPrerequisites).toHaveBeenCalled();
-      expect(activateVenvMock).toHaveBeenCalledWith('.', context);
+      expect(activateVenvMock).toHaveBeenCalledWith('.', false, context);
       expect(spawn.sync).toHaveBeenCalledTimes(1);
       expect(spawn.sync).toHaveBeenCalledWith(
         'uv',
@@ -448,7 +448,7 @@ describe('Flake8 Executor', () => {
         context,
       );
       expect(checkPrerequisites).toHaveBeenCalled();
-      expect(activateVenvMock).toHaveBeenCalledWith('.', context);
+      expect(activateVenvMock).toHaveBeenCalledWith('.', false, context);
       expect(spawn.sync).toHaveBeenCalledTimes(1);
       expect(spawn.sync).toHaveBeenCalledWith(
         'uv',
@@ -497,7 +497,7 @@ describe('Flake8 Executor', () => {
         context,
       );
       expect(checkPrerequisites).toHaveBeenCalled();
-      expect(activateVenvMock).toHaveBeenCalledWith('.', context);
+      expect(activateVenvMock).toHaveBeenCalledWith('.', false, context);
       expect(spawn.sync).toHaveBeenCalledTimes(1);
       expect(spawn.sync).toHaveBeenCalledWith(
         'uv',

--- a/packages/nx-python/src/executors/flake8/executor.ts
+++ b/packages/nx-python/src/executors/flake8/executor.ts
@@ -49,6 +49,7 @@ export default async function executor(
         log: false,
         error: false,
       },
+      options.installDependenciesIfNotExists,
       context,
     );
 

--- a/packages/nx-python/src/executors/flake8/schema.d.ts
+++ b/packages/nx-python/src/executors/flake8/schema.d.ts
@@ -1,4 +1,6 @@
-export interface Flake8ExecutorSchema {
+import { BaseExecutorSchema } from '../base-schema';
+
+export interface Flake8ExecutorSchema extends BaseExecutorSchema {
   outputFile: string;
   silent: boolean;
 }

--- a/packages/nx-python/src/executors/flake8/schema.json
+++ b/packages/nx-python/src/executors/flake8/schema.json
@@ -12,6 +12,11 @@
       "type": "boolean",
       "description": "Hide output text.",
       "default": false
+    },
+    "installDependenciesIfNotExists": {
+      "type": "boolean",
+      "description": "Run the package manager install command if the virtual environment is not activated (default: false)",
+      "default": false
     }
   },
   "required": ["outputFile"]

--- a/packages/nx-python/src/executors/publish/executor.spec.ts
+++ b/packages/nx-python/src/executors/publish/executor.spec.ts
@@ -122,7 +122,7 @@ describe('Publish Executor', () => {
 
       const output = await executor(options, context);
       expect(checkPoetryExecutableMock).toHaveBeenCalled();
-      expect(activateVenvMock).toHaveBeenCalledWith('.', context);
+      expect(activateVenvMock).toHaveBeenCalledWith('.', false, context);
       expect(childProcessMocks.spawn).not.toHaveBeenCalled();
       expect(output.success).toBe(false);
     });
@@ -138,7 +138,7 @@ describe('Publish Executor', () => {
 
       const output = await executor(options, context);
       expect(checkPoetryExecutableMock).toHaveBeenCalled();
-      expect(activateVenvMock).toHaveBeenCalledWith('.', context);
+      expect(activateVenvMock).toHaveBeenCalledWith('.', false, context);
       expect(childProcessMocks.spawn).not.toHaveBeenCalled();
       expect(output.success).toBe(false);
     });
@@ -155,7 +155,7 @@ describe('Publish Executor', () => {
 
       const output = await executor(options, context);
       expect(checkPoetryExecutableMock).toHaveBeenCalled();
-      expect(activateVenvMock).toHaveBeenCalledWith('.', context);
+      expect(activateVenvMock).toHaveBeenCalledWith('.', false, context);
       expect(childProcessMocks.spawn).not.toHaveBeenCalled();
       expect(output.success).toBe(false);
     });
@@ -184,7 +184,7 @@ describe('Publish Executor', () => {
 
       const output = await executor(options, context);
       expect(checkPoetryExecutableMock).toHaveBeenCalled();
-      expect(activateVenvMock).toHaveBeenCalledWith('.', context);
+      expect(activateVenvMock).toHaveBeenCalledWith('.', false, context);
       expect(childProcessMocks.spawn).toHaveBeenCalledWith('poetry publish', {
         cwd: 'tmp',
         env: { ...process.env, FORCE_COLOR: 'true' },
@@ -231,7 +231,7 @@ describe('Publish Executor', () => {
 
       const output = await executor(options, context);
       expect(checkPoetryExecutableMock).toHaveBeenCalled();
-      expect(activateVenvMock).toHaveBeenCalledWith('.', context);
+      expect(activateVenvMock).toHaveBeenCalledWith('.', false, context);
       expect(childProcessMocks.spawn).toHaveBeenCalledWith(
         'poetry publish --repository aws',
         {
@@ -281,7 +281,7 @@ describe('Publish Executor', () => {
 
       const output = await executor(options, context);
       expect(checkPoetryExecutableMock).toHaveBeenCalled();
-      expect(activateVenvMock).toHaveBeenCalledWith('.', context);
+      expect(activateVenvMock).toHaveBeenCalledWith('.', false, context);
       expect(childProcessMocks.spawn).toHaveBeenCalledWith(
         'poetry publish -vvv --dry-run',
         {
@@ -336,7 +336,7 @@ describe('Publish Executor', () => {
 
       const output = await executor(options, context);
       expect(checkPoetryExecutableMock).toHaveBeenCalled();
-      expect(activateVenvMock).toHaveBeenCalledWith('.', context);
+      expect(activateVenvMock).toHaveBeenCalledWith('.', false, context);
       expect(childProcessMocks.spawn).toHaveBeenCalledWith('poetry publish', {
         cwd: 'tmp',
         env: { ...process.env, FORCE_COLOR: 'true' },
@@ -388,7 +388,7 @@ describe('Publish Executor', () => {
 
       const output = await executor(options, context);
       expect(checkPoetryExecutableMock).toHaveBeenCalled();
-      expect(activateVenvMock).toHaveBeenCalledWith('.', context);
+      expect(activateVenvMock).toHaveBeenCalledWith('.', false, context);
       expect(childProcessMocks.spawn).toHaveBeenCalledWith('poetry publish', {
         cwd: 'tmp',
         env: { ...process.env, FORCE_COLOR: 'true' },

--- a/packages/nx-python/src/executors/publish/schema.d.ts
+++ b/packages/nx-python/src/executors/publish/schema.d.ts
@@ -1,4 +1,6 @@
-export interface PublishExecutorSchema {
+import { BaseExecutorSchema } from '../base-schema';
+
+export interface PublishExecutorSchema extends BaseExecutorSchema {
   silent: boolean;
   buildTarget: string;
   dryRun: boolean;

--- a/packages/nx-python/src/executors/publish/schema.json
+++ b/packages/nx-python/src/executors/publish/schema.json
@@ -23,6 +23,11 @@
       "type": "string",
       "description": "The repository to publish to."
     },
+    "installDependenciesIfNotExists": {
+      "type": "boolean",
+      "description": "Run the package manager install command if the virtual environment is not activated (default: false)",
+      "default": false
+    },
     "__unparsed__": {
       "hidden": true,
       "type": "array",

--- a/packages/nx-python/src/executors/remove/executor.spec.ts
+++ b/packages/nx-python/src/executors/remove/executor.spec.ts
@@ -80,7 +80,7 @@ describe('Delete Executor', () => {
 
       const output = await executor(options, context);
       expect(checkPoetryExecutableMock).toHaveBeenCalled();
-      expect(activateVenvMock).toHaveBeenCalledWith('.', context);
+      expect(activateVenvMock).toHaveBeenCalledWith('.', false, context);
       expect(spawn.sync).not.toHaveBeenCalled();
       expect(output.success).toBe(false);
     });
@@ -181,7 +181,7 @@ describe('Delete Executor', () => {
 
       const output = await executor(options, context);
       expect(checkPoetryExecutableMock).toHaveBeenCalled();
-      expect(activateVenvMock).toHaveBeenCalledWith('.', context);
+      expect(activateVenvMock).toHaveBeenCalledWith('.', false, context);
       expect(spawn.sync).toHaveBeenCalledTimes(5);
       expect(spawn.sync).toHaveBeenNthCalledWith(
         1,
@@ -333,7 +333,7 @@ describe('Delete Executor', () => {
 
       const output = await executor(options, context);
       expect(checkPoetryExecutableMock).toHaveBeenCalled();
-      expect(activateVenvMock).toHaveBeenCalledWith('.', context);
+      expect(activateVenvMock).toHaveBeenCalledWith('.', false, context);
       expect(spawn.sync).toHaveBeenCalledTimes(5);
       expect(spawn.sync).toHaveBeenNthCalledWith(
         1,
@@ -470,7 +470,7 @@ describe('Delete Executor', () => {
 
       const output = await executor(options, context);
       expect(checkPoetryExecutableMock).toHaveBeenCalled();
-      expect(activateVenvMock).toHaveBeenCalledWith('.', context);
+      expect(activateVenvMock).toHaveBeenCalledWith('.', false, context);
       expect(spawn.sync).toHaveBeenCalledTimes(7);
       expect(spawn.sync).toHaveBeenNthCalledWith(
         1,
@@ -588,7 +588,7 @@ describe('Delete Executor', () => {
 
       const output = await executor(options, context);
       expect(checkPoetryExecutableMock).toHaveBeenCalled();
-      expect(activateVenvMock).toHaveBeenCalledWith('.', context);
+      expect(activateVenvMock).toHaveBeenCalledWith('.', false, context);
       expect(spawn.sync).toHaveBeenCalledTimes(1);
       expect(spawn.sync).toHaveBeenNthCalledWith(
         1,
@@ -649,7 +649,7 @@ describe('Delete Executor', () => {
 
       const output = await executor(options, context);
       expect(checkPoetryExecutableMock).toHaveBeenCalled();
-      expect(activateVenvMock).toHaveBeenCalledWith('.', context);
+      expect(activateVenvMock).toHaveBeenCalledWith('.', false, context);
       expect(spawn.sync).toHaveBeenCalledTimes(1);
       expect(spawn.sync).toHaveBeenNthCalledWith(
         1,
@@ -716,7 +716,7 @@ describe('Delete Executor', () => {
 
       const output = await executor(options, context);
       expect(checkPoetryExecutableMock).toHaveBeenCalled();
-      expect(activateVenvMock).toHaveBeenCalledWith('.', context);
+      expect(activateVenvMock).toHaveBeenCalledWith('.', false, context);
       expect(spawn.sync).toHaveBeenNthCalledWith(
         1,
         'poetry',
@@ -802,7 +802,7 @@ describe('Delete Executor', () => {
 
       const output = await executor(options, context);
       expect(checkPoetryExecutableMock).toHaveBeenCalled();
-      expect(activateVenvMock).toHaveBeenCalledWith('.', context);
+      expect(activateVenvMock).toHaveBeenCalledWith('.', false, context);
       expect(spawn.sync).toHaveBeenNthCalledWith(
         1,
         'poetry',

--- a/packages/nx-python/src/executors/remove/schema.d.ts
+++ b/packages/nx-python/src/executors/remove/schema.d.ts
@@ -1,4 +1,6 @@
-export interface RemoveExecutorSchema {
+import { BaseExecutorSchema } from '../base-schema';
+
+export interface RemoveExecutorSchema extends BaseExecutorSchema {
   name: string;
   local: boolean;
   args?: string;

--- a/packages/nx-python/src/executors/remove/schema.json
+++ b/packages/nx-python/src/executors/remove/schema.json
@@ -17,6 +17,11 @@
       "type": "boolean",
       "description": "Local dependency",
       "default": false
+    },
+    "installDependenciesIfNotExists": {
+      "type": "boolean",
+      "description": "Run the package manager install command if the virtual environment is not activated (default: false)",
+      "default": false
     }
   },
   "required": ["name"]

--- a/packages/nx-python/src/executors/ruff-check/executor.spec.ts
+++ b/packages/nx-python/src/executors/ruff-check/executor.spec.ts
@@ -77,7 +77,7 @@ describe('Ruff Check Executor', () => {
 
       const output = await executor(options, context);
       expect(checkPoetryExecutableMock).toHaveBeenCalled();
-      expect(activateVenvMock).toHaveBeenCalledWith('.', context);
+      expect(activateVenvMock).toHaveBeenCalledWith('.', false, context);
       expect(spawn.sync).not.toHaveBeenCalled();
       expect(output.success).toBe(false);
     });
@@ -121,7 +121,7 @@ describe('Ruff Check Executor', () => {
         context,
       );
       expect(checkPoetryExecutableMock).toHaveBeenCalled();
-      expect(activateVenvMock).toHaveBeenCalledWith('.', context);
+      expect(activateVenvMock).toHaveBeenCalledWith('.', false, context);
       expect(spawn.sync).toHaveBeenCalledTimes(1);
       expect(spawn.sync).toHaveBeenCalledWith(
         'poetry',
@@ -174,7 +174,7 @@ describe('Ruff Check Executor', () => {
         context,
       );
       expect(checkPoetryExecutableMock).toHaveBeenCalled();
-      expect(activateVenvMock).toHaveBeenCalledWith('.', context);
+      expect(activateVenvMock).toHaveBeenCalledWith('.', false, context);
       expect(spawn.sync).toHaveBeenCalledTimes(1);
       expect(spawn.sync).toHaveBeenCalledWith(
         'poetry',
@@ -250,7 +250,7 @@ describe('Ruff Check Executor', () => {
 
       const output = await executor(options, context);
       expect(checkPrerequisites).toHaveBeenCalled();
-      expect(activateVenvMock).toHaveBeenCalledWith('.', context);
+      expect(activateVenvMock).toHaveBeenCalledWith('.', false, context);
       expect(spawn.sync).not.toHaveBeenCalled();
       expect(output.success).toBe(false);
     });
@@ -294,7 +294,7 @@ describe('Ruff Check Executor', () => {
         context,
       );
       expect(checkPrerequisites).toHaveBeenCalled();
-      expect(activateVenvMock).toHaveBeenCalledWith('.', context);
+      expect(activateVenvMock).toHaveBeenCalledWith('.', false, context);
       expect(spawn.sync).toHaveBeenCalledTimes(1);
       expect(spawn.sync).toHaveBeenCalledWith(
         'uv',
@@ -348,7 +348,7 @@ describe('Ruff Check Executor', () => {
         context,
       );
       expect(checkPrerequisites).toHaveBeenCalled();
-      expect(activateVenvMock).toHaveBeenCalledWith('.', context);
+      expect(activateVenvMock).toHaveBeenCalledWith('.', false, context);
       expect(spawn.sync).toHaveBeenCalledTimes(1);
       expect(spawn.sync).toHaveBeenCalledWith(
         'uv',
@@ -402,7 +402,7 @@ describe('Ruff Check Executor', () => {
         context,
       );
       expect(checkPrerequisites).toHaveBeenCalled();
-      expect(activateVenvMock).toHaveBeenCalledWith('.', context);
+      expect(activateVenvMock).toHaveBeenCalledWith('.', false, context);
       expect(spawn.sync).toHaveBeenCalledTimes(1);
       expect(spawn.sync).toHaveBeenCalledWith(
         'uv',

--- a/packages/nx-python/src/executors/ruff-check/executor.ts
+++ b/packages/nx-python/src/executors/ruff-check/executor.ts
@@ -58,6 +58,7 @@ export default async function executor(
         error: true,
         shell: true,
       },
+      options.installDependenciesIfNotExists,
       context,
     );
 

--- a/packages/nx-python/src/executors/ruff-check/schema.d.ts
+++ b/packages/nx-python/src/executors/ruff-check/schema.d.ts
@@ -1,4 +1,6 @@
-export interface RuffCheckExecutorSchema {
+import { BaseExecutorSchema } from '../base-schema';
+
+export interface RuffCheckExecutorSchema extends BaseExecutorSchema {
   lintFilePatterns: string[];
   fix?: boolean;
   __unparsed__: string[];

--- a/packages/nx-python/src/executors/ruff-check/schema.json
+++ b/packages/nx-python/src/executors/ruff-check/schema.json
@@ -17,6 +17,11 @@
       "default": false,
       "x-priority": "important"
     },
+    "installDependenciesIfNotExists": {
+      "type": "boolean",
+      "description": "Run the package manager install command if the virtual environment is not activated (default: false)",
+      "default": false
+    },
     "__unparsed__": {
       "hidden": true,
       "type": "array",

--- a/packages/nx-python/src/executors/ruff-format/executor.spec.ts
+++ b/packages/nx-python/src/executors/ruff-format/executor.spec.ts
@@ -78,7 +78,7 @@ describe('Ruff Format Executor', () => {
 
       const output = await executor(options, context);
       expect(checkPoetryExecutableMock).toHaveBeenCalled();
-      expect(activateVenvMock).toHaveBeenCalledWith('.', context);
+      expect(activateVenvMock).toHaveBeenCalledWith('.', false, context);
       expect(spawn.sync).not.toHaveBeenCalled();
       expect(output.success).toBe(false);
     });
@@ -123,7 +123,7 @@ describe('Ruff Format Executor', () => {
         context,
       );
       expect(checkPoetryExecutableMock).toHaveBeenCalled();
-      expect(activateVenvMock).toHaveBeenCalledWith('.', context);
+      expect(activateVenvMock).toHaveBeenCalledWith('.', false, context);
       expect(spawn.sync).toHaveBeenCalledTimes(1);
       expect(spawn.sync).toHaveBeenCalledWith(
         'poetry',
@@ -177,7 +177,7 @@ describe('Ruff Format Executor', () => {
         context,
       );
       expect(checkPoetryExecutableMock).toHaveBeenCalled();
-      expect(activateVenvMock).toHaveBeenCalledWith('.', context);
+      expect(activateVenvMock).toHaveBeenCalledWith('.', false, context);
       expect(spawn.sync).toHaveBeenCalledTimes(1);
       expect(spawn.sync).toHaveBeenCalledWith(
         'poetry',
@@ -231,7 +231,7 @@ describe('Ruff Format Executor', () => {
         context,
       );
       expect(checkPoetryExecutableMock).toHaveBeenCalled();
-      expect(activateVenvMock).toHaveBeenCalledWith('.', context);
+      expect(activateVenvMock).toHaveBeenCalledWith('.', false, context);
       expect(spawn.sync).toHaveBeenCalledTimes(1);
       expect(spawn.sync).toHaveBeenCalledWith(
         'poetry',
@@ -308,7 +308,7 @@ describe('Ruff Format Executor', () => {
 
       const output = await executor(options, context);
       expect(checkPrerequisites).toHaveBeenCalled();
-      expect(activateVenvMock).toHaveBeenCalledWith('.', context);
+      expect(activateVenvMock).toHaveBeenCalledWith('.', false, context);
       expect(spawn.sync).not.toHaveBeenCalled();
       expect(output.success).toBe(false);
     });
@@ -353,7 +353,7 @@ describe('Ruff Format Executor', () => {
         context,
       );
       expect(checkPrerequisites).toHaveBeenCalled();
-      expect(activateVenvMock).toHaveBeenCalledWith('.', context);
+      expect(activateVenvMock).toHaveBeenCalledWith('.', false, context);
       expect(spawn.sync).toHaveBeenCalledTimes(1);
       expect(spawn.sync).toHaveBeenCalledWith(
         'uv',
@@ -407,7 +407,7 @@ describe('Ruff Format Executor', () => {
         context,
       );
       expect(checkPrerequisites).toHaveBeenCalled();
-      expect(activateVenvMock).toHaveBeenCalledWith('.', context);
+      expect(activateVenvMock).toHaveBeenCalledWith('.', false, context);
       expect(spawn.sync).toHaveBeenCalledTimes(1);
       expect(spawn.sync).toHaveBeenCalledWith(
         'uv',
@@ -461,7 +461,7 @@ describe('Ruff Format Executor', () => {
         context,
       );
       expect(checkPrerequisites).toHaveBeenCalled();
-      expect(activateVenvMock).toHaveBeenCalledWith('.', context);
+      expect(activateVenvMock).toHaveBeenCalledWith('.', false, context);
       expect(spawn.sync).toHaveBeenCalledTimes(1);
       expect(spawn.sync).toHaveBeenCalledWith(
         'uv',

--- a/packages/nx-python/src/executors/ruff-format/executor.ts
+++ b/packages/nx-python/src/executors/ruff-format/executor.ts
@@ -43,6 +43,7 @@ export default async function executor(
         error: true,
         shell: true,
       },
+      options.installDependenciesIfNotExists,
       context,
     );
 

--- a/packages/nx-python/src/executors/ruff-format/schema.d.ts
+++ b/packages/nx-python/src/executors/ruff-format/schema.d.ts
@@ -1,4 +1,6 @@
-export interface RuffFormatExecutorSchema {
+import { BaseExecutorSchema } from '../base-schema';
+
+export interface RuffFormatExecutorSchema extends BaseExecutorSchema {
   filePatterns: string[];
   check: boolean;
   __unparsed__: string[];

--- a/packages/nx-python/src/executors/ruff-format/schema.json
+++ b/packages/nx-python/src/executors/ruff-format/schema.json
@@ -16,6 +16,11 @@
       "description": "Only check if the files are formatted correctly, don't format them",
       "default": false
     },
+    "installDependenciesIfNotExists": {
+      "type": "boolean",
+      "description": "Run the package manager install command if the virtual environment is not activated (default: false)",
+      "default": false
+    },
     "__unparsed__": {
       "hidden": true,
       "type": "array",

--- a/packages/nx-python/src/executors/run-commands/executor.spec.ts
+++ b/packages/nx-python/src/executors/run-commands/executor.spec.ts
@@ -56,7 +56,11 @@ describe('run commands executor', () => {
       };
       await executor(options, context);
 
-      expect(activateVenvMock).toHaveBeenCalledWith(context.root, context);
+      expect(activateVenvMock).toHaveBeenCalledWith(
+        context.root,
+        false,
+        context,
+      );
       expect(
         (await import('nx/src/executors/run-commands/run-commands.impl'))
           .default,
@@ -86,7 +90,11 @@ describe('run commands executor', () => {
         };
         await executor(options, context);
 
-        expect(activateVenvMock).toHaveBeenCalledWith(context.root, context);
+        expect(activateVenvMock).toHaveBeenCalledWith(
+          context.root,
+          false,
+          context,
+        );
         expect(
           (await import('nx/src/executors/run-commands/run-commands.impl'))
             .default,

--- a/packages/nx-python/src/executors/run-commands/executor.ts
+++ b/packages/nx-python/src/executors/run-commands/executor.ts
@@ -3,9 +3,14 @@ import baseExecutor, {
   RunCommandsOptions,
 } from 'nx/src/executors/run-commands/run-commands.impl';
 import { getProvider } from '../../provider';
+import { BaseExecutorSchema } from '../base-schema';
+
+export interface RunCommandsExecutorSchema
+  extends RunCommandsOptions,
+    BaseExecutorSchema {}
 
 export default async function executor(
-  options: RunCommandsOptions,
+  options: RunCommandsExecutorSchema,
   context: ExecutorContext,
 ) {
   const provider = await getProvider(
@@ -14,6 +19,10 @@ export default async function executor(
     undefined,
     context,
   );
-  await provider.activateVenv(context.root, context);
+  await provider.activateVenv(
+    context.root,
+    options.installDependenciesIfNotExists ?? false,
+    context,
+  );
   return baseExecutor(options, context);
 }

--- a/packages/nx-python/src/executors/run-commands/schema.json
+++ b/packages/nx-python/src/executors/run-commands/schema.json
@@ -115,6 +115,11 @@
       "type": "string",
       "description": "Current working directory of the commands. If it's not specified the commands will run in the workspace root, if a relative path is specified the commands will run in that path relative to the workspace root and if it's an absolute path the commands will run in that path."
     },
+    "installDependenciesIfNotExists": {
+      "type": "boolean",
+      "description": "Run the package manager install command if the virtual environment is not activated (default: false)",
+      "default": false
+    },
     "__unparsed__": {
       "hidden": true,
       "type": "array",

--- a/packages/nx-python/src/executors/sls-deploy/executor.spec.ts
+++ b/packages/nx-python/src/executors/sls-deploy/executor.spec.ts
@@ -61,7 +61,7 @@ describe('Serverless Framework Deploy Executor', () => {
         },
         context,
       );
-      expect(activateVenvMock).toHaveBeenCalledWith('.', context);
+      expect(activateVenvMock).toHaveBeenCalledWith('.', false, context);
       expect(spawn.sync).not.toHaveBeenCalled();
       expect(output.success).toBe(false);
     });
@@ -79,7 +79,7 @@ describe('Serverless Framework Deploy Executor', () => {
         },
         context,
       );
-      expect(activateVenvMock).toHaveBeenCalledWith('.', context);
+      expect(activateVenvMock).toHaveBeenCalledWith('.', false, context);
       expect(spawn.sync).not.toHaveBeenCalled();
       expect(output.success).toBe(false);
     });
@@ -105,7 +105,7 @@ describe('Serverless Framework Deploy Executor', () => {
         },
         context,
       );
-      expect(activateVenvMock).toHaveBeenCalledWith('.', context);
+      expect(activateVenvMock).toHaveBeenCalledWith('.', false, context);
       expect(spawn.sync).toHaveBeenCalledWith(
         'npx',
         ['sls', 'deploy', '--stage', 'dev'],
@@ -139,7 +139,7 @@ describe('Serverless Framework Deploy Executor', () => {
         },
         context,
       );
-      expect(activateVenvMock).toHaveBeenCalledWith('.', context);
+      expect(activateVenvMock).toHaveBeenCalledWith('.', false, context);
       expect(spawn.sync).toHaveBeenCalledWith(
         'npx',
         ['sls', 'deploy', '--stage', 'dev'],
@@ -173,7 +173,7 @@ describe('Serverless Framework Deploy Executor', () => {
         },
         context,
       );
-      expect(activateVenvMock).toHaveBeenCalledWith('.', context);
+      expect(activateVenvMock).toHaveBeenCalledWith('.', false, context);
       expect(spawn.sync).toHaveBeenCalledWith(
         'npx',
         ['sls', 'deploy', '--stage', 'dev', '--verbose', '--force'],

--- a/packages/nx-python/src/executors/sls-deploy/executor.ts
+++ b/packages/nx-python/src/executors/sls-deploy/executor.ts
@@ -21,7 +21,11 @@ export default async function executor(
     undefined,
     context,
   );
-  await provider.activateVenv(workspaceRoot, context);
+  await provider.activateVenv(
+    workspaceRoot,
+    options.installDependenciesIfNotExists ?? false,
+    context,
+  );
 
   const projectConfig =
     context.projectsConfigurations.projects[context.projectName];

--- a/packages/nx-python/src/executors/sls-deploy/schema.d.ts
+++ b/packages/nx-python/src/executors/sls-deploy/schema.d.ts
@@ -1,4 +1,6 @@
-export interface ExecutorSchema {
+import { BaseExecutorSchema } from '../base-schema';
+
+export interface ExecutorSchema extends BaseExecutorSchema {
   stage: string;
   verbose: boolean;
   force: boolean;

--- a/packages/nx-python/src/executors/sls-deploy/schema.json
+++ b/packages/nx-python/src/executors/sls-deploy/schema.json
@@ -17,6 +17,11 @@
       "type": "boolean",
       "description": "Force flag.",
       "default": false
+    },
+    "installDependenciesIfNotExists": {
+      "type": "boolean",
+      "description": "Run the package manager install command if the virtual environment is not activated (default: false)",
+      "default": false
     }
   },
   "required": ["stage"]

--- a/packages/nx-python/src/executors/sls-package/executor.spec.ts
+++ b/packages/nx-python/src/executors/sls-package/executor.spec.ts
@@ -59,7 +59,7 @@ describe('Serverless Framework Package Executor', () => {
         },
         context,
       );
-      expect(activateVenvMock).toHaveBeenCalledWith('.', context);
+      expect(activateVenvMock).toHaveBeenCalledWith('.', false, context);
       expect(spawn.sync).not.toHaveBeenCalled();
       expect(output.success).toBe(false);
     });
@@ -75,7 +75,7 @@ describe('Serverless Framework Package Executor', () => {
         },
         context,
       );
-      expect(activateVenvMock).toHaveBeenCalledWith('.', context);
+      expect(activateVenvMock).toHaveBeenCalledWith('.', false, context);
       expect(spawn.sync).not.toHaveBeenCalled();
       expect(output.success).toBe(false);
     });
@@ -99,7 +99,7 @@ describe('Serverless Framework Package Executor', () => {
         },
         context,
       );
-      expect(activateVenvMock).toHaveBeenCalledWith('.', context);
+      expect(activateVenvMock).toHaveBeenCalledWith('.', false, context);
       expect(spawn.sync).toHaveBeenCalledWith(
         'npx',
         ['sls', 'package', '--stage', 'dev'],
@@ -131,7 +131,7 @@ describe('Serverless Framework Package Executor', () => {
         },
         context,
       );
-      expect(activateVenvMock).toHaveBeenCalledWith('.', context);
+      expect(activateVenvMock).toHaveBeenCalledWith('.', false, context);
       expect(spawn.sync).toHaveBeenCalledWith(
         'npx',
         ['sls', 'package', '--stage', 'dev'],

--- a/packages/nx-python/src/executors/sls-package/executor.ts
+++ b/packages/nx-python/src/executors/sls-package/executor.ts
@@ -21,7 +21,11 @@ export default async function executor(
     undefined,
     context,
   );
-  await provider.activateVenv(workspaceRoot, context);
+  await provider.activateVenv(
+    workspaceRoot,
+    options.installDependenciesIfNotExists ?? false,
+    context,
+  );
 
   const projectConfig =
     context.projectsConfigurations.projects[context.projectName];

--- a/packages/nx-python/src/executors/sls-package/schema.d.ts
+++ b/packages/nx-python/src/executors/sls-package/schema.d.ts
@@ -1,3 +1,5 @@
-export interface ExecutorSchema {
+import { BaseExecutorSchema } from '../base-schema';
+
+export interface ExecutorSchema extends BaseExecutorSchema {
   stage: string;
 }

--- a/packages/nx-python/src/executors/sls-package/schema.json
+++ b/packages/nx-python/src/executors/sls-package/schema.json
@@ -7,6 +7,11 @@
     "stage": {
       "type": "string",
       "description": "Stage Name"
+    },
+    "installDependenciesIfNotExists": {
+      "type": "boolean",
+      "description": "Run the package manager install command if the virtual environment is not activated (default: false)",
+      "default": false
     }
   },
   "required": ["stage"]

--- a/packages/nx-python/src/executors/tox/executor.spec.ts
+++ b/packages/nx-python/src/executors/tox/executor.spec.ts
@@ -121,7 +121,7 @@ describe('Tox Executor', () => {
 
       const output = await executor(options, context);
       expect(checkPoetryExecutableMock).toHaveBeenCalled();
-      expect(activateVenvMock).toHaveBeenCalledWith('.', context);
+      expect(activateVenvMock).toHaveBeenCalledWith('.', false, context);
       expect(buildExecutorMock).toBeCalledWith(
         {
           silent: options.silent,
@@ -164,7 +164,7 @@ describe('Tox Executor', () => {
       );
 
       expect(checkPoetryExecutableMock).toHaveBeenCalled();
-      expect(activateVenvMock).toHaveBeenCalledWith('.', context);
+      expect(activateVenvMock).toHaveBeenCalledWith('.', false, context);
       expect(buildExecutorMock).toBeCalledWith(
         {
           silent: options.silent,

--- a/packages/nx-python/src/executors/tox/executor.ts
+++ b/packages/nx-python/src/executors/tox/executor.ts
@@ -75,6 +75,7 @@ export default async function executor(
       {
         cwd: projectConfig.root,
       },
+      options.installDependenciesIfNotExists,
       context,
     );
 

--- a/packages/nx-python/src/executors/tox/schema.d.ts
+++ b/packages/nx-python/src/executors/tox/schema.d.ts
@@ -1,4 +1,6 @@
-export interface ToxExecutorSchema {
+import { BaseExecutorSchema } from '../base-schema';
+
+export interface ToxExecutorSchema extends BaseExecutorSchema {
   silent: boolean;
   args?: string;
 }

--- a/packages/nx-python/src/executors/tox/schema.json
+++ b/packages/nx-python/src/executors/tox/schema.json
@@ -12,6 +12,11 @@
     "args": {
       "type": "string",
       "description": "Tox custom args"
+    },
+    "installDependenciesIfNotExists": {
+      "type": "boolean",
+      "description": "Run the package manager install command if the virtual environment is not activated (default: false)",
+      "default": false
     }
   },
   "required": []

--- a/packages/nx-python/src/executors/update/executor.spec.ts
+++ b/packages/nx-python/src/executors/update/executor.spec.ts
@@ -78,7 +78,7 @@ describe('Update Executor', () => {
 
       const output = await executor(options, context);
       expect(checkPoetryExecutableMock).toHaveBeenCalled();
-      expect(activateVenvMock).toHaveBeenCalledWith('.', context);
+      expect(activateVenvMock).toHaveBeenCalledWith('.', false, context);
       expect(spawn.sync).not.toHaveBeenCalled();
       expect(output.success).toBe(false);
     });
@@ -126,7 +126,7 @@ describe('Update Executor', () => {
 
       const output = await executor(options, context);
       expect(checkPoetryExecutableMock).toHaveBeenCalled();
-      expect(activateVenvMock).toHaveBeenCalledWith('.', context);
+      expect(activateVenvMock).toHaveBeenCalledWith('.', false, context);
       expect(spawn.sync).toHaveBeenCalledWith('poetry', ['update', 'numpy'], {
         cwd: 'apps/app',
         shell: false,
@@ -178,7 +178,7 @@ describe('Update Executor', () => {
 
       const output = await executor(options, context);
       expect(checkPoetryExecutableMock).toHaveBeenCalled();
-      expect(activateVenvMock).toHaveBeenCalledWith('.', context);
+      expect(activateVenvMock).toHaveBeenCalledWith('.', false, context);
       expect(spawn.sync).not.toHaveBeenCalled();
       expect(output.success).toBe(false);
     });
@@ -230,7 +230,7 @@ describe('Update Executor', () => {
 
       const output = await executor(options, context);
       expect(checkPoetryExecutableMock).toHaveBeenCalled();
-      expect(activateVenvMock).toHaveBeenCalledWith('.', context);
+      expect(activateVenvMock).toHaveBeenCalledWith('.', false, context);
       expect(spawn.sync).toHaveBeenCalledWith('poetry', ['update', 'numpy'], {
         cwd: 'apps/app',
         shell: false,
@@ -332,7 +332,7 @@ describe('Update Executor', () => {
 
       const output = await executor(options, context);
       expect(checkPoetryExecutableMock).toHaveBeenCalled();
-      expect(activateVenvMock).toHaveBeenCalledWith('.', context);
+      expect(activateVenvMock).toHaveBeenCalledWith('.', false, context);
       expect(spawn.sync).toHaveBeenCalledTimes(7);
       expect(spawn.sync).toHaveBeenNthCalledWith(
         1,
@@ -501,7 +501,7 @@ describe('Update Executor', () => {
 
       const output = await executor(options, context);
       expect(checkPoetryExecutableMock).toHaveBeenCalled();
-      expect(activateVenvMock).toHaveBeenCalledWith('.', context);
+      expect(activateVenvMock).toHaveBeenCalledWith('.', false, context);
       expect(spawn.sync).toHaveBeenCalledTimes(7);
       expect(spawn.sync).toHaveBeenNthCalledWith(
         1,
@@ -619,7 +619,7 @@ describe('Update Executor', () => {
 
       const output = await executor(options, context);
       expect(checkPoetryExecutableMock).toHaveBeenCalled();
-      expect(activateVenvMock).toHaveBeenCalledWith('.', context);
+      expect(activateVenvMock).toHaveBeenCalledWith('.', false, context);
       expect(spawn.sync).toHaveBeenCalledTimes(2);
       expect(spawn.sync).toHaveBeenNthCalledWith(
         1,
@@ -702,7 +702,7 @@ describe('Update Executor', () => {
 
       const output = await executor(options, context);
       expect(checkPoetryExecutableMock).toHaveBeenCalled();
-      expect(activateVenvMock).toHaveBeenCalledWith('.', context);
+      expect(activateVenvMock).toHaveBeenCalledWith('.', false, context);
       expect(spawn.sync).toHaveBeenCalledTimes(2);
       expect(spawn.sync).toHaveBeenNthCalledWith(
         1,
@@ -782,7 +782,7 @@ describe('Update Executor', () => {
 
       const output = await executor(options, context);
       expect(checkPoetryExecutableMock).toHaveBeenCalled();
-      expect(activateVenvMock).toHaveBeenCalledWith('.', context);
+      expect(activateVenvMock).toHaveBeenCalledWith('.', false, context);
       expect(spawn.sync).toHaveBeenCalledWith(
         'poetry',
         ['update', 'numpy', '--group', 'dev'],
@@ -837,7 +837,7 @@ describe('Update Executor', () => {
 
       const output = await executor(options, context);
       expect(checkPoetryExecutableMock).toHaveBeenCalled();
-      expect(activateVenvMock).toHaveBeenCalledWith('.', context);
+      expect(activateVenvMock).toHaveBeenCalledWith('.', false, context);
       expect(spawn.sync).toHaveBeenCalledWith('poetry', ['update'], {
         cwd: 'apps/app',
         shell: false,
@@ -898,7 +898,7 @@ describe('Update Executor', () => {
 
       const output = await executor(options, context);
       expect(checkPoetryExecutableMock).toHaveBeenCalled();
-      expect(activateVenvMock).toHaveBeenCalledWith('.', context);
+      expect(activateVenvMock).toHaveBeenCalledWith('.', false, context);
       expect(spawn.sync).toHaveBeenNthCalledWith(
         1,
         'poetry',
@@ -1035,7 +1035,7 @@ describe('Update Executor', () => {
 
       const output = await executor(options, context);
       expect(checkPoetryExecutableMock).toHaveBeenCalled();
-      expect(activateVenvMock).toHaveBeenCalledWith('.', context);
+      expect(activateVenvMock).toHaveBeenCalledWith('.', false, context);
       expect(spawn.sync).toHaveBeenCalledTimes(6);
       expect(spawn.sync).toHaveBeenNthCalledWith(
         1,

--- a/packages/nx-python/src/executors/update/schema.d.ts
+++ b/packages/nx-python/src/executors/update/schema.d.ts
@@ -1,4 +1,6 @@
-export interface UpdateExecutorSchema {
+import { BaseExecutorSchema } from '../base-schema';
+
+export interface UpdateExecutorSchema extends BaseExecutorSchema {
   name?: string;
   local: boolean;
   args?: string;

--- a/packages/nx-python/src/executors/update/schema.json
+++ b/packages/nx-python/src/executors/update/schema.json
@@ -16,6 +16,11 @@
       "type": "boolean",
       "description": "Local dependency",
       "default": false
+    },
+    "installDependenciesIfNotExists": {
+      "type": "boolean",
+      "description": "Run the package manager install command if the virtual environment is not activated (default: false)",
+      "default": false
     }
   },
   "required": []

--- a/packages/nx-python/src/provider/base.spec.ts
+++ b/packages/nx-python/src/provider/base.spec.ts
@@ -60,7 +60,7 @@ describe('Activate Venv', () => {
         },
       },
     };
-    await provider.activateVenv('.', context);
+    await provider.activateVenv('.', true, context);
 
     expect(process.env).toStrictEqual({
       ...originalEnv,
@@ -68,5 +68,35 @@ describe('Activate Venv', () => {
       PATH: `${path.resolve('apps/app/.venv')}/bin:${originalEnv.PATH}`,
     });
     expect(installMock).toHaveBeenCalled();
+  });
+
+  it('should not install venv before activating it', async () => {
+    delete process.env.VIRTUAL_ENV;
+
+    const context: ExecutorContext = {
+      root: '.',
+      cwd: '.',
+      projectName: 'app',
+      isVerbose: false,
+      nxJsonConfiguration: {},
+      projectGraph: {
+        dependencies: {},
+        nodes: {},
+      },
+      projectsConfigurations: {
+        version: 1,
+        projects: {
+          app: {
+            root: 'apps/app',
+          },
+        },
+      },
+    };
+    await provider.activateVenv('.', false, context);
+
+    expect(process.env).toStrictEqual({
+      ...originalEnv,
+    });
+    expect(installMock).not.toHaveBeenCalled();
   });
 });

--- a/packages/nx-python/src/provider/poetry/provider.ts
+++ b/packages/nx-python/src/provider/poetry/provider.ts
@@ -225,7 +225,11 @@ export class PoetryProvider extends BaseProvider {
     options: AddExecutorSchema,
     context: ExecutorContext,
   ): Promise<void> {
-    await this.activateVenv(context.root, context);
+    await this.activateVenv(
+      context.root,
+      options.installDependenciesIfNotExists ?? false,
+      context,
+    );
     await checkPoetryExecutable();
     const projectConfig =
       context.projectsConfigurations.projects[context.projectName];
@@ -269,7 +273,11 @@ export class PoetryProvider extends BaseProvider {
     options: UpdateExecutorSchema,
     context: ExecutorContext,
   ): Promise<void> {
-    await this.activateVenv(context.root, context);
+    await this.activateVenv(
+      context.root,
+      options.installDependenciesIfNotExists ?? false,
+      context,
+    );
     await checkPoetryExecutable();
     const projectConfig =
       context.projectsConfigurations.projects[context.projectName];
@@ -318,7 +326,11 @@ export class PoetryProvider extends BaseProvider {
     options: RemoveExecutorSchema,
     context: ExecutorContext,
   ): Promise<void> {
-    await this.activateVenv(context.root, context);
+    await this.activateVenv(
+      context.root,
+      options.installDependenciesIfNotExists ?? false,
+      context,
+    );
     await checkPoetryExecutable();
     const rootPyprojectToml = fs.existsSync('pyproject.toml');
     const projectConfig =
@@ -363,7 +375,11 @@ export class PoetryProvider extends BaseProvider {
     let buildFolderPath = '';
 
     try {
-      await this.activateVenv(context.root, context);
+      await this.activateVenv(
+        context.root,
+        options.installDependenciesIfNotExists ?? false,
+        context,
+      );
       await checkPoetryExecutable();
 
       for await (const output of await runExecutor<BuildExecutorOutput>(
@@ -635,7 +651,11 @@ export class PoetryProvider extends BaseProvider {
     options: BuildExecutorSchema,
     context: ExecutorContext,
   ): Promise<string> {
-    await this.activateVenv(context.root, context);
+    await this.activateVenv(
+      context.root,
+      options.installDependenciesIfNotExists ?? false,
+      context,
+    );
     await checkPoetryExecutable();
     if (
       options.lockedVersions === true &&
@@ -771,9 +791,14 @@ export class PoetryProvider extends BaseProvider {
       log?: boolean;
       error?: boolean;
     } & SpawnSyncOptions,
+    installIfNotExists?: boolean,
     context?: ExecutorContext,
   ): Promise<void> {
-    await this.activateVenv(workspaceRoot, context);
+    await this.activateVenv(
+      workspaceRoot,
+      installIfNotExists ?? false,
+      context,
+    );
     await checkPoetryExecutable();
 
     runPoetry(['run', ...args], options);

--- a/packages/nx-python/src/provider/uv/provider.ts
+++ b/packages/nx-python/src/provider/uv/provider.ts
@@ -672,9 +672,14 @@ export class UVProvider extends BaseProvider {
       log?: boolean;
       error?: boolean;
     } & SpawnSyncOptions,
+    installIfNotExists?: boolean,
     context?: ExecutorContext,
   ): Promise<void> {
-    await this.activateVenv(workspaceRoot, context);
+    await this.activateVenv(
+      workspaceRoot,
+      installIfNotExists ?? false,
+      context,
+    );
     await this.checkPrerequisites();
 
     runUv(['run', ...args], {


### PR DESCRIPTION
## Current Behavior

The `activateVenv` function currently forces virtual environment activation and dependency installation in ways that can conflict with Poetry's own environment management. As reported in [#318](https://github.com/lucasvieirasilva/nx-plugins/issues/318), this causes issues where:

- Poetry environments are not respected
- The plugin forces VIRTUAL_ENV to be set before doing any run-like command
- The plugin overrules Poetry's way of installing dependencies
- Virtual environments are forced into workspace- or project root when VIRTUAL_ENV is not set
- Poetry's existing virtual environments get recreated unnecessarily

## Expected Behavior

The `activateVenv` function now has an optional `installDependenciesIfNotExists` parameter that defaults to `false`. This change:

- Makes dependency installation optional rather than forced, respecting Poetry's environment management
- Allows users to control when dependencies are installed rather than having the plugin automatically override Poetry's behavior
- Maintains backward compatibility by defaulting to the safer behavior (not installing)
- Introduces a new `BaseExecutorSchema` interface that other executors can extend to include this optional parameter
- Fixes the issue where Poetry environments were being overridden by giving users control over the install behavior.

If you still want to install automatically, the `installDependenciesIfNotExists` doesn't need to be specified on every project.json, you can add the default target options in the `nx.json`, like this:

```json
    {
      // ...
      "targetDefaults": {
        "docs-gen": {
          "options": {
            "installDependenciesIfNotExists": true
          }
        }
      }
      // ...
    }
```

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #318