### PR TITLE
fix(nx-python): sanitize the package name for consistency between pyproject.toml and poetry.lock

### DIFF
--- a/packages/nx-python/src/provider/poetry/build/resolvers/utils.ts
+++ b/packages/nx-python/src/provider/poetry/build/resolvers/utils.ts
@@ -38,3 +38,12 @@ export function includeDependencyPackage(
     }
   }
 }
+
+/**
+ * Sanitizes the provided package name to match what Poetry lists in the lockfile (underscores -> dashes)
+ * @param packageName Package name to update
+ * @returns Updated package name
+ */
+export function sanitizePackageName(packageName: string) {
+  return packageName.replace(/_/g, '-');
+}


### PR DESCRIPTION
<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
By convention, the package name listed in `pyproject.toml` is expected to use dashes instead of underscores.  However, if underscores are provided, Poetry will silently normalize the package name to use dashes when generating the lockfile.  For local packages that are used as dependencies for another project, this may cause issues during the resolution of the package in `getLockedPackage`.  Since this function directly inspects the package's `pyproject.toml`, it can fail to detect the package if the naming does not match what is listed in the lockfile.

A minimal reproducible example is available [here](https://github.com/lucasvieirasilva/python-poetry-monorepo/compare/main...raymondhoagland:python-poetry-monorepo).  Specifically, the [name attribute in pyproject.toml](
https://github.com/lucasvieirasilva/python-poetry-monorepo/compare/main...raymondhoagland:python-poetry-monorepo:main#diff-6f436cc453ea1ce6d45922bf830d6f990518553dd0257db0be8a91b084f51613R13) for `lib1` uses underscores, which triggers the error when running the build (`yarn nx run-many -t build`).

## Expected Behavior
Following Poetry's behavior, the plugin sanitizes the package name when reading the package name from `pyproject.toml` to ensure the package name is kept consistent with what is in the lockfile.
<!-- This is the behavior we should expect with the changes in this PR -->
