### PR TITLE
fix: honor dependency version range when internal bundling is disabled

### DIFF
--- a/packages/nx-python/src/provider/uv/build/resolvers/project.ts
+++ b/packages/nx-python/src/provider/uv/build/resolvers/project.ts
@@ -14,6 +14,10 @@ import { BuildExecutorSchema } from '../../../../executors/build/schema';
 import { ExecutorContext } from '@nx/devkit';
 import { createHash } from 'crypto';
 
+// Matches a package name followed by a version specifier (>, >=, <, <=, ==, !=, ~=, ===) and version number
+const VERSION_RANGE_REGEX =
+  /^([a-zA-Z0-9._-]+)\s*(==|!=|~=|===|>=|<=|>|<)\s*([^\s,;]+)(?:,?\s*(==|!=|~=|===|>=|<=|>|<)\s*([^\s,;]+))*$/;
+
 /**
  * Resolves project dependencies for UV package manager when lockedVersion is false.
  *
@@ -404,7 +408,10 @@ export class ProjectDependencyResolver {
         } else {
           // Step 6: Handle publish mode - reference local dependency by version
           const index = this.addIndex(pyproject, targetOptions);
-          const depName = `${dependency}==${dependencyPyproject.project.version}`;
+          // Step 6a: Check if the dependency has a version range specified
+          const depName = VERSION_RANGE_REGEX.test(dependency)
+            ? dependency
+            : `${dependency}==${dependencyPyproject.project.version}`;
           this.appendDependency(pyproject, targetOptions, group, depName, true);
 
           // Update the source configuration


### PR DESCRIPTION
Honor dependency version range when internal bundling is disabled.

## Current Behavior

When a project depends on an internal library with a version range and `buildBundleLocalDependencies: false`

```toml
[project]
name = "my-app"
version = "1.0.0"
dependencies = [
    "my-lib>=1.0.0,<2.0.0"
]

[tool.uv.sources.my-lib]
workspace = true
```

The build process throws the following exception:

```log
Caused by:
    TOML parse error at line 5, column 5
       |
     5 | dependencies = [ "my-lib>=1.0.0,<2.0.0==1.0.1" ]
       |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    after parsing `2.0.0`, found `==1.0.1`, which is not part of a valid version
```

## Expected Behavior

When the version range is provided, the build process should preserve it.

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #332 
