### PR TITLE
fix: check for pyproject.toml existence before reading

### DIFF
--- a/packages/nx-python/src/provider/utils.ts
+++ b/packages/nx-python/src/provider/utils.ts
@@ -1,13 +1,17 @@
 import toml, { JsonMap } from '@iarna/toml';
 import { ExecutorContext, Tree } from '@nx/devkit';
 import chalk from 'chalk';
-import { readFileSync } from 'fs';
+import { existsSync, readFileSync } from 'fs';
 
 export const getPyprojectData = <T>(pyprojectToml: string): T => {
+  if (!existsSync(pyprojectToml)) {
+    return {} as T;
+  }
+
   const content = readFileSync(pyprojectToml).toString('utf-8');
   if (content.trim() === '') return {} as T;
 
-  return toml.parse(readFileSync(pyprojectToml).toString('utf-8')) as T;
+  return toml.parse(content) as T;
 };
 
 export const readPyprojectToml = <T>(tree: Tree, tomlFile: string): T => {


### PR DESCRIPTION
<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
The global sync generator fails to run when a non-python project exists in the workspace, as there is no pyproject.toml
<!-- This is the behavior we have today -->

## Expected Behavior
Non-python projects are quietly ignored by the sync generator
<!-- This is the behavior we should expect with the changes in this PR -->

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
