### PR TITLE
fix(nx-python): use Python package name for lockfile lookup in UV workspace deps

### DIFF
--- a/packages/nx-python/src/plugins/plugin.spec.ts
+++ b/packages/nx-python/src/plugins/plugin.spec.ts
@@ -1118,6 +1118,97 @@ describe('nx-python dependency graph', () => {
         ]);
       });
 
+      it('should detect dependencies when Nx project name differs from Python package name', async () => {
+        vol.fromJSON({
+          'apps/my-app/pyproject.toml': dedent`
+          [project]
+          name = "acme-my-app"
+          version = "0.1.0"
+          requires-python = ">=3.12"
+          dependencies = [
+              "acme-shared-lib",
+          ]
+
+          [tool.uv.sources]
+          acme-shared-lib = { workspace = true }
+          `,
+
+          'libs/shared-lib/pyproject.toml': dedent`
+          [project]
+          name = "acme-shared-lib"
+          version = "0.1.0"
+          requires-python = ">=3.12"
+          dependencies = []
+          `,
+
+          'pyproject.toml': dedent`
+          [tool.uv.sources]
+          acme-my-app = { workspace = true }
+          acme-shared-lib = { workspace = true }
+          `,
+
+          'uv.lock': dedent`
+          version = 1
+          requires-python = ">=3.12"
+
+          [[package]]
+          name = "acme-my-app"
+          version = "0.1.0"
+          source = { editable = "apps/my-app" }
+          dependencies = [
+              { name = "acme-shared-lib" },
+          ]
+
+          [package.metadata]
+          requires-dist = [
+              { name = "acme-shared-lib", editable = "libs/shared-lib" },
+          ]
+
+          [[package]]
+          name = "acme-shared-lib"
+          version = "0.1.0"
+          source = { editable = "libs/shared-lib" }
+          `,
+        });
+
+        const projects = {
+          'my-app': {
+            root: 'apps/my-app',
+            targets: {},
+          },
+          'shared-lib': {
+            root: 'libs/shared-lib',
+            targets: {},
+          },
+        };
+
+        const result = await createDependencies(
+          { packageManager: 'uv' },
+          {
+            externalNodes: {},
+            workspaceRoot: '.',
+            projects,
+            nxJsonConfiguration: {},
+            fileMap: {
+              nonProjectFiles: [],
+              projectFileMap: {},
+            },
+            filesToProcess: {
+              nonProjectFiles: [],
+              projectFileMap: {},
+            },
+          },
+        );
+
+        expect(result).toStrictEqual([
+          {
+            source: 'my-app',
+            target: 'shared-lib',
+            type: 'implicit',
+          },
+        ]);
+      });
+
       it('should progress the dependency graph when there is an app with an empty pyproject.toml', async () => {
         vol.fromJSON({
           'apps/app1/pyproject.toml': dedent`

--- a/packages/nx-python/src/provider/uv/provider.ts
+++ b/packages/nx-python/src/provider/uv/provider.ts
@@ -218,10 +218,11 @@ export class UVProvider extends BaseProvider<UVPyprojectToml> {
     if (this.fileExists(pyprojectToml)) {
       const tomlData = this.getPyprojectToml(projectData.root);
       const sources = this.sources(tomlData);
+      const packageName = tomlData?.project?.name ?? projectName;
 
       deps.push(
         ...this.resolveDependencies(
-          projectName,
+          packageName,
           sources,
           projects[projectName],
           tomlData?.project?.dependencies || [],
@@ -233,7 +234,7 @@ export class UVProvider extends BaseProvider<UVPyprojectToml> {
       for (const group in tomlData['dependency-groups']) {
         deps.push(
           ...this.resolveDependencies(
-            projectName,
+            packageName,
             sources,
             projects[projectName],
             tomlData['dependency-groups'][group],
@@ -888,7 +889,7 @@ export class UVProvider extends BaseProvider<UVPyprojectToml> {
   }
 
   private resolveDependencies(
-    projectName: string,
+    packageName: string,
     sources: UVPyprojectToml['tool']['uv']['sources'],
     projectData: ProjectConfiguration,
     dependencies: string[],
@@ -905,7 +906,7 @@ export class UVProvider extends BaseProvider<UVPyprojectToml> {
 
       if (this.isWorkspace) {
         this.appendWorkspaceDependencyToDeps(
-          projectName,
+          packageName,
           normalizedDep,
           category,
           sources,
@@ -928,7 +929,7 @@ export class UVProvider extends BaseProvider<UVPyprojectToml> {
   }
 
   private appendWorkspaceDependencyToDeps(
-    projectName: string,
+    packageName: string,
     dependencyName: string,
     category: string,
     sources: UVPyprojectToml['tool']['uv']['sources'],
@@ -939,7 +940,7 @@ export class UVProvider extends BaseProvider<UVPyprojectToml> {
       return;
     }
 
-    const packageMetadata = this.rootLockfile.package[projectName]?.metadata;
+    const packageMetadata = this.rootLockfile.package[packageName]?.metadata;
 
     const depMetadata =
       category === 'main'


### PR DESCRIPTION
## Current Behavior

`createDependencies` in the UV workspace provider returns zero dependency edges when the Nx project name differs from the Python package name. For example, an Nx project named `my-app` whose `pyproject.toml` declares `[project] name = "acme-my-app"` will never have its dependencies detected.

This happens because `appendWorkspaceDependencyToDeps` uses the Nx project name to look up package metadata in `this.rootLockfile.package[projectName]`, but `uv.lock` is keyed by the Python package name from `pyproject.toml` `[project].name`. When these differ, the lookup returns `undefined` and the method silently returns without adding the dependency edge.

This is common in real-world monorepos — in ours, 35 out of 64 Python projects have mismatched names, resulting in 0 auto-detected dependency edges.

## Expected Behavior

`createDependencies` should resolve the Python package name from the project's `pyproject.toml` before looking up the lockfile, so dependency edges are correctly detected regardless of whether the Nx project name matches the Python package name.

After this fix, our monorepo goes from 0 to 70 auto-detected dependency edges with 0 false positives.

## Related Issue(s)

No existing issue found
