### PR TITLE
fix(nx-python): skip __pycache__ during copySync to avoid CPython race

### DIFF
--- a/packages/nx-python/src/provider/poetry/build/resolvers/utils.ts
+++ b/packages/nx-python/src/provider/poetry/build/resolvers/utils.ts
@@ -1,6 +1,7 @@
 import { join } from 'path';
 import { copySync } from 'fs-extra';
 import { PoetryPyprojectToml } from '../../types';
+import { pycacheFilter } from '../../../utils';
 
 export function includeDependencyPackage(
   tomlData: PoetryPyprojectToml,
@@ -12,7 +13,7 @@ export function includeDependencyPackage(
     const pkgFolder = join(root, pkg.from ?? '', pkg.include);
     const buildPackageFolder = join(buildFolderPath, pkg.include);
 
-    copySync(pkgFolder, buildPackageFolder);
+    copySync(pkgFolder, buildPackageFolder, { filter: pycacheFilter });
 
     if (
       buildTomlData.tool.poetry.packages.find(

--- a/packages/nx-python/src/provider/poetry/provider.ts
+++ b/packages/nx-python/src/provider/poetry/provider.ts
@@ -58,6 +58,7 @@ import {
 } from './build/resolvers';
 import {
   getLocalDependencyConfig,
+  pycacheFilter,
   readPyprojectToml,
   writePyprojectToml,
 } from '../utils';
@@ -803,7 +804,7 @@ export class PoetryProvider extends BaseProvider<PoetryPyprojectToml> {
       ) {
         const source = join(root, file);
         const target = join(buildFolderPath, file);
-        copySync(source, target);
+        copySync(source, target, { filter: pycacheFilter });
       }
     });
 

--- a/packages/nx-python/src/provider/utils.spec.ts
+++ b/packages/nx-python/src/provider/utils.spec.ts
@@ -1,0 +1,45 @@
+import { sep } from 'path';
+import { pycacheFilter } from './utils';
+
+describe('pycacheFilter', () => {
+  it('allows regular source files', () => {
+    expect(
+      pycacheFilter(['libs', 'mylib', 'src', 'mylib', 'mod.py'].join(sep)),
+    ).toBe(true);
+    expect(pycacheFilter(['libs', 'mylib', 'pyproject.toml'].join(sep))).toBe(
+      true,
+    );
+  });
+
+  it('excludes __pycache__ directories at any depth', () => {
+    expect(pycacheFilter(['libs', 'mylib', '__pycache__'].join(sep))).toBe(
+      false,
+    );
+    expect(
+      pycacheFilter(['libs', 'mylib', 'src', 'mylib', '__pycache__'].join(sep)),
+    ).toBe(false);
+  });
+
+  it('excludes files inside __pycache__', () => {
+    expect(
+      pycacheFilter(
+        ['libs', 'mylib', '__pycache__', 'mod.cpython-314.pyc'].join(sep),
+      ),
+    ).toBe(false);
+    expect(
+      pycacheFilter(
+        [
+          'libs',
+          'mylib',
+          '__pycache__',
+          'mod.cpython-314.pyc.139819699349712',
+        ].join(sep),
+      ),
+    ).toBe(false);
+  });
+
+  it('does not exclude paths that merely contain __pycache__ as a substring', () => {
+    expect(pycacheFilter(['libs', 'my__pycache__thing'].join(sep))).toBe(true);
+    expect(pycacheFilter(['libs', 'prefix__pycache__'].join(sep))).toBe(true);
+  });
+});

--- a/packages/nx-python/src/provider/utils.ts
+++ b/packages/nx-python/src/provider/utils.ts
@@ -2,7 +2,7 @@ import toml, { JsonMap } from '@iarna/toml';
 import { ExecutorContext, Tree } from '@nx/devkit';
 import chalk from 'chalk';
 import { existsSync, readFileSync } from 'fs';
-import { sep } from 'path';
+import { sep } from 'node:path';
 
 export const getPyprojectData = <T>(pyprojectToml: string): T => {
   if (!existsSync(pyprojectToml)) {

--- a/packages/nx-python/src/provider/utils.ts
+++ b/packages/nx-python/src/provider/utils.ts
@@ -2,6 +2,7 @@ import toml, { JsonMap } from '@iarna/toml';
 import { ExecutorContext, Tree } from '@nx/devkit';
 import chalk from 'chalk';
 import { existsSync, readFileSync } from 'fs';
+import { sep } from 'path';
 
 export const getPyprojectData = <T>(pyprojectToml: string): T => {
   if (!existsSync(pyprojectToml)) {
@@ -34,6 +35,11 @@ export function writePyprojectToml(
 export function getLoggingTab(level: number): string {
   return '    '.repeat(level);
 }
+
+// Skip __pycache__ during recursive copies: CPython writes .pyc files atomically
+// (temp file then rename), which races with readdir+lstat walks and surfaces ENOENT.
+export const pycacheFilter = (src: string): boolean =>
+  !src.split(sep).includes('__pycache__');
 
 export function getLocalDependencyConfig(
   context: ExecutorContext,

--- a/packages/nx-python/src/provider/uv/build/resolvers/utils.ts
+++ b/packages/nx-python/src/provider/uv/build/resolvers/utils.ts
@@ -2,6 +2,7 @@ import { join } from 'path';
 import { UVPyprojectToml } from '../../types';
 import { copySync } from 'fs-extra';
 import { existsSync, readdirSync } from 'fs';
+import { pycacheFilter } from '../../../utils';
 
 export function includeDependencyPackage(
   projectData: UVPyprojectToml,
@@ -41,7 +42,7 @@ export function includeDependencyPackage(
   if (isSrcDir) {
     for (const pkg of readdirSync(join(workspaceRoot, projectRoot, 'src'))) {
       const pkgFolder = join(workspaceRoot, projectRoot, 'src', pkg);
-      copySync(pkgFolder, getTargetModulePath(pkg));
+      copySync(pkgFolder, getTargetModulePath(pkg), { filter: pycacheFilter });
 
       updateModules(pkg);
     }
@@ -49,7 +50,7 @@ export function includeDependencyPackage(
     for (const pkg of projectData.tool?.hatch?.build?.targets?.wheel
       ?.packages ?? []) {
       const pkgFolder = join(workspaceRoot, projectRoot, pkg);
-      copySync(pkgFolder, getTargetModulePath(pkg));
+      copySync(pkgFolder, getTargetModulePath(pkg), { filter: pycacheFilter });
 
       updateModules(pkg);
     }

--- a/packages/nx-python/src/provider/uv/provider.ts
+++ b/packages/nx-python/src/provider/uv/provider.ts
@@ -37,6 +37,7 @@ import chalk from 'chalk';
 import { copySync, removeSync, writeFileSync } from 'fs-extra';
 import {
   getLocalDependencyConfig,
+  pycacheFilter,
   readPyprojectToml,
   writePyprojectToml,
 } from '../utils';
@@ -795,7 +796,7 @@ export class UVProvider extends BaseProvider<UVPyprojectToml> {
       ) {
         const source = join(projectRoot, file);
         const target = join(buildFolderPath, file);
-        copySync(source, target);
+        copySync(source, target, { filter: pycacheFilter });
       }
     });
 

--- a/packages/nx-python/src/utils/mocks/fs.mock.ts
+++ b/packages/nx-python/src/utils/mocks/fs.mock.ts
@@ -8,8 +8,14 @@ import path from 'path';
 const copyRecursiveSync = (
   src: string,
   dest: string,
-  options?: { recursive: boolean },
+  options?: {
+    recursive?: boolean;
+    filter?: (src: string, dest: string) => boolean;
+  },
 ) => {
+  if (options?.filter && !options.filter(src, dest)) {
+    return;
+  }
   const exists = fs.existsSync(src);
   const stats = exists && fs.statSync(src);
   const isDirectory = exists && stats && stats.isDirectory();
@@ -18,10 +24,11 @@ const copyRecursiveSync = (
       fs.mkdirSync(dest);
     }
     fs.readdirSync(src).forEach(function (childItemName) {
-      if (options === undefined || options?.recursive) {
+      if (options === undefined || options?.recursive !== false) {
         copyRecursiveSync(
           path.join(src, childItemName),
           path.join(dest, childItemName),
+          options,
         );
       }
     });


### PR DESCRIPTION
### Summary
- Five unfiltered `fs-extra.copySync` calls in the build executor recursively walk source trees, including `__pycache__` directories that CPython may be atomically writing to (temp `.pyc.<id>` then rename).
- When any concurrent process imports a module from a local workspace dep during the copy, a temp entry seen in `readdir` can vanish before the follow-up `lstat`, which surfaces as `ENOENT` and crashes the build.

### Changes
- Added a shared `pycacheFilter` in `packages/nx-python/src/provider/utils.ts` that returns `false` for any path whose segments include `__pycache__`.
- Added the filter to all five `copySync` sites.
- Extended the memfs test mock in `src/utils/mocks/fs.mock.ts` to honor the `filter` option so the new code path is exercised by the existing test suite.
- Added unit tests for `pycacheFilter` in `src/provider/utils.spec.ts` covering normal paths, nested `__pycache__`, files inside `__pycache__`, and substring edge cases.

### Why not the existing `ignorePaths` option

- `ignorePaths` only filters top-level direntries of `projectRoot` via `minimatch` on a basename. For typical src-layout projects, `__pycache__` lives at `src/<pkg>/<subpkg>/__pycache__/` and is never seen by that filter. The per-local-dep `copySync` in `includeDependencyPackage` does not consult `ignorePaths` at all.

### Testing

- [x] `pnpm nx test nx-python`
- [x] `pnpm nx run nx-python:lint`
- [x] `pnpm nx format:check`
- [x] Reproducer from #351 

### Notes

- `__pycache__` is derived data that `hatchling` and `uv_build` already strip from the final wheel/sdist, so no change to produced artifacts. Temp build folders are slightly smaller and builds are slightly faster.
- No change to the public executor schema or options.
- Closes #351 