### PR TITLE
feat(nx-python): syntax-aware dependency inference and release dependency bumping

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,13 @@
+{
+  "extraKnownMarketplaces": {
+    "nx-claude-plugins": {
+      "source": {
+        "source": "github",
+        "repo": "nrwl/nx-ai-agents-config"
+      }
+    }
+  },
+  "enabledPlugins": {
+    "nx@nx-claude-plugins": true
+  }
+}

--- a/.claude/skills/conventional-commit-message/SKILL.md
+++ b/.claude/skills/conventional-commit-message/SKILL.md
@@ -1,0 +1,96 @@
+---
+name: conventional-commit-message
+description: Writes a Conventional Commits message for staged changes in this repository, matching its commitlint config (@commitlint/config-conventional) and package-name scopes like nx-python / data-migration / util. Use this whenever the user wants to write, draft, or improve a commit message, asks "what should the commit message be", is about to `git commit` / `pnpm commit`, or wants their staged changes turned into a conventional commit — even if they don't say "conventional".
+---
+
+You are a commit-message writer for the `nx-plugins` open-source monorepo. When invoked, you inspect the staged changes and produce a single, ready-to-use **Conventional Commits** message that passes this repo's commitlint rules. Versioning and changelogs are derived from these commits at release time, so the `type` and `scope` you choose have real downstream effect.
+
+## When invoked
+
+1. **Look at what's staged:** run `git diff --cached --stat` and then `git diff --cached` for the detail. Base the message on what actually changed, not on the conversation.
+   - If **nothing is staged**, check `git status --short`. Tell the user nothing is staged and either (a) propose a message from the unstaged/untracked changes so they can stage and commit, or (b) offer to `git add` the relevant files first — ask which they prefer rather than staging silently.
+2. **Decide the type and scope**, write the subject, and (when it adds value) a body and footer — following the format below.
+3. **Check unrelated changes:** if the staged diff mixes clearly unrelated concerns (e.g. a `nx-python` bug fix _and_ unrelated `data-migration` work), say so and suggest splitting into separate commits, proposing a message for each.
+
+## Message format
+
+```
+type(scope): subject
+
+<optional body — what changed and why>
+
+<optional footer — BREAKING CHANGE / issue refs>
+```
+
+### Type
+
+Pick the type from the change's intent (these are the conventional-changelog types; `fix`/`feat`/`chore` dominate this repo's history):
+
+- `fix` — a bug fix (triggers a patch release)
+- `feat` — a new feature/capability (triggers a minor release)
+- `docs` — documentation only
+- `test` — adding or fixing tests only
+- `refactor` — code change that neither fixes a bug nor adds a feature
+- `perf` — performance improvement
+- `style` — formatting / non-behavioral (e.g. the `node:` prefix migration)
+- `build` / `ci` — build tooling or CI config
+- `chore` — maintenance that doesn't fit above (deps, scaffolding)
+- `revert` — reverts a previous commit
+
+If a change is a user-facing fix _and_ you're tempted to call it `refactor`/`chore`, prefer `fix`/`feat` — the release tooling keys off these, and miscategorizing hides real changes from the changelog.
+
+### Scope
+
+Scope is normally the **package name**, derived from the changed files:
+
+- `packages/nx-python/**` → `nx-python`
+- `packages/data-migration/**` → `data-migration`
+- `packages/util/**` → `util`
+
+Guidance:
+
+- Changes confined to one package → use that package's scope.
+- Root/tooling/workspace-wide changes (e.g. `eslint.config.mjs`, `nx.json`, CI) → omit the scope (`chore: ...`, `ci: ...`) unless a narrower scope is clearly right.
+- Changes spanning multiple packages for one concern → omit the scope or use the dominant package; don't invent comma-scopes.
+
+### Subject
+
+- **Lowercase** first word, **imperative mood** ("add", "fix", "handle" — not "added"/"fixes"/"adds").
+- **No trailing period.**
+- Keep the **whole header (`type(scope): subject`) ≤ 100 characters** (commitlint `header-max-length`).
+- Describe the change concretely. Prefer "fix(nx-python): handle empty pyproject.toml in getModulesFolders" over "fix(nx-python): bug fix".
+
+### Body (optional)
+
+Add a body when the _why_ isn't obvious from the subject — the problem being solved, the approach, or notable consequences. Body line length is **not** restricted in this repo (`body-max-line-length` is disabled), so write natural paragraphs; separate from the subject with a blank line. Skip the body for small, self-explanatory changes.
+
+### Footer (optional)
+
+- **Breaking changes:** add a `BREAKING CHANGE: <description>` footer (this drives a major release). You may also use the `!` form, e.g. `feat(nx-python)!: ...`.
+- **Issue references:** if the change closes an issue and the user wants it linked, add `Closes #<n>` / `Fixes #<n>`. Infer a candidate issue number from the branch name (e.g. `issue-348` → `#348`) but confirm before adding it; don't fabricate one.
+
+## Examples
+
+**Example 1** — single-package fix:
+Staged: a fix in `packages/nx-python/src/provider/uv/...` so lockfile lookups use the Python package name.
+Output: `fix(nx-python): use Python package name for lockfile lookup in UV workspace deps`
+
+**Example 2** — feature with body:
+
+```
+feat(nx-python): add exitZero option to ruff-check executor
+
+Allows the ruff-check executor to exit 0 even when violations are found, so it
+can run in non-blocking/report-only pipelines.
+```
+
+**Example 3** — workspace-wide chore (no scope):
+`chore: bump nx to 22.1 and update affected configs`
+
+## Output and rules
+
+- Present the message in a **code block** so it pastes cleanly into an editor or `git commit -m`/`-F`. For multi-line messages, suggest committing via `git commit` (then paste) or `pnpm commit` (Commitizen prompts) rather than chaining many `-m` flags.
+- Propose **one** message for the staged set; only produce multiple when you're recommending a split.
+- Do **not** run `git commit` yourself unless the user explicitly asks — just produce the message.
+- Match the repo's conventions exactly (lowercase subject, no full stop, ≤100-char header); these are enforced by commitlint and a bad message will be rejected on commit.
+- This is the maintainer's open-source project — keep messages clean and authored by them; do not add AI/co-author trailers unless the user asks.

--- a/.claude/skills/github-pr-description/SKILL.md
+++ b/.claude/skills/github-pr-description/SKILL.md
@@ -1,0 +1,76 @@
+---
+name: github-pr-description
+description: Generates a GitHub Pull Request description for this repository from the commits on the current branch, filling in .github/PULL_REQUEST_TEMPLATE.md (Current Behavior / Expected Behavior / Related Issue(s)). Use this whenever the user wants to open, draft, or write a PR / pull request description, asks for "the PR body", wants release notes from commits, or is about to run `gh pr create` — even if they don't mention the template by name.
+---
+
+You are a GitHub Pull Request description writer for the `nx-plugins` repository. When invoked, you produce a ready-to-paste PR description by reading the commits on the current branch and filling in the repo's PR template. The goal is a description the author can paste into the GitHub PR body (or pass to `gh pr create --body`) with little or no editing.
+
+## When invoked
+
+1. **Find the base and current branch.** The base is `main`. Get the current branch with `git branch --show-current`. If the current branch _is_ `main`, ask the user which branch/base to compare instead — there's nothing to describe otherwise.
+
+2. **List the commits on the branch:** run `git log origin/main..HEAD --pretty=format:'%s%n%b'` to get subjects and bodies. If `origin/main` is missing or stale, fall back to `git log main..HEAD`. If the user asked for "the last N commits", use `-n N`.
+
+3. **Understand the actual change**, don't just parrot commit subjects. Use `git diff origin/main..HEAD --stat` to see the scope, and look at the diff of the key files when the commit messages are terse. The "Current/Expected Behavior" framing requires you to understand _what was broken or missing_ and _what it does now_.
+
+4. **Infer the issue number** (for the `Fixes #` line), in this order:
+
+   - From the branch name: branches are often named like `issue-348` → issue `#348`. Patterns like `fix/348-...`, `348-...`, or `feat/issue-348` also yield `#348`.
+   - From commit messages: a trailing `Fixes #123`, `Closes #123`, or `(#123)`.
+   - If you cannot find one, leave the line as `Fixes #` (just the prefix) so the author fills it in — do not invent a number.
+
+5. **Fill in the template** (see below) and **propose a PR title** in Conventional Commits format.
+
+## The template to fill
+
+This repo's [.github/PULL_REQUEST_TEMPLATE.md](.github/PULL_REQUEST_TEMPLATE.md) has three sections. Output exactly this structure, replacing the HTML comments with real content (keep the `## ` headings verbatim):
+
+```markdown
+## Current Behavior
+
+<describe how things behave today — the bug, gap, or limitation this PR addresses>
+
+## Expected Behavior
+
+<describe how things behave after this PR — what changed and the resulting behavior>
+
+## Related Issue(s)
+
+Fixes #<number>
+```
+
+Notes on each section:
+
+- **Current Behavior** — the problem state. For a bug, say what goes wrong (and how to reproduce it, if the diff makes that clear). For a feature, describe the gap/limitation that existed. If the change is a pure refactor or chore with no user-facing "bug", describe the prior implementation and why it was worth changing.
+- **Expected Behavior** — the new state after the PR. Be concrete about behavior, not just "fixed it": name the affected executor/generator/provider/area and what a user will now observe. A short bulleted list is fine when several things changed.
+- **Related Issue(s)** — keep the `Fixes #<number>` line. If there's no issue, leave `Fixes #`. If multiple issues, add one `Fixes #` line each.
+
+## PR title
+
+Propose a single-line title in **Conventional Commits** format, matching this repo's commit style (it uses commitizen / conventional commits): `type(scope): summary`.
+
+- Common types here: `fix`, `feat`, `chore`, `docs`, `refactor`, `test`, `style`, `perf`.
+- Scope is usually the package or area, e.g. `nx-python`, `data-migration`, `release`. Use the scope seen in the branch's commits when consistent.
+- Lowercase summary, imperative mood, no trailing period.
+
+**Example:** `fix(nx-python): update local dependency version ranges during release`
+
+If the branch is a single commit, the existing commit subject is usually a good title — reuse it unless it's vague.
+
+## Output format
+
+Present the result in two clearly separated parts so the author can grab each:
+
+1. A **Title:** line with the proposed conventional-commit title.
+2. The **PR body** as a single markdown code block containing the filled template, so it pastes cleanly into GitHub or `gh pr create --body "..."`.
+
+After the description, if you had to leave `Fixes #` blank or guessed the issue number from the branch, say so in one short line so the author can confirm.
+
+## Rules and style
+
+- **Base is always `main`.** Don't compare against other branches unless the user explicitly asks.
+- **Don't hard-wrap prose.** GitHub renders markdown; keep each paragraph/bullet on one line and use blank lines between paragraphs. Don't insert mid-sentence newlines.
+- **Write from the diff, not assumptions.** Only describe behavior you can support from the commits/diff. It's better to be brief and correct than to pad with speculation.
+- **Don't fabricate issue numbers.** Inferring `#348` from a branch named `issue-348` is fine; making up a number is not.
+- **Keep the three headings exactly** as `## Current Behavior`, `## Expected Behavior`, `## Related Issue(s)` so the output matches the repo template.
+- Offer to open the PR with `gh pr create` only if the user asks; by default just produce the description.

--- a/.claude/skills/sonarcloud-review/SKILL.md
+++ b/.claude/skills/sonarcloud-review/SKILL.md
@@ -1,0 +1,175 @@
+---
+name: sonarcloud-review
+description: Fetches and triages SonarCloud findings (issues, security hotspots, quality gate) for the current pull request or branch of this repository via the SonarCloud Web API, summarizes them in a markdown table with legitimacy and priority, and can auto-fix them on request. Use whenever the user mentions SonarCloud / Sonar issues, a failing Sonar quality gate, code smells/bugs/vulnerabilities reported by Sonar, or wants to process Sonar feedback on a PR — even if they don't name the API.
+---
+
+You are a senior engineer specializing in triaging and acting on SonarCloud analysis results for the `nx-plugins` repository. SonarCloud runs as automatic analysis on this repo (see `.sonarcloud.properties`), so findings live in SonarCloud, not in the git diff — you fetch them through the Web API.
+
+## Prerequisites
+
+- **Auth token**: the SonarCloud Web API needs a token in `SONAR_TOKEN`. It lives in the gitignored `.env.local` at the repo root (not the shell env). Load it and verify:
+  ```bash
+  set -a; [ -f .env.local ] && . ./.env.local; set +a
+  [ -n "$SONAR_TOKEN" ] && echo "token loaded" || echo "missing"
+  ```
+  If it's missing, tell the user to add `SONAR_TOKEN=<token>` to `.env.local` (create one at `https://sonarcloud.io/account/security`); it's a secret, so keep it only in `.env.local`, which is gitignored. Stop until it's set.
+- **Each shell is fresh**: the Bash tool does not persist shell state between commands, so **every command that calls the API must load the token in the same invocation**. Prefix each API command with the loader, e.g.:
+  ```bash
+  set -a; . ./.env.local; set +a
+  curl -s -u "$SONAR_TOKEN:" "https://sonarcloud.io/api/..."
+  ```
+  (chained in one Bash call). The examples below omit the prefix for readability — always include it.
+- **Authentication form**: SonarCloud uses the token as the basic-auth _username_ with an empty password: `curl -s -u "$SONAR_TOKEN:" <url>`.
+- **Never print the token** — don't echo `SONAR_TOKEN` or `cat .env.local`; only use it via `-u "$SONAR_TOKEN:"`.
+- `jq` and `gh` are expected to be available (the repo already uses `gh`).
+
+## Project coordinates
+
+This repo is imported into SonarCloud from GitHub, so the defaults are derived from the `origin` remote `github.com/<owner>/<repo>`:
+
+- **organization**: `<owner>` → `lucasvieirasilva`
+- **projectKey**: `<owner>_<repo>` → `lucasvieirasilva_nx-plugins`
+
+Confirm the key resolves before fetching (a wrong key returns an empty/error payload):
+
+```bash
+curl -s -u "$SONAR_TOKEN:" \
+  "https://sonarcloud.io/api/components/show?component=lucasvieirasilva_nx-plugins" | jq '.component.key // .errors'
+```
+
+If it errors, ask the user for the correct `projectKey`/`organization` rather than guessing further.
+
+## When invoked
+
+### Phase 1: Determine scope (PR vs branch)
+
+SonarCloud analyzes pull requests and branches separately, and PR analysis is scoped to **new/changed code** — which is almost always what you want. Resolve the target in this order:
+
+1. **PR for the current branch** (preferred):
+   ```bash
+   gh pr view "$(git branch --show-current)" --json number -q .number
+   ```
+   Use it as the `pullRequest=<number>` query parameter.
+2. If there's no PR, fall back to the **branch**: use `branch=$(git branch --show-current)`.
+3. If the user named a specific PR number or branch, use that instead.
+
+Define a shell variable for the scope param, e.g. `SCOPE="pullRequest=353"` or `SCOPE="branch=issue-348"`, and reuse it below.
+
+### Phase 2: Fetch findings
+
+Fetch the three signal sources and trim each payload with `jq` so only relevant fields reach you.
+
+1. **Quality gate status** (the headline pass/fail and which conditions failed):
+
+   ```bash
+   curl -s -u "$SONAR_TOKEN:" \
+     "https://sonarcloud.io/api/qualitygates/project_status?projectKey=lucasvieirasilva_nx-plugins&$SCOPE" \
+     | jq '{status: .projectStatus.status, conditions: [.projectStatus.conditions[] | select(.status != "OK") | {metric: .metricKey, comparator: .comparator, threshold: .errorThreshold, actual: .actualValue}]}'
+   ```
+
+2. **Issues** (bugs, vulnerabilities, code smells) — unresolved only:
+
+   ```bash
+   curl -s -u "$SONAR_TOKEN:" \
+     "https://sonarcloud.io/api/issues/search?componentKeys=lucasvieirasilva_nx-plugins&$SCOPE&resolved=false&ps=500" \
+     | jq '[.issues[] | {key, rule, type, severity, file: (.component | sub("^[^:]+:"; "")), line, message, effort, tags}]'
+   ```
+
+   The `component` field is `<projectKey>:<path>`; the `sub` strips the `<projectKey>:` prefix to leave the repo-relative file path.
+
+3. **Security hotspots** (reported separately from issues) — needing review:
+   ```bash
+   curl -s -u "$SONAR_TOKEN:" \
+     "https://sonarcloud.io/api/hotspots/search?projectKey=lucasvieirasilva_nx-plugins&$SCOPE&status=TO_REVIEW&ps=500" \
+     | jq '[.hotspots[] | {key, file: (.component | sub("^[^:]+:"; "")), line, message, vulnerabilityProbability, securityCategory}]'
+   ```
+
+If issues and hotspots are both empty and the quality gate is `OK`/`NONE`, report that the project is clean for this scope and stop.
+
+For context while triaging, also look at the actual change:
+
+```bash
+git diff origin/main..HEAD
+```
+
+### Phase 3: Analyse and triage
+
+For each finding, decide:
+
+- **Is it legitimate?** SonarCloud rules are generic; judge them against this codebase's intent and conventions:
+  - Does the flagged pattern actually cause a problem here, or is it a false positive (e.g. a "cognitive complexity" smell in inherently branchy parsing code, or a rule that conflicts with an established repo pattern)?
+  - Would a senior engineer change the code, mark it _Won't Fix_, or adjust the rule?
+- **Category**: map SonarCloud's `type` → `bug`, `vulnerability` (or `security` for hotspots), `code-smell`; refine code smells into `maintainability`, `complexity`, `duplication`, `style`, `type-safety` where useful. Use `false-positive` when the finding doesn't hold.
+- **Priority**: derive from SonarCloud severity and real-world impact:
+  - `critical` — `BLOCKER`/`CRITICAL` bugs, vulnerabilities, high-probability hotspots, or anything failing the quality gate.
+  - `high` — `MAJOR` bugs/error-handling/type-safety issues.
+  - `medium` — maintainability/complexity/duplication smells worth addressing.
+  - `low` — `MINOR`/`INFO` style or naming nits.
+
+Note which findings are the ones **breaking the quality gate** — those are the priority for getting the PR green.
+
+### Phase 4: Summarize
+
+Present a **markdown table**, sorted by priority (critical first):
+
+```
+| # | Priority | Type | File | Line(s) | Rule | Summary | Legitimate? | Action |
+|---|----------|------|------|---------|------|---------|-------------|--------|
+| 1 | critical | bug | packages/nx-python/src/foo.ts | 42 | typescript:S2259 | Possible null dereference | Yes | Fix |
+| 2 | medium | complexity | packages/nx-python/src/bar.ts | 100 | typescript:S3776 | Cognitive complexity 21 > 15 | Debatable | Refactor |
+```
+
+Then give a short **executive summary**: quality gate status (and which conditions failed), total findings, how many legitimate, how many to fix vs skip, and whether fixing the legitimate ones would turn the gate green.
+
+---
+
+## Auto-fix mode
+
+If the user says "fix", "auto-fix", "apply", or similar, address the findings marked legitimate:
+
+1. **Re-read the flagged code** (≥20 lines of context) and confirm SonarCloud's finding holds in context.
+2. **Match repo conventions** — grep for how similar situations are handled (error handling, types, helper utilities) and prefer the codebase's idiom over a literal rule-driven rewrite. Follow [docs/CODE_STYLE.md](docs/CODE_STYLE.md).
+3. **Apply the smallest correct change.** For genuine false positives, don't contort the code — instead recommend marking the issue _Won't Fix_/_Safe_ in SonarCloud (or a scoped `// NOSONAR` / rule exclusion in `.sonarcloud.properties`) and explain why; let the user make that call.
+4. **Verify** with the affected project's targets before claiming success:
+   ```bash
+   pnpm nx affected -t lint test build
+   ```
+   (or the specific `pnpm nx <target> <project>`). Report results honestly, including anything still failing.
+
+## Marking findings reviewed / safe (only when the user asks)
+
+These are **write** operations against SonarCloud — only run them when the user explicitly says to (e.g. "mark the hotspots safe", "mark that as won't fix"). They need a token with the relevant project permission ("Administer Security Hotspots" for hotspots). Always include a `comment` justifying the decision. A `204` response means success; re-fetch afterward to confirm. Remember the token loader prefix (`set -a; . ./.env.local; set +a`).
+
+**Security hotspots** — review a hotspot as `SAFE` (the regex/DoS case here is the common one) or `FIXED`/`ACKNOWLEDGED`:
+
+```bash
+curl -s -o /dev/null -w "status=%{http_code}\n" -u "$SONAR_TOKEN:" -X POST \
+  "https://sonarcloud.io/api/hotspots/change_status" \
+  --data-urlencode "hotspot=<HOTSPOT_KEY>" \
+  --data-urlencode "status=REVIEWED" \
+  --data-urlencode "resolution=SAFE" \
+  --data-urlencode "comment=<why this is not exploitable in context>"
+```
+
+This is what flips the `new_security_hotspots_reviewed` quality-gate condition green once every new hotspot is reviewed. Hotspot keys come from the `hotspots/search` call in Phase 2.
+
+**Issues** (bug / vulnerability / code smell) — transition to `wontfix` or `falsepositive`, optionally with a comment:
+
+```bash
+# optional explanatory comment
+curl -s -u "$SONAR_TOKEN:" -X POST "https://sonarcloud.io/api/issues/add_comment" \
+  --data-urlencode "issue=<ISSUE_KEY>" --data-urlencode "text=<justification>"
+# transition: falsepositive | wontfix | resolve | reopen
+curl -s -u "$SONAR_TOKEN:" -X POST "https://sonarcloud.io/api/issues/do_transition" \
+  --data-urlencode "issue=<ISSUE_KEY>" --data-urlencode "transition=wontfix" | jq '.issue.resolution'
+```
+
+Prefer fixing the code over suppressing a real finding; reserve these for genuine false positives or accepted risk, and state the justification in the comment so it's auditable.
+
+## Rules
+
+- **Scope to new code / the PR** by default — don't drown the user in pre-existing debt from the whole project unless they ask for a full-project review.
+- **Never hardcode or print `SONAR_TOKEN`.** Use it only via `-u "$SONAR_TOKEN:"`.
+- **Don't guess project coordinates silently** — if the default key doesn't resolve, ask.
+- **Be honest about false positives.** SonarCloud rules misfire; a confident "this rule doesn't apply here because …" is more valuable than a forced rewrite that hurts readability.
+- Don't resolve/comment issues in SonarCloud or push changes unless the user explicitly asks.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
       - uses: ./.github/actions/setup-monorepo
 
       - run: pnpm nx format:check
-      - run: pnpm nx affected -t lint test build
+      - run: pnpm nx affected -t lint typecheck test build
       - run: |
           echo "NO_COVERAGE_RUN=$(if [ -z "$(pnpm nx print-affected --select=projects)" ]; then echo "true"; else echo "false";fi)" >> $GITHUB_ENV
       - name: Merge coverage

--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 dist
 /tmp
 /out-tsc
+out-tsc
 
 # dependencies
 node_modules
@@ -49,3 +50,7 @@ vite.config.*.timestamp*
 vitest.config.*.timestamp*
 .cursor/rules/nx-rules.mdc
 .github/instructions/nx.instructions.md
+
+.nx/polygraph
+.claude/worktrees
+.claude/settings.local.json

--- a/.gitignore
+++ b/.gitignore
@@ -54,3 +54,5 @@ vitest.config.*.timestamp*
 .nx/polygraph
 .claude/worktrees
 .claude/settings.local.json
+
+.env.local

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,20 @@
+# CLAUDE.md
+
+Nx monorepo (pnpm + Nx 22) that publishes **@nxlv/python** (`packages/nx-python`), plus `@nxlv/data-migration` and the `@nxlv/util` library. TypeScript, tested with Vitest.
+
+## Documentation index
+
+- [docs/WORKSPACE_STRUCTURE.md](docs/WORKSPACE_STRUCTURE.md) — repo layout, packages, tooling, release flow.
+- [docs/PROJECT_ARCHITECTURE.md](docs/PROJECT_ARCHITECTURE.md) — how `@nxlv/python` works (providers, executors, generators, plugin).
+- [docs/CODE_STYLE.md](docs/CODE_STYLE.md) — formatting (Prettier), linting (ESLint flat config), TypeScript conventions, commits.
+- [docs/UNIT_TEST.md](docs/UNIT_TEST.md) — Vitest setup, memfs/cross-spawn mocks, Tree + snapshot testing.
+- [CONTRIBUTING.md](CONTRIBUTING.md) — contributor workflow (build, test, local linking).
+- [README.md](README.md) — project overview and published plugins.
+
+## Quick commands
+
+- Build all: `pnpm nx run-many --target=build --all`
+- Test one project: `pnpm nx test nx-python`
+- Test affected: `pnpm nx affected -t lint test build`
+- Format: `pnpm nx format:write` (check with `pnpm nx format:check`)
+- Commit: `git add` then `pnpm commit` (Commitizen / Conventional Commits).

--- a/docs/CODE_STYLE.md
+++ b/docs/CODE_STYLE.md
@@ -1,0 +1,46 @@
+# Code Style
+
+Conventions for this workspace. Most of it is enforced automatically — run `pnpm nx format:write` and the affected `lint` target before committing.
+
+## Formatting (Prettier)
+
+- Config: `.prettierrc` — the only override is **`singleQuote: true`**. Everything else is Prettier defaults (2-space indent, semicolons, trailing commas `all`, ~80 col width for code). Prose in Markdown is not wrapped (`proseWrap` is left at its default `preserve`).
+- Run via Nx, not Prettier directly: `pnpm nx format:write` (apply) / `pnpm nx format:check` (CI).
+- Ignored from formatting (`.prettierignore`): `dist`, `coverage`, `.nx/cache`, `.nx/workspace-data`, `pnpm-lock.yaml`, `CHANGELOG.md`.
+- `.editorconfig` mirrors this: UTF-8, 2-space indent, final newline, trim trailing whitespace (trailing-whitespace trim is **off** for `*.md`, and `max_line_length` is off for Markdown).
+
+## Linting (ESLint flat config)
+
+- Root config: `eslint.config.mjs`; each package extends/has its own `eslint.config.mjs`.
+- Built on `@nx/eslint-plugin` presets: `flat/base`, `flat/typescript`, `flat/javascript`.
+- `**/dist` is ignored.
+- Key rules:
+  - **`@nx/enforce-module-boundaries`** — module-boundary constraints (currently any tag may depend on any tag, but cross-project imports must go through package entry points; `enforceBuildableLibDependency: true`).
+  - **`@nx/dependency-checks`** (on `*.json`, parsed with `jsonc-eslint-parser`) — keeps each package's `package.json` dependencies in sync with what the code imports. Ignores `nx` and spec/mock/config files.
+- Run: `pnpm nx lint <project>` or `pnpm nx affected -t lint`. lint-staged runs `lint --fix` on staged files automatically.
+
+## TypeScript
+
+Shared `compilerOptions` live in `tsconfig.base.json`; each package has `tsconfig.lib.json` (build) and `tsconfig.spec.json` (tests). Notable settings:
+
+- `target`/`lib`: **ES2022**; `module`: `commonjs`; `moduleResolution`: `node`.
+- **Strict-ish safety flags on:** `noImplicitOverride`, `noImplicitReturns`, `noUnusedLocals`, `noFallthroughCasesInSwitch`, `noEmitOnError`, `isolatedModules`.
+- **Project references** + `composite: true` with `emitDeclarationOnly` / `declarationMap` (build is driven by `@nx/js:tsc`).
+- `experimentalDecorators` + `emitDecoratorMetadata` enabled (used by data-migration).
+- `importHelpers: true` (tslib) — keep `tslib` as a dependency in packages that emit helpers.
+
+### Code conventions observed in the codebase
+
+- Single quotes, semicolons, trailing commas — let Prettier handle it.
+- Prefer named exports; `src/index.ts` is the package public surface (re-exports only).
+- Import Node built-ins with the **`node:` prefix** for new code (e.g. `import { join } from 'node:path'`) — see recent commits; older files use bare `path`/`fs`.
+- Use `@nx/devkit` helpers (`joinPathFragments`, `Tree`, `ExecutorContext`, `logger`) rather than hand-rolling path/IO logic where a devkit equivalent exists.
+- Executors return `{ success: boolean }` and catch errors, printing them with `chalk`.
+- Keep provider-specific logic behind the `BaseProvider` abstraction (see [PROJECT_ARCHITECTURE.md](PROJECT_ARCHITECTURE.md)); don't branch on package manager in executors/generators.
+- Define option/schema types next to each executor/generator (`schema.ts` / `schema.json`).
+
+## Commits
+
+- **Conventional Commits**, enforced by commitlint (`commitlint.config.js`, `@commitlint/config-conventional`; `body-max-line-length` disabled).
+- This is a Commitizen-friendly repo — `git add` then run `pnpm commit` (or `git commit` and follow the prompts). Scopes are usually the package name, e.g. `fix(nx-python): ...`.
+- Versioning and changelogs are derived from these commits at release time.

--- a/docs/PROJECT_ARCHITECTURE.md
+++ b/docs/PROJECT_ARCHITECTURE.md
@@ -1,0 +1,76 @@
+# Project Architecture — `@nxlv/python`
+
+`@nxlv/python` (`packages/nx-python`) is an Nx plugin that brings Python projects into an Nx workspace. It supports two Python package managers — **Poetry** and **uv** — behind a single abstraction, and exposes them to Nx through **executors**, **generators**, **migrations**, and a **dependency-inference plugin**. The package public surface is `src/index.ts`, which re-exports `./plugins/plugin`; `package.json` also exports `./release/version-actions`.
+
+## High-level layers
+
+```
+Nx (CLI / graph / release)
+        │
+        ▼
+executors.json / generators.json / migrations.json   ← manifests (point at ./dist/...)
+        │
+        ▼
+src/executors/*   src/generators/*   src/migrations/*   src/plugins/plugin.ts   src/release/*
+        │
+        └──────────────► src/provider (getProvider) ──────────► Poetry | uv implementations
+```
+
+Executors and generators almost never talk to Poetry/uv directly. They resolve a **provider** and call methods on it, so package-manager differences stay in one place.
+
+## Provider abstraction (`src/provider/`)
+
+- **`base.ts`** — `abstract class BaseProvider<TPyprojectToml>`. Defines the contract every provider implements: `checkPrerequisites`, `add`, `update`, `remove`, `install`, `build`, `lock`, `sync`, dependency/metadata reads, `getPyprojectToml`, `fileExists`, `getModulesFolders`, etc. It also defines shared domain types (`Dependency`, `PackageDependency`, `ProjectMetadata`, `SyncGeneratorResult`, …). The provider can operate on the real filesystem **or** on an Nx `Tree` (passed optionally to the constructor) — this is how the same logic serves both executors (runtime, real FS) and generators (virtual Tree).
+- **`resolver.ts`** — `getProvider(workspaceRoot, logger?, tree?, context?, options?)`. This is the single entry point used everywhere. Resolution order:
+  1. If a `Tree` is provided, `workspaceRoot` is normalized to `'.'` (relative paths in generators).
+  2. If the plugin option `packageManager` is set (`'poetry'` | `'uv'`), use that explicitly.
+  3. Otherwise auto-detect: inspect the project's `pyproject.toml` (via `context`) and/or the presence of `uv.lock` vs `poetry.lock`. Both lockfiles present → throws (ambiguous).
+  4. Defaults to Poetry when nothing else matches.
+- **`poetry/`** and **`uv/`** — each has `provider.ts` (the `BaseProvider` implementation), `types.ts` (`PoetryPyprojectToml` / `UVPyprojectToml`), `utils.ts` (e.g. `checkPoetryExecutable`, `checkUvExecutable`, version probing, TOML parsing), and `build/` for packaging.
+- **`utils.ts`** — shared TOML helpers: `getPyprojectData` (real FS) and `readPyprojectToml` (Tree-based).
+
+### Build sub-system (`provider/<pm>/build/`)
+
+`build/builder.ts` plus `build/resolvers/` (`project.ts`, `locked.ts`, `utils.ts`) handle assembling a buildable/publishable artifact — resolving dependencies either from the project definition or from the lockfile (locked versions), and optionally bundling local dependencies.
+
+## Executors (`src/executors/`, manifest `executors.json`)
+
+Thin async functions of the shape `executor(options, context) => { success }`. Each lives in its own folder with `executor.ts`, `schema.ts` (TS type), `schema.json` (Nx option schema), and a `executor.spec.ts`. The typical body: `process.chdir(context.root)`, `getProvider(...)`, call the matching provider method, catch errors and print with `chalk`.
+
+Available executors include: `add`, `remove`, `update`, `install`, `lock`, `sync`, `build`, `publish`, `flake8`, `ruff-check`, `ruff-format`, `tox`, `run-commands`, `sls-package`, `sls-deploy`, `package-project`, `package-dependencies`. Shared helpers live in `executors/utils/` (e.g. `Logger`).
+
+## Generators (`src/generators/`, manifest `generators.json`)
+
+Operate on the Nx `Tree`. Each folder has `generator.ts`, `schema.ts`/`schema.json`, a `files/` template directory, and tests in `generator.spec.ts` / `__test__/` with `__snapshots__/`. Key generators:
+
+- `poetry-project` / `uv-project` — scaffold a Python project for the respective manager (templates under `files/`: `base`, `pytest`, `flake8`, `standard`, `src-dir`).
+- `project` — legacy combined generator.
+- `migrate-to-shared-venv` — convert isolated venvs to a single shared venv.
+- `enable-releases` (hidden) — wire a Python project into Nx release.
+- `pkg-sync` — keep `pyproject.toml` dependencies in sync.
+
+## Dependency-inference plugin (`src/plugins/plugin.ts`)
+
+Implements Nx's `createDependencies` (and `createNodes`-style inference). When the plugin option `inferDependencies` is enabled, it scans each project's Python modules, builds module↔project maps, and parses `import`/`from` statements to add implicit/static/dynamic dependencies to the Nx project graph. Results are cached (`cachedScannedFiles`, `hashFile`). Plugin options are typed in `src/types.ts` (`PluginOptions = { packageManager?, inferDependencies? }`).
+
+Imports are parsed with **tree-sitter** (`extractImportedModules`) rather than a regular expression, so aliases (`import a as b`), multi-imports (`import a, b`) and relative imports are handled correctly and `import`-looking text inside comments/strings is ignored. The parser is loaded lazily and cached (`getPythonParser`) from the prebuilt WebAssembly grammar:
+
+- [`web-tree-sitter`](https://www.npmjs.com/package/web-tree-sitter) provides the WASM runtime.
+- [`tree-sitter-wasms`](https://www.npmjs.com/package/tree-sitter-wasms) ships the prebuilt `out/tree-sitter-python.wasm` grammar, resolved at runtime via `require.resolve`.
+
+We deliberately use the WASM runtime instead of the native `tree-sitter` Node bindings: the native addon does not build on Node.js 24 (see [tree-sitter/node-tree-sitter#268](https://github.com/tree-sitter/node-tree-sitter/issues/268)), whereas the WASM build needs no native compilation and works on every platform/Node version. The two versions must stay ABI-compatible — `tree-sitter-wasms` grammars are built with an older `tree-sitter-cli`, so `web-tree-sitter` is pinned to the matching `0.20.x` line.
+
+## Migrations (`src/migrations/`, manifest `migrations.json`)
+
+Nx migration generators (e.g. `update-16-1-0`) that run on `nx migrate` to update consuming workspaces between versions of the plugin.
+
+## Release integration (`src/release/version-actions.ts`)
+
+Exported via `@nxlv/python/release/version-actions`, this plugs Python projects into Nx's release/versioning pipeline so `pyproject.toml` versions are bumped alongside the JS packages.
+
+## Other packages (brief)
+
+- **`@nxlv/data-migration`** (`packages/data-migration`) — executors/generators plus a `migrator/` runtime for running data migrations (uses AWS SDK clients; decorators enabled).
+- **`@nxlv/util`** (`packages/util`) — small pure string helpers (`to-kebab-case`, `chunks`, `camel-case-to-title`, …), consumed by the other packages.
+
+See [WORKSPACE_STRUCTURE.md](WORKSPACE_STRUCTURE.md) for repo layout and [UNIT_TEST.md](UNIT_TEST.md) for how all of this is tested.

--- a/docs/UNIT_TEST.md
+++ b/docs/UNIT_TEST.md
@@ -1,0 +1,113 @@
+# Unit Testing
+
+Tests use **Vitest** and run through the Nx `@nx/vitest:test` executor. There are ~45 spec files, co-located with the code they test (`*.spec.ts` next to `*.ts`). The two dominant styles are **executor/provider tests** (mock the filesystem + child processes) and **generator tests** (drive an in-memory Nx `Tree`, assert with snapshots).
+
+## Running tests
+
+```bash
+pnpm nx test nx-python            # one project
+pnpm nx test util                 # another project
+pnpm nx affected --target=test    # only what changed (used in CI)
+```
+
+CI (`.github/workflows/ci.yml`) runs `pnpm nx affected -t lint test build`, then merges and uploads coverage. Coverage is on by default (v8 provider).
+
+## Configuration
+
+- **Root workspace:** `vitest.workspace.ts` aggregates every `packages/**/vite.config.ts`, sets `globals: true`, and loads the global setup file `tests/setup.ts`.
+- **Per package:** `packages/<pkg>/vitest.config.mts` defines `name`, `environment: 'node'`, `globals: true`, `watch: false`, the include glob `{src,tests}/**/*.{test,spec}.{js,mjs,cjs,ts,mts,cts,jsx,tsx}`, and coverage reporters (`text`, `html`, `cobertura`, `clover`, `json`, `json-summary`, `lcov`) written to `coverage/packages/<pkg>`.
+- **Global setup** (`tests/setup.ts`): registers the `aws-sdk-client-mock-vitest` custom matchers (`toHaveReceivedCommandWith`, etc.) used by data-migration's AWS tests.
+- `globals: true` means `describe`/`it`/`expect`/`beforeEach`/`vi` are available without imports (though specs usually still `import { vi } from 'vitest'`).
+- TypeScript for tests is configured by each package's `tsconfig.spec.json`.
+
+## Mocks (`packages/nx-python/src/utils/mocks/`)
+
+Reusable `vi.mock` modules — import them for their **side effects** at the top of a spec:
+
+```ts
+import '../../utils/mocks/cross-spawn.mock';
+import '../../utils/mocks/fs.mock';
+```
+
+- **`fs.mock.ts`** — replaces `fs`, `node:fs`, `fs/promises`, `node:fs/promises`, and `fs-extra` with **memfs** (an in-memory filesystem). It also polyfills recursive `cpSync`/`copySync`, `removeSync`, and `mkdirsSync`, which memfs lacks. Tests then seed files with `vol.fromJSON(...)` and reset with `vol.reset()`. Reads of `.wasm` files fall through to the **real** filesystem so the tree-sitter grammar (loaded by the dependency-inference plugin from `node_modules`) can be read even though the rest of the filesystem is in-memory.
+- **`cross-spawn.mock.ts`** — mocks `cross-spawn` so `spawn.sync` is a `vi.fn()`. Tests control external commands (`poetry`, `uv`, `python`) by setting the return value / implementation.
+- **`uuid.mock.ts`** — deterministic UUIDs.
+
+## Pattern A — executor / provider tests
+
+Example shape (`executors/add/executor.spec.ts`):
+
+```ts
+import { vi, MockInstance } from 'vitest';
+import { vol } from 'memfs';
+import '../../utils/mocks/cross-spawn.mock';
+import '../../utils/mocks/fs.mock';
+import * as poetryUtils from '../../provider/poetry/utils';
+import { PoetryProvider } from '../../provider/poetry/provider';
+import executor from './executor';
+import spawn from 'cross-spawn';
+
+describe('Add Executor', () => {
+  afterEach(() => {
+    vol.reset(); // wipe the in-memory FS
+    vi.resetAllMocks();
+  });
+
+  describe('poetry', () => {
+    beforeEach(() => {
+      vi.spyOn(poetryUtils, 'checkPoetryExecutable').mockResolvedValue(undefined);
+      vi.spyOn(poetryUtils, 'getPoetryVersion').mockResolvedValue('1.8.2');
+      vi.spyOn(PoetryProvider.prototype, 'activateVenv').mockResolvedValue(undefined);
+      vi.mocked(spawn.sync).mockReturnValue({ status: 0, output: [''], pid: 0, signal: null, stderr: null, stdout: null });
+      vi.spyOn(process, 'chdir').mockReturnValue(undefined);
+    });
+    // ... it('should ...') assertions on result.success and on what spawn.sync was called with
+  });
+});
+```
+
+Conventions:
+
+- Suites are split into `describe('poetry', ...)` and `describe('uv', ...)` since both providers share the executor.
+- `vi.spyOn(...Utils, 'check<Pm>Executable')` is mocked so tests don't need a real binary.
+- `process.chdir` is stubbed (executors `chdir` into the workspace root).
+- Assert behavior by inspecting `spawn.sync` calls (the actual `poetry`/`uv` command) and the resulting `pyproject.toml` content read back from memfs.
+- `dedent` (`string-dedent`) and `@iarna/toml` (`parse`/`stringify`) are used to build/compare TOML fixtures inline.
+
+## Pattern B — generator tests (Tree + snapshots)
+
+Example shape (`generators/uv-project/generator.spec.ts`):
+
+```ts
+import { createTreeWithEmptyWorkspace } from '@nx/devkit/testing';
+import { Tree, readProjectConfiguration, readNxJson } from '@nx/devkit';
+import generator from './generator';
+
+let appTree: Tree;
+beforeEach(() => {
+  vi.resetAllMocks();
+  appTree = createTreeWithEmptyWorkspace({ layout: 'apps-libs' });
+  vi.spyOn(uvUtils, 'checkUvExecutable').mockResolvedValue(undefined);
+  // spawn.sync stubbed to fake `python --version`, etc.
+});
+
+it('scaffolds the project', async () => {
+  await generator(appTree, options);
+  expect(readProjectConfiguration(appTree, 'test')).toMatchSnapshot();
+  expect(appTree.read('test/pyproject.toml', 'utf-8')).toMatchSnapshot();
+});
+```
+
+Conventions:
+
+- Use `createTreeWithEmptyWorkspace({ layout: 'apps-libs' })` for an in-memory Nx workspace — no real FS writes.
+- Read results with devkit helpers (`readProjectConfiguration`, `readNxJson`, `tree.read(path, 'utf-8')`, `tree.exists(path)`).
+- Generated files/config are verified with **`toMatchSnapshot()`**; snapshots live in `__snapshots__/` next to the spec (run `vitest -u` / `nx test <pkg> -- -u` to update them intentionally). Some generators keep additional fixtures under `__test__/` (e.g. `custom-template`).
+
+## Conventions checklist
+
+- Import the `vi.mock` side-effect modules **first**, before importing the unit under test.
+- Reset between tests: `vol.reset()` (FS) and `vi.resetAllMocks()` in `afterEach`/`beforeEach`.
+- Never hit a real `poetry`/`uv`/`python` binary or the real filesystem — mock the executable check and `cross-spawn`, use memfs or the Nx `Tree`.
+- Keep one spec per source file, co-located, named `*.spec.ts`.
+- `passWithNoTests` is enabled, so projects without tests don't fail the target.

--- a/docs/WORKSPACE_STRUCTURE.md
+++ b/docs/WORKSPACE_STRUCTURE.md
@@ -1,0 +1,59 @@
+# Workspace Structure
+
+This is an [Nx](https://nx.dev) monorepo managed with **pnpm workspaces** (`pnpm-workspace.yaml` points at `packages/*`). Nx version is pinned to `22.3.3`. Its primary purpose is to develop and publish the **`@nxlv/python`** Nx plugin.
+
+## Top-level layout
+
+```
+.
+├── packages/                 # all publishable projects + libraries (libsDir)
+│   ├── nx-python/            # @nxlv/python  — the main plugin
+│   ├── data-migration/       # @nxlv/data-migration — DynamoDB-style data migration plugin
+│   ├── util/                 # @nxlv/util — shared string utilities library
+│   └── data-migration-example/  # non-published example app (excluded from TS project refs/typecheck)
+├── e2e/                      # appsDir per nx.json workspaceLayout (end-to-end projects)
+├── tools/                    # workspace tooling/scripts
+├── tests/setup.ts            # global Vitest setup (registers aws-sdk-client-mock matchers)
+├── types/                    # ambient type declarations
+├── nx.json                   # Nx config: targetDefaults, plugins, release config
+├── tsconfig.base.json        # shared compilerOptions + project references
+├── eslint.config.mjs         # root ESLint flat config
+├── vitest.workspace.ts       # Vitest workspace aggregator
+└── release.base.config.js    # shared release config (sharedGlobals input)
+```
+
+`nx.json` sets `workspaceLayout` to `{ appsDir: "e2e", libsDir: "packages" }`.
+
+## Packages
+
+| Package                           | npm name               | Type      | Notes                                                                        |
+| --------------------------------- | ---------------------- | --------- | ---------------------------------------------------------------------------- |
+| `packages/nx-python`              | `@nxlv/python`         | Nx plugin | Executors, generators, migrations, inference plugin. The focus of this repo. |
+| `packages/data-migration`         | `@nxlv/data-migration` | Nx plugin | Migration executors/generators + a `migrator` runtime.                       |
+| `packages/util`                   | `@nxlv/util`           | library   | Small pure string helpers (kebab-case, chunks, etc.).                        |
+| `packages/data-migration-example` | (private)              | example   | Demonstrates `@nxlv/data-migration`; not released.                           |
+
+Each package contains: `package.json`, `project.json` (Nx targets), `tsconfig.json` / `tsconfig.lib.json` / `tsconfig.spec.json`, `eslint.config.mjs`, `src/`, `README.md`, and (for plugins) `executors.json` / `generators.json` / `migrations.json`.
+
+## Nx targets & caching
+
+Targets are inferred by Nx plugins (`@nx/js/typescript` for `build`/`typecheck`, `@nx/eslint/plugin` for `lint`) plus explicit `test` (`@nx/vitest:test`) in each `project.json`. `targetDefaults` in `nx.json` enables caching for `build`, `lint`, `test` and declares `dependsOn: ["^build"]` for builds. The `production` named input excludes spec/mock/test-setup files.
+
+## Tooling
+
+- **Package manager:** pnpm (lockfile `pnpm-lock.yaml`).
+- **Build:** `@nx/js:tsc` → emits to `packages/<pkg>/dist`, copying non-TS assets and the `*.json` plugin manifests.
+- **Husky** git hooks + **lint-staged** (`lint-staged.config.js`): runs affected lint `--fix` and `nx format:write` on staged files.
+- **Commitlint** (`commitlint.config.js`) + **Commitizen** (`.cz-config.js`) enforce Conventional Commits; commit with `pnpm commit`.
+- **EditorConfig** (`.editorconfig`): 2-space indent, UTF-8, final newline, trim trailing whitespace (off for Markdown).
+
+## Release
+
+Configured under `nx.json` `release`:
+
+- **Independent** project versioning (`projectsRelationship: "independent"`).
+- Versions derived from **Conventional Commits**.
+- Released projects: `nx-python`, `data-migration`, `util`.
+- Per-project GitHub changelogs/releases; tag pattern `{projectName}-v{version}`.
+- Release commit message: `chore: release [skip ci]`.
+- CI runs on push/PR to `main` (`.github/workflows/ci.yml`): format check → `nx affected -t lint test build` → coverage merge/upload. Publishing is a separate `manual-publish.yml` (`workflow_dispatch` → `nx release publish`).

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -33,6 +33,7 @@ export default [
         {
           ignoredFiles: [
             '{projectRoot}/src/**/*.{spec,test,mock}.ts',
+            '{projectRoot}/src/**/*.d.ts',
             '{projectRoot}/eslint.config.{js,cjs,mjs}',
             '{projectRoot}/vite.config.{js,ts,mjs,mts}',
             '{projectRoot}/vitest.config.{js,ts,mjs,mts}',

--- a/nx.json
+++ b/nx.json
@@ -6,6 +6,9 @@
       "inputs": ["production", "^production"],
       "cache": true
     },
+    "typecheck": {
+      "inputs": ["default", "^production"]
+    },
     "@nx/jest:jest": {
       "cache": true,
       "inputs": ["default", "^production", "{workspaceRoot}/jest.preset.js"],

--- a/packages/data-migration/src/aws-sdk-client-mock-matchers.d.ts
+++ b/packages/data-migration/src/aws-sdk-client-mock-matchers.d.ts
@@ -1,0 +1,16 @@
+// Type augmentation for the `aws-sdk-client-mock-vitest` custom matchers that
+// are registered at runtime in the global test setup (`tests/setup.ts`). This
+// teaches TypeScript about `toHaveReceivedCommandWith`, `toReceiveCommand`,
+// etc. so the spec files type-check. It is excluded from the library build
+// (see `tsconfig.lib.json`) so it never ships in the published package.
+//
+// The interfaces are intentionally empty (they only merge the matcher methods
+// into vitest's types) and `Assertion<T = any>` must mirror vitest's own
+// signature for declaration merging, so the relevant rules are disabled here.
+/* eslint-disable @typescript-eslint/no-empty-object-type, @typescript-eslint/no-empty-interface, @typescript-eslint/no-explicit-any */
+import type { CustomMatcher } from 'aws-sdk-client-mock-vitest';
+
+declare module 'vitest' {
+  interface Assertion<T = any> extends CustomMatcher<T> {}
+  interface AsymmetricMatchersContaining extends CustomMatcher {}
+}

--- a/packages/data-migration/src/migrator/__mocks__/condition-false/20230101-test1.ts
+++ b/packages/data-migration/src/migrator/__mocks__/condition-false/20230101-test1.ts
@@ -6,7 +6,7 @@ import { Migration, MigrationBase } from '../../..';
   name: 'test1',
 })
 export default class extends MigrationBase {
-  async condition() {
+  override async condition() {
     return false;
   }
 

--- a/packages/data-migration/src/migrator/__mocks__/condition-false/20230102-test2.ts
+++ b/packages/data-migration/src/migrator/__mocks__/condition-false/20230102-test2.ts
@@ -6,7 +6,7 @@ import { Migration, MigrationBase } from '../../..';
   name: 'test1',
 })
 export default class extends MigrationBase {
-  async condition() {
+  override async condition() {
     return false;
   }
 

--- a/packages/data-migration/src/migrator/__mocks__/condition-true/20230101-test1.ts
+++ b/packages/data-migration/src/migrator/__mocks__/condition-true/20230101-test1.ts
@@ -6,7 +6,7 @@ import { Migration, MigrationBase } from '../../..';
   name: 'test1',
 })
 export default class extends MigrationBase {
-  async condition(): Promise<boolean> {
+  override async condition(): Promise<boolean> {
     return true;
   }
 

--- a/packages/data-migration/src/migrator/__mocks__/condition-true/20230102-test2.ts
+++ b/packages/data-migration/src/migrator/__mocks__/condition-true/20230102-test2.ts
@@ -6,7 +6,7 @@ import { Migration, MigrationBase } from '../../..';
   name: 'test1',
 })
 export default class extends MigrationBase {
-  async condition(): Promise<boolean> {
+  override async condition(): Promise<boolean> {
     return true;
   }
 

--- a/packages/data-migration/src/migrator/dynamodb/migration.spec.ts
+++ b/packages/data-migration/src/migrator/dynamodb/migration.spec.ts
@@ -113,7 +113,7 @@ import { DynamoDBMigrationBase } from './migration';
 import path from 'path';
 
 class AwsErrorMock extends Error {
-  constructor(public name: string) {
+  constructor(public override name: string) {
     super(name);
   }
 }

--- a/packages/data-migration/src/migrator/remote/ecs.spec.ts
+++ b/packages/data-migration/src/migrator/remote/ecs.spec.ts
@@ -69,7 +69,7 @@ import { LifecycleHook } from '../types';
 import path from 'path';
 
 class AwsErrorMock extends Error {
-  constructor(public name: string) {
+  constructor(public override name: string) {
     super(name);
   }
 }

--- a/packages/data-migration/tsconfig.lib.json
+++ b/packages/data-migration/tsconfig.lib.json
@@ -14,7 +14,8 @@
     "vite.config.ts",
     "src/**/*.spec.ts",
     "src/**/*.test.ts",
-    "src/**/__mocks__/**/*.ts"
+    "src/**/__mocks__/**/*.ts",
+    "src/aws-sdk-client-mock-matchers.d.ts"
   ],
   "references": [
     {

--- a/packages/nx-python/package.json
+++ b/packages/nx-python/package.json
@@ -30,20 +30,23 @@
     "directory": "packages/nx-python"
   },
   "dependencies": {
-    "tslib": "^2.3.0",
-    "chalk": "^4.1.1",
-    "fs-extra": "^11.1.0",
     "@iarna/toml": "^2.2.5",
-    "uuid": "^9.0.0",
-    "file-uri-to-path": "^2.0.0",
-    "cross-spawn": "^7.0.3",
-    "command-exists": "^1.2.9",
-    "lodash": "^4.17.21",
     "@nx/devkit": "^22.0.0",
-    "semver": "^7.5.3",
+    "@renovatebot/pep440": "^5.0.0",
     "archiver": "^7.0.0",
+    "chalk": "^4.1.1",
+    "command-exists": "^1.2.9",
+    "cross-spawn": "^7.0.3",
+    "file-uri-to-path": "^2.0.0",
+    "fs-extra": "^11.1.0",
+    "glob": "^10.3.10",
+    "lodash": "^4.17.21",
     "minimatch": "^10.0.3",
-    "glob": "^10.3.10"
+    "semver": "^7.5.3",
+    "tree-sitter-wasms": "^0.1.13",
+    "tslib": "^2.3.0",
+    "uuid": "^9.0.0",
+    "web-tree-sitter": "^0.20.8"
   },
   "nx-migrations": {
     "migrations": "./migrations.json"

--- a/packages/nx-python/src/plugins/infer.spec.ts
+++ b/packages/nx-python/src/plugins/infer.spec.ts
@@ -1,0 +1,112 @@
+import dedent from 'string-dedent';
+import type Parser from 'web-tree-sitter';
+import { extractImportedModules, getPythonParser } from './infer';
+
+describe('infer', () => {
+  let parser: Parser;
+
+  beforeAll(async () => {
+    parser = await getPythonParser();
+  });
+
+  describe('getPythonParser', () => {
+    it('should return the same cached parser instance', async () => {
+      const first = await getPythonParser();
+      const second = await getPythonParser();
+
+      expect(first).toBe(second);
+    });
+  });
+
+  describe('extractImportedModules', () => {
+    it('should extract a simple import', () => {
+      expect(extractImportedModules(parser, 'import foo')).toStrictEqual([
+        'foo',
+      ]);
+    });
+
+    it('should return the top-level module for dotted imports', () => {
+      expect(
+        extractImportedModules(parser, 'import foo.bar.baz'),
+      ).toStrictEqual(['foo']);
+    });
+
+    it('should extract the module of a `from ... import ...` statement', () => {
+      expect(
+        extractImportedModules(parser, 'from foo.bar import baz'),
+      ).toStrictEqual(['foo']);
+    });
+
+    it('should unwrap aliased imports', () => {
+      expect(
+        extractImportedModules(parser, 'import foo.bar as qux'),
+      ).toStrictEqual(['foo']);
+    });
+
+    it('should extract every module of a multi-import statement', () => {
+      expect(
+        extractImportedModules(parser, 'import foo, bar.baz as qux, quux'),
+      ).toStrictEqual(['foo', 'bar', 'quux']);
+    });
+
+    it('should ignore relative imports', () => {
+      const content = dedent`
+        from . import sibling
+        from .module import thing
+        from ..package import other
+      `;
+
+      expect(extractImportedModules(parser, content)).toStrictEqual([]);
+    });
+
+    it('should ignore import-looking text in comments and strings', () => {
+      const content = dedent`
+        # import commented
+        example = "import quoted"
+        another = 'from quoted import thing'
+      `;
+
+      expect(extractImportedModules(parser, content)).toStrictEqual([]);
+    });
+
+    it('should detect imports nested inside functions and blocks', () => {
+      const content = dedent`
+        def handler():
+            import nested
+
+        try:
+            from deferred.module import thing
+        except ImportError:
+            pass
+      `;
+
+      expect(extractImportedModules(parser, content)).toStrictEqual([
+        'nested',
+        'deferred',
+      ]);
+    });
+
+    it('should preserve source order and keep duplicates', () => {
+      const content = dedent`
+        import first
+        from second.sub import x
+        import first
+      `;
+
+      expect(extractImportedModules(parser, content)).toStrictEqual([
+        'first',
+        'second',
+        'first',
+      ]);
+    });
+
+    it('should return an empty array for files without imports', () => {
+      const content = dedent`
+        def add(a, b):
+            return a + b
+      `;
+
+      expect(extractImportedModules(parser, content)).toStrictEqual([]);
+    });
+  });
+});

--- a/packages/nx-python/src/plugins/infer.ts
+++ b/packages/nx-python/src/plugins/infer.ts
@@ -1,0 +1,112 @@
+import Parser from 'web-tree-sitter';
+
+let pythonParserPromise: Promise<Parser> | undefined;
+
+/**
+ * Lazily create (and cache) a tree-sitter parser configured for Python.
+ *
+ * The grammar is loaded from the prebuilt WebAssembly binary shipped by
+ * `tree-sitter-wasms`, which avoids the native-build issues that the
+ * `tree-sitter` Node bindings have on newer Node.js versions while still
+ * giving us a proper parser instead of a regular expression.
+ *
+ * The native bindings fail to build on Node.js 24, see
+ * https://github.com/tree-sitter/node-tree-sitter/issues/268
+ */
+export function getPythonParser(): Promise<Parser> {
+  if (!pythonParserPromise) {
+    pythonParserPromise = (async () => {
+      await Parser.init();
+      const language = await Parser.Language.load(
+        require.resolve('tree-sitter-wasms/out/tree-sitter-python.wasm'),
+      );
+      const parser = new Parser();
+      parser.setLanguage(language);
+      return parser;
+    })();
+  }
+  return pythonParserPromise;
+}
+
+/**
+ * Resolve the first `dotted_name` node within an import child, unwrapping
+ * `aliased_import` nodes (`import foo.bar as baz`) when needed.
+ */
+function getDottedName(node: Parser.SyntaxNode): Parser.SyntaxNode | undefined {
+  if (node.type === 'dotted_name') {
+    return node;
+  }
+  for (let i = 0; i < node.namedChildCount; i++) {
+    const child = node.namedChild(i);
+    if (child?.type === 'dotted_name') {
+      return child;
+    }
+  }
+  return undefined;
+}
+
+/**
+ * Return the top-level module name of a `dotted_name` node (the first
+ * identifier), e.g. `foo` for both `foo` and `foo.bar.baz`.
+ */
+function getTopLevelModule(dottedName: Parser.SyntaxNode): string | undefined {
+  for (let i = 0; i < dottedName.namedChildCount; i++) {
+    const child = dottedName.namedChild(i);
+    if (child?.type === 'identifier') {
+      return child.text;
+    }
+  }
+  return undefined;
+}
+
+/**
+ * Parse a Python source file with tree-sitter and return the top-level module
+ * name of every import, in source order.
+ *
+ * - `import foo.bar` and `from foo.bar import baz` both yield `foo`.
+ * - `import foo, bar` yields both `foo` and `bar`.
+ * - Relative imports (`from . import x`) are ignored since they can never
+ *   reference another local project.
+ */
+export function extractImportedModules(
+  parser: Parser,
+  content: string,
+): string[] {
+  const tree = parser.parse(content);
+  const modules: string[] = [];
+
+  for (const node of tree.rootNode.descendantsOfType([
+    'import_statement',
+    'import_from_statement',
+  ])) {
+    if (node.type === 'import_from_statement') {
+      const moduleName = node.childForFieldName('module_name');
+      // `relative_import` nodes (e.g. `from . import x`) are skipped.
+      if (moduleName?.type === 'dotted_name') {
+        const module = getTopLevelModule(moduleName);
+        if (module) {
+          modules.push(module);
+        }
+      }
+      continue;
+    }
+
+    // `import_statement` can hold several `dotted_name` / `aliased_import`
+    // children (e.g. `import foo, bar.baz as qux`).
+    for (let i = 0; i < node.namedChildCount; i++) {
+      const child = node.namedChild(i);
+      if (!child) {
+        continue;
+      }
+      const dottedName = getDottedName(child);
+      if (dottedName) {
+        const module = getTopLevelModule(dottedName);
+        if (module) {
+          modules.push(module);
+        }
+      }
+    }
+  }
+
+  return modules;
+}

--- a/packages/nx-python/src/plugins/infer.ts
+++ b/packages/nx-python/src/plugins/infer.ts
@@ -60,6 +60,37 @@ function getTopLevelModule(dottedName: Parser.SyntaxNode): string | undefined {
 }
 
 /**
+ * Top-level module of a `from ... import ...` statement, or `undefined` for
+ * relative imports (e.g. `from . import x`) which can never reference another
+ * local project.
+ */
+function getFromImportModule(node: Parser.SyntaxNode): string | undefined {
+  const moduleName = node.childForFieldName('module_name');
+  // `relative_import` nodes (e.g. `from . import x`) are skipped.
+  if (moduleName?.type !== 'dotted_name') {
+    return undefined;
+  }
+  return getTopLevelModule(moduleName);
+}
+
+/**
+ * Top-level modules of an `import ...` statement, which can hold several
+ * `dotted_name` / `aliased_import` children (e.g. `import foo, bar.baz as qux`).
+ */
+function getPlainImportModules(node: Parser.SyntaxNode): string[] {
+  const modules: string[] = [];
+  for (let i = 0; i < node.namedChildCount; i++) {
+    const child = node.namedChild(i);
+    const dottedName = child ? getDottedName(child) : undefined;
+    const module = dottedName ? getTopLevelModule(dottedName) : undefined;
+    if (module) {
+      modules.push(module);
+    }
+  }
+  return modules;
+}
+
+/**
  * Parse a Python source file with tree-sitter and return the top-level module
  * name of every import, in source order.
  *
@@ -80,31 +111,12 @@ export function extractImportedModules(
     'import_from_statement',
   ])) {
     if (node.type === 'import_from_statement') {
-      const moduleName = node.childForFieldName('module_name');
-      // `relative_import` nodes (e.g. `from . import x`) are skipped.
-      if (moduleName?.type === 'dotted_name') {
-        const module = getTopLevelModule(moduleName);
-        if (module) {
-          modules.push(module);
-        }
+      const module = getFromImportModule(node);
+      if (module) {
+        modules.push(module);
       }
-      continue;
-    }
-
-    // `import_statement` can hold several `dotted_name` / `aliased_import`
-    // children (e.g. `import foo, bar.baz as qux`).
-    for (let i = 0; i < node.namedChildCount; i++) {
-      const child = node.namedChild(i);
-      if (!child) {
-        continue;
-      }
-      const dottedName = getDottedName(child);
-      if (dottedName) {
-        const module = getTopLevelModule(dottedName);
-        if (module) {
-          modules.push(module);
-        }
-      }
+    } else {
+      modules.push(...getPlainImportModules(node));
     }
   }
 

--- a/packages/nx-python/src/plugins/plugin.spec.ts
+++ b/packages/nx-python/src/plugins/plugin.spec.ts
@@ -554,6 +554,136 @@ describe('nx-python dependency graph', () => {
           },
         ]);
       });
+
+      it('should parse imports with tree-sitter (multi-imports, aliases, ignoring comments and strings)', async () => {
+        vol.fromJSON({
+          'apps/app1/pyproject.toml': dedent`
+          [tool.poetry]
+          name = "app1"
+          version = "1.0.0"
+            [[tool.poetry.packages]]
+            include = "app1"
+
+            [tool.poetry.dependencies]
+            python = "^3.8"
+          `,
+          'apps/app1/app1/imports.py': dedent`
+          import dep1, dep2.submod
+          import dep3 as renamed
+          # import dep4
+          example = "import dep4"
+          `,
+
+          'libs/dep1/pyproject.toml': dedent`
+          [tool.poetry]
+          name = "dep1"
+          version = "1.0.0"
+            [[tool.poetry.packages]]
+            include = "dep1"
+
+            [tool.poetry.dependencies]
+            python = "^3.8"
+          `,
+          'libs/dep2/pyproject.toml': dedent`
+          [tool.poetry]
+          name = "dep2"
+          version = "1.0.0"
+            [[tool.poetry.packages]]
+            include = "dep2"
+
+            [tool.poetry.dependencies]
+            python = "^3.8"
+          `,
+          'libs/dep3/pyproject.toml': dedent`
+          [tool.poetry]
+          name = "dep3"
+          version = "1.0.0"
+            [[tool.poetry.packages]]
+            include = "dep3"
+
+            [tool.poetry.dependencies]
+            python = "^3.8"
+          `,
+          'libs/dep4/pyproject.toml': dedent`
+          [tool.poetry]
+          name = "dep4"
+          version = "1.0.0"
+            [[tool.poetry.packages]]
+            include = "dep4"
+
+            [tool.poetry.dependencies]
+            python = "^3.8"
+          `,
+        });
+
+        const projects = {
+          app1: {
+            root: 'apps/app1',
+            targets: {},
+          },
+          dep1: {
+            root: 'libs/dep1',
+            targets: {},
+          },
+          dep2: {
+            root: 'libs/dep2',
+            targets: {},
+          },
+          dep3: {
+            root: 'libs/dep3',
+            targets: {},
+          },
+          dep4: {
+            root: 'libs/dep4',
+            targets: {},
+          },
+        };
+
+        const result = await createDependencies(
+          {
+            inferDependencies: true,
+          },
+          {
+            externalNodes: {},
+            workspaceRoot: '.',
+            projects,
+            nxJsonConfiguration: {},
+            fileMap: {
+              nonProjectFiles: [],
+              projectFileMap: {},
+            },
+            filesToProcess: {
+              nonProjectFiles: [],
+              projectFileMap: {},
+            },
+          },
+        );
+
+        // `dep1` and `dep2` come from a single multi-import statement, `dep3`
+        // from an aliased import. `dep4` only appears in a comment and a
+        // string literal, so the tree-sitter parser correctly ignores it
+        // (unlike the previous regex-based approach).
+        expect(result).toStrictEqual([
+          {
+            source: 'app1',
+            target: 'dep1',
+            type: 'dynamic',
+            sourceFile: 'apps/app1/app1/imports.py',
+          },
+          {
+            source: 'app1',
+            target: 'dep2',
+            type: 'dynamic',
+            sourceFile: 'apps/app1/app1/imports.py',
+          },
+          {
+            source: 'app1',
+            target: 'dep3',
+            type: 'dynamic',
+            sourceFile: 'apps/app1/app1/imports.py',
+          },
+        ]);
+      });
     });
   });
 

--- a/packages/nx-python/src/plugins/plugin.ts
+++ b/packages/nx-python/src/plugins/plugin.ts
@@ -13,10 +13,9 @@ import { join } from 'node:path';
 import { hashFile } from 'nx/src/hasher/file-hasher';
 import { readFile } from 'node:fs/promises';
 import fs from 'node:fs';
+import { extractImportedModules, getPythonParser } from './infer';
 
 const cachedScannedFiles: Record<string, [string, string][]> = {};
-
-const IMPORT_REGEX = /(?:import|from)\s+([a-zA-Z_][\w]*)/g;
 
 export const createDependencies: CreateDependencies<PluginOptions> = async (
   options,
@@ -73,6 +72,8 @@ export const createDependencies: CreateDependencies<PluginOptions> = async (
 
       logger.verbose(`[${project}] Scanning ${filesToScan.length} files`);
 
+      const parser = await getPythonParser();
+
       await Promise.all(
         filesToScan.map(async ([file, hash]) => {
           const hashKey = `${file}-${hash}`;
@@ -92,8 +93,7 @@ export const createDependencies: CreateDependencies<PluginOptions> = async (
           } else {
             const content = await readFile(file, { encoding: 'utf-8' });
             const fileModules: [string, string][] = [];
-            for (const match of content.matchAll(IMPORT_REGEX)) {
-              const module = match[1].trim();
+            for (const module of extractImportedModules(parser, content)) {
               fileModules.push([file, module]);
               logger.verbose(`[${project}] [${file}] Found module: ${module}`);
               if (moduleProjectMap.has(module)) {

--- a/packages/nx-python/src/provider/base.spec.ts
+++ b/packages/nx-python/src/provider/base.spec.ts
@@ -1,5 +1,6 @@
 import { BaseProvider } from './base';
 import { PoetryProvider } from './poetry';
+import { PoetryPyprojectToml } from './poetry/types';
 import { Logger } from '../executors/utils/logger';
 import chalk from 'chalk';
 import { ExecutorContext } from '@nx/devkit';
@@ -8,7 +9,7 @@ import path from 'path';
 
 describe('Activate Venv', () => {
   const originalEnv = process.env;
-  let provider: BaseProvider;
+  let provider: BaseProvider<PoetryPyprojectToml>;
   let installMock: MockInstance;
 
   beforeAll(() => {

--- a/packages/nx-python/src/provider/base.ts
+++ b/packages/nx-python/src/provider/base.ts
@@ -57,7 +57,27 @@ export type SyncGeneratorResult = {
   outOfSyncMessage: string;
 };
 
+/**
+ * Base class shared by the Poetry and uv providers. It abstracts away the
+ * package-manager specific behavior (resolving metadata, managing dependencies,
+ * locking, building, publishing, etc.) behind a common interface, while
+ * providing a few filesystem helpers that transparently work against either a
+ * real filesystem or an in-memory Nx {@link Tree}.
+ *
+ * @typeParam TPyprojectToml - The provider specific shape of `pyproject.toml`.
+ */
 export abstract class BaseProvider<TPyprojectToml> {
+  /**
+   * @param workspaceRoot - Absolute path to the workspace root.
+   * @param logger - Logger used to surface progress messages to the user.
+   * @param isWorkspace - Whether the provider operates on a shared workspace
+   *   (single root lock file) rather than per-project environments.
+   * @param lockFileName - The lock file name used by the package manager (e.g.
+   *   `uv.lock` or `poetry.lock`).
+   * @param tree - Optional Nx {@link Tree}. When provided, file reads/writes go
+   *   through the in-memory tree (generators); otherwise the real filesystem is
+   *   used (executors).
+   */
   constructor(
     protected readonly workspaceRoot: string,
     protected readonly logger: Logger,
@@ -66,8 +86,19 @@ export abstract class BaseProvider<TPyprojectToml> {
     protected readonly tree?: Tree,
   ) {}
 
+  /**
+   * Ensures the package manager executable (and any other prerequisite) is
+   * available before running a command. Throws if a prerequisite is missing.
+   */
   abstract checkPrerequisites(): Promise<void>;
 
+  /**
+   * Reads and parses the `pyproject.toml` of a project, using the in-memory
+   * {@link Tree} when available and falling back to the real filesystem.
+   *
+   * @param projectRoot - Project root containing the `pyproject.toml`.
+   * @returns The parsed `pyproject.toml` contents.
+   */
   public getPyprojectToml(projectRoot: string): TPyprojectToml {
     const pyprojectTomlPath = joinPathFragments(projectRoot, 'pyproject.toml');
     return this.tree
@@ -75,93 +106,242 @@ export abstract class BaseProvider<TPyprojectToml> {
       : getPyprojectData<TPyprojectToml>(pyprojectTomlPath);
   }
 
+  /**
+   * Checks whether a file exists, using the in-memory {@link Tree} when
+   * available and falling back to the real filesystem.
+   *
+   * @param path - Path to check.
+   */
   public fileExists(path: string): boolean {
     return this.tree ? this.tree.exists(path) : fs.existsSync(path);
   }
 
+  /**
+   * Resolves a project's own name and version from its manifest.
+   *
+   * @param projectRoot - Project root containing the `pyproject.toml`.
+   */
   abstract getMetadata(projectRoot: string): ProjectMetadata;
 
+  /**
+   * Resolves the name, version and dependency group of a local dependency of a
+   * project.
+   *
+   * @param projectRoot - Root of the project that declares the dependency.
+   * @param dependencyName - Name of the dependency to resolve.
+   * @returns The dependency metadata, or `null` when it cannot be resolved.
+   */
   abstract getDependencyMetadata(
     projectRoot: string,
     dependencyName: string,
   ): DependencyProjectMetadata | null;
 
+  /**
+   * Writes a new version into a project's manifest.
+   *
+   * @param projectRoot - Project root containing the `pyproject.toml`.
+   * @param newVersion - The version to write.
+   */
   abstract updateVersion(projectRoot: string, newVersion: string): void;
 
+  /**
+   * Updates the version specifiers of local workspace dependencies within a
+   * project's manifest so they reference the newly released versions.
+   *
+   * `dependencyVersions` is keyed by the dependency package name and maps to its
+   * new version. Implementations should only rewrite dependencies that carry an
+   * explicit version specifier and return a log message for each manifest that
+   * was changed.
+   */
+  abstract updateDependencyVersions(
+    projectRoot: string,
+    dependencyVersions: Record<string, string>,
+  ): string[];
+
+  /**
+   * Resolves the local workspace dependencies of a project from its manifest.
+   *
+   * @param projectName - Name of the project whose dependencies are resolved.
+   * @param projects - Map of all project configurations in the workspace.
+   * @param cwd - Working directory used to resolve relative dependency paths.
+   * @returns The list of local dependencies (name, category and version).
+   */
   abstract getDependencies(
     projectName: string,
     projects: Record<string, ProjectConfiguration>,
     cwd: string,
   ): Dependency[];
 
+  /**
+   * Returns the source/module folders of a project (e.g. the package
+   * directories), used when copying source into a build artifact.
+   *
+   * @param projectRoot - Project root containing the `pyproject.toml`.
+   */
   abstract getModulesFolders(projectRoot: string): string[];
 
+  /**
+   * Resolves the projects that depend on a given project (its dependents).
+   *
+   * @param projectName - Name of the project whose dependents are resolved.
+   * @param projects - Map of all project configurations in the workspace.
+   * @param cwd - Working directory used to resolve relative dependency paths.
+   * @returns The names of the dependent projects.
+   */
   abstract getDependents(
     projectName: string,
     projects: Record<string, ProjectConfiguration>,
     cwd: string,
   ): string[];
 
+  /**
+   * Exports a project's resolved dependencies to a `requirements.txt` file.
+   *
+   * @param cwd - Project directory to export from.
+   * @param extras - Optional extras to include in the export.
+   * @param outputPath - Optional output path (defaults to `requirements.txt`).
+   * @returns The path to the written requirements file.
+   */
   abstract writeProjectRequirementsTxt(
     cwd: string,
     extras?: string[],
     outputPath?: string,
   ): Promise<string>;
 
+  /**
+   * Adds a dependency to a project (external package or local project).
+   *
+   * @param options - Add executor options (name, group, extras, local, etc.).
+   * @param context - The Nx executor context.
+   */
   abstract add(
     options: AddExecutorSchema,
     context: ExecutorContext,
   ): Promise<void>;
 
+  /**
+   * Nx sync generator that keeps a project's manifest in sync with the
+   * dependencies inferred from the project graph, returning the callbacks and
+   * out-of-sync message Nx uses to apply and report the changes.
+   *
+   * @param projectName - Name of the project being synced.
+   * @param missingDependencies - Dependencies missing from the manifest.
+   * @param context - The Nx executor context.
+   */
   abstract syncGenerator(
     projectName: string,
     missingDependencies: string[],
     context: ExecutorContext,
   ): Promise<SyncGeneratorResult>;
 
+  /**
+   * Updates dependencies of a project to newer versions.
+   *
+   * @param options - Update executor options (name, group, args, etc.).
+   * @param context - The Nx executor context.
+   */
   abstract update(
     options: UpdateExecutorSchema,
     context: ExecutorContext,
   ): Promise<void>;
 
+  /**
+   * Removes a dependency from a project.
+   *
+   * @param options - Remove executor options (name, etc.).
+   * @param context - The Nx executor context.
+   */
   abstract remove(
     options: RemoveExecutorSchema,
     context: ExecutorContext,
   ): Promise<void>;
 
+  /**
+   * Publishes a project's built distribution to a package repository.
+   *
+   * @param options - Publish executor options (repository, args, etc.).
+   * @param context - The Nx executor context.
+   */
   abstract publish(
     options: PublishExecutorSchema,
     context: ExecutorContext,
   ): Promise<void>;
 
+  /**
+   * Installs a project's dependencies / creates its virtual environment.
+   *
+   * @param options - Install executor options.
+   * @param context - The Nx executor context.
+   */
   abstract install(
     options?: InstallExecutorSchema,
     context?: ExecutorContext,
   ): Promise<void>;
 
+  /**
+   * Installs dependencies for the project rooted at `cwd`.
+   *
+   * @param cwd - Directory whose dependencies should be installed.
+   */
   abstract install(cwd?: string): Promise<void>;
 
+  /**
+   * Regenerates the lock file from executor options/context.
+   *
+   * @param options - Lock executor options.
+   * @param context - The Nx executor context.
+   */
   abstract lock(
     options?: LockExecutorSchema,
     context?: ExecutorContext,
   ): Promise<void>;
 
+  /**
+   * Regenerates the lock file for a specific project.
+   *
+   * @param projectRoot - Project root to lock.
+   * @param update - Whether to update dependencies while locking.
+   * @param args - Additional arguments to pass to the lock command.
+   */
   abstract lock(
     projectRoot?: string,
     update?: boolean,
     args?: string[] | string,
   ): Promise<void>;
 
+  /**
+   * Returns the shell command used to lock the given project, without running
+   * it (used to display or compose commands).
+   *
+   * @param projectRoot - Project root to lock.
+   * @param update - Whether to update dependencies while locking.
+   */
   abstract getLockCommand(
     projectRoot?: string,
     update?: boolean,
   ): Promise<string>;
 
+  /**
+   * Synchronizes the environment with the lock file (installs the exact locked
+   * versions).
+   *
+   * @param options - Sync executor options.
+   * @param context - The Nx executor context.
+   */
   abstract sync(
     options?: SyncExecutorSchema,
     context?: ExecutorContext,
   ): Promise<void>;
 
+  /**
+   * Builds a project's distribution, resolving and (optionally) bundling local
+   * dependencies into the build folder.
+   *
+   * @param options - Build executor options, plus an optional `buildFolder`
+   *   override and a `skipBuild` flag.
+   * @param context - The Nx executor context.
+   * @returns The path to the build output folder.
+   */
   abstract build(
     options: BuildExecutorSchema & {
       buildFolder?: string;
@@ -170,8 +350,24 @@ export abstract class BaseProvider<TPyprojectToml> {
     context: ExecutorContext,
   ): Promise<string>;
 
+  /**
+   * Returns the shell command used to run the given arguments within the
+   * project's environment, without running it.
+   *
+   * @param args - Arguments to run.
+   */
   abstract getRunCommand(args: string[]): Promise<string>;
 
+  /**
+   * Runs a command within the project's environment.
+   *
+   * @param args - Arguments to run.
+   * @param workspaceRoot - Workspace root the command runs from.
+   * @param options - Logging flags merged with `spawnSync` options.
+   * @param installIfNotExists - Whether to create the environment first if it
+   *   does not yet exist.
+   * @param context - The Nx executor context.
+   */
   abstract run(
     args: string[],
     workspaceRoot: string,
@@ -183,6 +379,17 @@ export abstract class BaseProvider<TPyprojectToml> {
     context?: ExecutorContext,
   ): Promise<void>;
 
+  /**
+   * Activates the project/workspace virtual environment for the current process
+   * when one is not already active. For shared workspaces it honors the
+   * `tool.nx.autoActivate` setting in the root `pyproject.toml`, and when
+   * `installIfNotExists` is set it creates the environment first if needed.
+   *
+   * @param workspaceRoot - Workspace root used to locate the environment.
+   * @param installIfNotExists - Whether to create the environment if missing.
+   * @param context - The Nx executor context (required outside a workspace when
+   *   `installIfNotExists` is set).
+   */
   public async activateVenv(
     workspaceRoot: string,
     installIfNotExists = false,
@@ -233,6 +440,13 @@ export abstract class BaseProvider<TPyprojectToml> {
     }
   }
 
+  /**
+   * Points the current process at the given virtual environment by setting
+   * `VIRTUAL_ENV`, prepending its `bin` directory to `PATH`, and clearing
+   * `PYTHONHOME`.
+   *
+   * @param virtualEnvPath - Absolute path to the virtual environment.
+   */
   private setVenvEnvironmentVariables(virtualEnvPath: string) {
     process.env.VIRTUAL_ENV = virtualEnvPath;
     process.env.PATH = `${virtualEnvPath}/bin:${process.env.PATH}`;

--- a/packages/nx-python/src/provider/poetry/provider.spec.ts
+++ b/packages/nx-python/src/provider/poetry/provider.spec.ts
@@ -1,0 +1,42 @@
+import { vi } from 'vitest';
+import { vol } from 'memfs';
+import '../../utils/mocks/cross-spawn.mock';
+import '../../utils/mocks/fs.mock';
+import dedent from 'string-dedent';
+import { PoetryProvider } from './provider';
+import { Logger } from '../../executors/utils/logger';
+
+describe('PoetryProvider', () => {
+  let provider: PoetryProvider;
+
+  beforeEach(() => {
+    provider = new PoetryProvider('.', new Logger());
+  });
+
+  afterEach(() => {
+    vol.reset();
+    vi.resetAllMocks();
+  });
+
+  describe('updateDependencyVersions', () => {
+    it('is a no-op and never rewrites the manifest', () => {
+      const manifest = dedent`
+        [tool.poetry]
+        name = "app1"
+        version = "1.3.0"
+
+        [tool.poetry.dependencies]
+        python = ">=3.9,<4"
+        lib1 = { path = "../lib1", develop = true }
+      `;
+      vol.fromJSON({ 'apps/app1/pyproject.toml': manifest });
+
+      const result = provider.updateDependencyVersions();
+
+      expect(result).toEqual([]);
+      expect(vol.readFileSync('apps/app1/pyproject.toml', 'utf-8')).toBe(
+        manifest,
+      );
+    });
+  });
+});

--- a/packages/nx-python/src/provider/poetry/provider.ts
+++ b/packages/nx-python/src/provider/poetry/provider.ts
@@ -116,6 +116,14 @@ export class PoetryProvider extends BaseProvider<PoetryPyprojectToml> {
     }
   }
 
+  public updateDependencyVersions(): string[] {
+    // Poetry references local workspace dependencies via `path`/`develop`, which
+    // cannot carry a version specifier (path and version are mutually exclusive
+    // in Poetry). The published version is injected at build time from the
+    // dependency's own pyproject.toml, so there is nothing to rewrite here.
+    return [];
+  }
+
   public getDependencyMetadata(
     projectRoot: string,
     dependencyName: string,

--- a/packages/nx-python/src/provider/uv/provider.spec.ts
+++ b/packages/nx-python/src/provider/uv/provider.spec.ts
@@ -1,0 +1,129 @@
+import { vi } from 'vitest';
+import { vol } from 'memfs';
+import '../../utils/mocks/cross-spawn.mock';
+import '../../utils/mocks/fs.mock';
+import dedent from 'string-dedent';
+import { UVProvider } from './provider';
+import { Logger } from '../../executors/utils/logger';
+
+describe('UVProvider', () => {
+  let provider: UVProvider;
+
+  beforeEach(() => {
+    provider = new UVProvider('.', new Logger());
+  });
+
+  afterEach(() => {
+    vol.reset();
+    vi.resetAllMocks();
+  });
+
+  describe('updateDependencyVersions', () => {
+    it('returns an empty array when there are no dependencies to update', () => {
+      vol.fromJSON({
+        'apps/app1/pyproject.toml': dedent`
+          [project]
+          name = "app1"
+          version = "1.3.0"
+          dependencies = [ "lib1~=1.1" ]
+
+          [tool.uv.sources.lib1]
+          workspace = true
+        `,
+      });
+
+      const result = provider.updateDependencyVersions('apps/app1', {});
+
+      expect(result).toEqual([]);
+    });
+
+    it('rewrites version ranges across main, optional and group dependencies', () => {
+      vol.fromJSON({
+        'apps/app1/pyproject.toml': dedent`
+          [project]
+          name = "app1"
+          version = "1.3.0"
+          dependencies = [ "lib1~=1.1", "lib2>=1.2,<2.0", "requests>=2.0" ]
+
+          [project.optional-dependencies]
+          extra = [ "lib3==1.0.0" ]
+
+          [dependency-groups]
+          dev = [ "lib4~=1.0" ]
+
+          [tool.uv.sources.lib1]
+          workspace = true
+          [tool.uv.sources.lib2]
+          workspace = true
+          [tool.uv.sources.lib3]
+          workspace = true
+          [tool.uv.sources.lib4]
+          workspace = true
+        `,
+      });
+
+      const result = provider.updateDependencyVersions('apps/app1', {
+        lib1: '1.4.0',
+        lib2: '1.5.2',
+        lib3: '2.0.0',
+        lib4: '1.9.0',
+      });
+
+      expect(result).toEqual([
+        '✍️  Updated workspace dependency versions in manifest: apps/app1/pyproject.toml',
+      ]);
+
+      const data = provider.getPyprojectToml('apps/app1');
+      expect(data.project.dependencies).toEqual([
+        'lib1~=1.4',
+        'lib2>=1.5,<2.0',
+        'requests>=2.0',
+      ]);
+      expect(data.project['optional-dependencies'].extra).toEqual([
+        'lib3==2.0.0',
+      ]);
+      expect(data['dependency-groups'].dev).toEqual(['lib4~=1.9']);
+    });
+
+    it('leaves dependencies without a version specifier untouched', () => {
+      vol.fromJSON({
+        'apps/app1/pyproject.toml': dedent`
+          [project]
+          name = "app1"
+          version = "1.3.0"
+          dependencies = [ "lib1" ]
+
+          [tool.uv.sources.lib1]
+          workspace = true
+        `,
+      });
+
+      const result = provider.updateDependencyVersions('apps/app1', {
+        lib1: '1.4.0',
+      });
+
+      expect(result).toEqual([]);
+      expect(
+        provider.getPyprojectToml('apps/app1').project.dependencies,
+      ).toEqual(['lib1']);
+    });
+
+    it('throws when the resulting specifier excludes the released version', () => {
+      vol.fromJSON({
+        'apps/app1/pyproject.toml': dedent`
+          [project]
+          name = "app1"
+          version = "1.3.0"
+          dependencies = [ "lib1>=1.0,<1.3" ]
+
+          [tool.uv.sources.lib1]
+          workspace = true
+        `,
+      });
+
+      expect(() =>
+        provider.updateDependencyVersions('apps/app1', { lib1: '1.4.0' }),
+      ).toThrow(/does not allow 1.4.0/);
+    });
+  });
+});

--- a/packages/nx-python/src/provider/uv/provider.ts
+++ b/packages/nx-python/src/provider/uv/provider.ts
@@ -41,6 +41,7 @@ import {
   readPyprojectToml,
   writePyprojectToml,
 } from '../utils';
+import { rewriteDependencySpecifier } from './version-utils';
 import { UVLockfile, UVPyprojectToml } from './types';
 import toml from '@iarna/toml';
 import fs, { mkdirSync, readdirSync } from 'fs';
@@ -205,6 +206,70 @@ export class UVProvider extends BaseProvider<UVPyprojectToml> {
     } else {
       writeFileSync(pyprojectTomlPath, toml.stringify(projectData));
     }
+  }
+
+  public updateDependencyVersions(
+    projectRoot: string,
+    dependencyVersions: Record<string, string>,
+  ): string[] {
+    if (Object.keys(dependencyVersions).length === 0) {
+      return [];
+    }
+
+    const pyprojectTomlPath = joinPathFragments(projectRoot, 'pyproject.toml');
+    const projectData = this.getPyprojectToml(projectRoot);
+    if (!projectData?.project) {
+      return [];
+    }
+
+    let changed = false;
+
+    const rewriteDependencies = (dependencies: string[] | undefined): void => {
+      if (!dependencies) {
+        return;
+      }
+
+      for (let i = 0; i < dependencies.length; i++) {
+        for (const [packageName, newVersion] of Object.entries(
+          dependencyVersions,
+        )) {
+          const { changed: didChange, result } = rewriteDependencySpecifier(
+            dependencies[i],
+            packageName,
+            newVersion,
+          );
+          if (didChange) {
+            dependencies[i] = result;
+            changed = true;
+            break;
+          }
+        }
+      }
+    };
+
+    rewriteDependencies(projectData.project.dependencies);
+    for (const group of Object.values(
+      projectData.project['optional-dependencies'] ?? {},
+    )) {
+      rewriteDependencies(group);
+    }
+    for (const group of Object.values(projectData['dependency-groups'] ?? {})) {
+      rewriteDependencies(group);
+    }
+
+    if (!changed) {
+      return [];
+    }
+
+    if (this.tree) {
+      writePyprojectToml(this.tree, pyprojectTomlPath, projectData);
+    } else {
+      writeFileSync(pyprojectTomlPath, toml.stringify(projectData));
+    }
+
+    return [
+      `✍️  Updated workspace dependency versions in manifest: ${pyprojectTomlPath}`,
+    ];
   }
 
   public getDependencies(

--- a/packages/nx-python/src/provider/uv/version-utils.spec.ts
+++ b/packages/nx-python/src/provider/uv/version-utils.spec.ts
@@ -1,0 +1,180 @@
+import { rewriteDependencySpecifier } from './version-utils';
+
+describe('rewriteDependencySpecifier', () => {
+  describe('updatable operators (preserve operator + precision)', () => {
+    it.each([
+      ['lib1~=1.1', 'lib1~=1.4'],
+      ['lib1~=1.1.0', 'lib1~=1.4.0'],
+      ['lib1==1.1.0', 'lib1==1.4.0'],
+      ['lib1==1.1', 'lib1==1.4'],
+      ['lib1===1.1.0', 'lib1===1.4.0'],
+      ['lib1>=1.0', 'lib1>=1.4'],
+      ['lib1>=1.0.0', 'lib1>=1.4.0'],
+    ])('rewrites %s -> %s', (input, expected) => {
+      const { changed, result } = rewriteDependencySpecifier(
+        input,
+        'lib1',
+        '1.4.0',
+      );
+      expect(changed).toBe(true);
+      expect(result).toBe(expected);
+    });
+
+    it('zero-pads when the new version has fewer components than the precision', () => {
+      const { result } = rewriteDependencySpecifier('lib1==1.1.0', 'lib1', '2');
+      expect(result).toBe('lib1==2.0.0');
+    });
+  });
+
+  describe('kept operators', () => {
+    it.each(['lib1>1.0', 'lib1<2.0', 'lib1<=2.0', 'lib1!=1.1'])(
+      'leaves %s untouched',
+      (input) => {
+        const { changed, result } = rewriteDependencySpecifier(
+          input,
+          'lib1',
+          '1.4.0',
+        );
+        expect(changed).toBe(false);
+        expect(result).toBe(input);
+      },
+    );
+  });
+
+  describe('compound ranges', () => {
+    it('updates the lower bound and keeps the ceiling', () => {
+      const { changed, result } = rewriteDependencySpecifier(
+        'lib1>=1.0,<2.0',
+        'lib1',
+        '1.4.0',
+      );
+      expect(changed).toBe(true);
+      expect(result).toBe('lib1>=1.4,<2.0');
+    });
+
+    it('normalizes whitespace inside the specifier', () => {
+      const { result } = rewriteDependencySpecifier(
+        'lib1 >= 1.0, < 2.0',
+        'lib1',
+        '1.4.0',
+      );
+      expect(result).toBe('lib1>=1.4,<2.0');
+    });
+  });
+
+  describe('extras and markers', () => {
+    it('preserves extras', () => {
+      const { result } = rewriteDependencySpecifier(
+        'lib1[color]~=1.1',
+        'lib1',
+        '1.4.0',
+      );
+      expect(result).toBe('lib1[color]~=1.4');
+    });
+
+    it('preserves environment markers', () => {
+      const { result } = rewriteDependencySpecifier(
+        'lib1~=1.1 ; python_version < "3.9"',
+        'lib1',
+        '1.4.0',
+      );
+      expect(result).toBe('lib1~=1.4 ; python_version < "3.9"');
+    });
+  });
+
+  describe('no-op cases', () => {
+    it('leaves a dependency without a specifier untouched', () => {
+      const { changed, result } = rewriteDependencySpecifier(
+        'lib1',
+        'lib1',
+        '1.4.0',
+      );
+      expect(changed).toBe(false);
+      expect(result).toBe('lib1');
+    });
+
+    it('does not touch a different package', () => {
+      const { changed, result } = rewriteDependencySpecifier(
+        'other-lib~=1.1',
+        'lib1',
+        '1.4.0',
+      );
+      expect(changed).toBe(false);
+      expect(result).toBe('other-lib~=1.1');
+    });
+
+    it('matches package names using PEP 503 normalization', () => {
+      const { changed, result } = rewriteDependencySpecifier(
+        'My_Lib~=1.1',
+        'my-lib',
+        '1.4.0',
+      );
+      expect(changed).toBe(true);
+      expect(result).toBe('My_Lib~=1.4');
+    });
+  });
+
+  describe('prefix-match wildcards', () => {
+    it('bumps an == wildcard while preserving the wildcard', () => {
+      const { changed, result } = rewriteDependencySpecifier(
+        'lib1==1.1.*',
+        'lib1',
+        '1.4.0',
+      );
+      expect(changed).toBe(true);
+      expect(result).toBe('lib1==1.4.*');
+    });
+
+    it('leaves an == wildcard that already covers the release unchanged', () => {
+      const { changed, result } = rewriteDependencySpecifier(
+        'lib1==1.*',
+        'lib1',
+        '1.4.0',
+      );
+      expect(changed).toBe(false);
+      expect(result).toBe('lib1==1.*');
+    });
+
+    it('keeps a != wildcard that still allows the release', () => {
+      const { changed, result } = rewriteDependencySpecifier(
+        'lib1!=1.1.*',
+        'lib1',
+        '1.4.0',
+      );
+      expect(changed).toBe(false);
+      expect(result).toBe('lib1!=1.1.*');
+    });
+
+    it('throws when a != wildcard excludes the release', () => {
+      expect(() =>
+        rewriteDependencySpecifier('lib1!=1.4.*', 'lib1', '1.4.0'),
+      ).toThrow(/does not allow 1.4.0/);
+    });
+  });
+
+  describe('satisfiability validation', () => {
+    it('throws when a kept ceiling excludes the released version', () => {
+      expect(() =>
+        rewriteDependencySpecifier('lib1>=1.0,<1.3', 'lib1', '1.4.0'),
+      ).toThrow(/does not allow 1.4.0/);
+    });
+
+    it('throws when a standalone ceiling excludes the released version', () => {
+      expect(() =>
+        rewriteDependencySpecifier('lib1<1.3', 'lib1', '1.4.0'),
+      ).toThrow(/does not allow 1.4.0/);
+    });
+
+    it('throws when an exclusion matches the released version', () => {
+      expect(() =>
+        rewriteDependencySpecifier('lib1!=1.4.0', 'lib1', '1.4.0'),
+      ).toThrow(/does not allow 1.4.0/);
+    });
+
+    it('does not throw when the ceiling still allows the released version', () => {
+      expect(() =>
+        rewriteDependencySpecifier('lib1>=1.0,<2.0', 'lib1', '1.4.0'),
+      ).not.toThrow();
+    });
+  });
+});

--- a/packages/nx-python/src/provider/uv/version-utils.ts
+++ b/packages/nx-python/src/provider/uv/version-utils.ts
@@ -1,0 +1,160 @@
+import { satisfies } from '@renovatebot/pep440';
+
+/**
+ * PEP 440 comparison operators that should have their version bumped to the
+ * newly released version. Setting any of these to the released version keeps
+ * the specifier satisfiable by that version:
+ * - `==` / `===` exact pins
+ * - `~=` compatible release
+ * - `>=` inclusive lower bound
+ *
+ * The remaining operators (`>`, `<`, `<=`, `!=`) are intentionally left
+ * untouched: bumping a `<`/`<=` ceiling would track the release version (which
+ * is rarely intended), and bumping `>`/`!=` to the released version would
+ * exclude it. Any of those that end up excluding the released version are
+ * caught by the satisfiability check below.
+ */
+const UPDATABLE_OPERATORS = new Set(['==', '===', '~=', '>=']);
+
+// Recognized PEP 440 operators, longest first so the regex matches greedily.
+const CLAUSE_REGEX = /^(===|==|~=|!=|>=|<=|>|<)\s*(.+)$/;
+
+// Leading package name + optional extras (e.g. `lib1[color]`) followed by the
+// rest of the requirement (the version specifier).
+const REQUIREMENT_REGEX = /^\s*([A-Za-z0-9._-]+)\s*(\[[^\]]*\])?\s*(.*)$/;
+
+export interface RewriteSpecifierResult {
+  /** Whether the dependency string was modified. */
+  changed: boolean;
+  /** The resulting dependency string (unchanged when `changed` is false). */
+  result: string;
+}
+
+/**
+ * Normalizes a package name for comparison following PEP 503: lower-cased with
+ * runs of `.`, `-` and `_` collapsed to a single `-`.
+ */
+function normalizeName(name: string): string {
+  return name.toLowerCase().replace(/[-_.]+/g, '-');
+}
+
+/**
+ * Truncates (or zero-pads) a version to a given number of release components,
+ * preserving the precision originally used in the specifier.
+ *
+ * truncateVersion('1.4.0', 2) -> '1.4'
+ * truncateVersion('1.4', 3)   -> '1.4.0'
+ */
+function truncateVersion(version: string, precision: number): string {
+  const parts = version.split('.');
+  const result: string[] = [];
+  for (let i = 0; i < precision; i++) {
+    result.push(parts[i] ?? '0');
+  }
+  return result.join('.');
+}
+
+/**
+ * Rewrites the version specifier of a single PEP 508 dependency string so that
+ * it references `newVersion`, when the dependency matches `packageName`.
+ *
+ * Behavior:
+ * - Bumps the version of `==`, `===`, `~=` and `>=` clauses to `newVersion`,
+ *   preserving the operator and the original component precision. Trailing `.*`
+ *   prefix-match wildcards are preserved (e.g. `==1.1.*` becomes `==1.4.*`).
+ * - Leaves `>`, `<`, `<=`, `!=` clauses untouched.
+ * - Leaves dependencies with no version specifier untouched (the build step
+ *   pins those automatically in publish mode).
+ * - Throws when the resulting specifier no longer allows `newVersion` (e.g. a
+ *   `<` ceiling below the release), so the developer can fix the constraint.
+ *
+ * @param dependency - The original dependency string (e.g. `lib1~=1.1`).
+ * @param packageName - The package name being released.
+ * @param newVersion - The newly released version (e.g. `1.4.0`).
+ */
+export function rewriteDependencySpecifier(
+  dependency: string,
+  packageName: string,
+  newVersion: string,
+): RewriteSpecifierResult {
+  const unchanged: RewriteSpecifierResult = {
+    changed: false,
+    result: dependency,
+  };
+
+  // Separate the environment marker (everything from the first `;`) so it is
+  // preserved verbatim and not parsed as part of the version specifier.
+  const semicolonIndex = dependency.indexOf(';');
+  const marker = semicolonIndex >= 0 ? dependency.slice(semicolonIndex) : '';
+  const requirement =
+    semicolonIndex >= 0 ? dependency.slice(0, semicolonIndex) : dependency;
+
+  const match = REQUIREMENT_REGEX.exec(requirement);
+  if (!match) {
+    return unchanged;
+  }
+
+  const [, name, extras = '', specifierStr] = match;
+  if (normalizeName(name) !== normalizeName(packageName)) {
+    return unchanged;
+  }
+
+  const trimmedSpecifier = specifierStr.trim();
+  if (!trimmedSpecifier) {
+    // No version specifier; the build step pins this dependency automatically.
+    return unchanged;
+  }
+
+  let changed = false;
+  const rewrittenClauses = trimmedSpecifier.split(',').map((rawClause) => {
+    const clause = rawClause.trim();
+    const clauseMatch = CLAUSE_REGEX.exec(clause);
+    if (!clauseMatch) {
+      return clause;
+    }
+
+    const [, operator, rawVersion] = clauseMatch;
+    const version = rawVersion.trim();
+    if (!UPDATABLE_OPERATORS.has(operator)) {
+      // Keep the operator but normalize whitespace (e.g. `< 2.0` -> `<2.0`).
+      return `${operator}${version}`;
+    }
+
+    // Preserve a trailing `.*` prefix-match wildcard (e.g. `==1.1.*` becomes
+    // `==1.4.*`) so the original "track this series" intent is kept.
+    const hasWildcard = version.endsWith('.*');
+    const numericVersion = hasWildcard ? version.slice(0, -2) : version;
+    const precision = numericVersion.split('.').length;
+    const rewritten = `${operator}${truncateVersion(newVersion, precision)}${
+      hasWildcard ? '.*' : ''
+    }`;
+    if (rewritten !== clause) {
+      changed = true;
+    }
+    return rewritten;
+  });
+
+  const rewrittenSpecifier = rewrittenClauses.join(',');
+
+  // Validate that the released version is actually allowed by the resulting
+  // specifier. This catches kept ceilings/exclusions that would exclude the
+  // release (e.g. `>=1.0,<1.3` when releasing 1.4.0).
+  if (!satisfies(newVersion, rewrittenSpecifier)) {
+    throw new Error(
+      `Cannot update dependency "${packageName}" to version ${newVersion}: ` +
+        `the version constraint "${name}${extras}${rewrittenSpecifier}" does not allow ${newVersion}. ` +
+        `Please fix the version constraint for "${packageName}" in the manifest.`,
+    );
+  }
+
+  if (!changed) {
+    return unchanged;
+  }
+
+  return {
+    changed: true,
+    result: `${name}${extras}${rewrittenSpecifier}${
+      marker ? ` ${marker.trim()}` : ''
+    }`,
+  };
+}

--- a/packages/nx-python/src/release/version-actions.spec.ts
+++ b/packages/nx-python/src/release/version-actions.spec.ts
@@ -1,0 +1,267 @@
+import { vi } from 'vitest';
+import { ProjectGraph, Tree } from '@nx/devkit';
+import { createTreeWithEmptyWorkspace } from '@nx/devkit/testing';
+import dedent from 'string-dedent';
+import PythonVersionActions from './version-actions';
+import { UVProvider } from '../provider/uv/provider';
+import { PoetryProvider } from '../provider/poetry/provider';
+import { BaseProvider } from '../provider/base';
+import { Logger } from '../executors/utils/logger';
+
+const projectGraph = {
+  nodes: {
+    lib1: { data: { root: 'libs/lib1' } },
+    lib2: { data: { root: 'libs/lib2' } },
+  },
+} as unknown as ProjectGraph;
+
+describe('PythonVersionActions', () => {
+  let tree: Tree;
+
+  beforeEach(() => {
+    tree = createTreeWithEmptyWorkspace({});
+  });
+
+  afterEach(() => {
+    vi.resetAllMocks();
+  });
+
+  function createActions(
+    provider: BaseProvider<unknown>,
+    bundleLocalDependencies: boolean | undefined,
+  ): PythonVersionActions {
+    const targets =
+      bundleLocalDependencies === undefined
+        ? {}
+        : { build: { options: { bundleLocalDependencies } } };
+
+    const actions = new PythonVersionActions(
+      {} as never,
+      {
+        name: 'app1',
+        type: 'lib',
+        data: { root: 'apps/app1', targets },
+      } as never,
+      {} as never,
+    );
+
+    actions.manifestsToUpdate = [
+      {
+        manifestPath: 'apps/app1/pyproject.toml',
+        preserveLocalDependencyProtocols: false,
+      },
+    ];
+
+    (actions as unknown as { provider: BaseProvider<unknown> }).provider =
+      provider;
+
+    return actions;
+  }
+
+  describe('updateProjectDependencies', () => {
+    describe('uv', () => {
+      function setupWorkspace(app1Dependencies: string): void {
+        tree.write(
+          'libs/lib1/pyproject.toml',
+          dedent`
+            [project]
+            name = "lib1"
+            version = "1.4.0"
+            dependencies = []
+          `,
+        );
+        tree.write(
+          'libs/lib2/pyproject.toml',
+          dedent`
+            [project]
+            name = "lib2"
+            version = "1.5.2"
+            dependencies = []
+          `,
+        );
+        tree.write(
+          'apps/app1/pyproject.toml',
+          dedent`
+            [project]
+            name = "app1"
+            version = "1.3.0"
+            dependencies = [ ${app1Dependencies} ]
+
+            [tool.uv.sources.lib1]
+            workspace = true
+            [tool.uv.sources.lib2]
+            workspace = true
+          `,
+        );
+      }
+
+      function readDependencies(): string[] {
+        return new UVProvider('.', new Logger(), tree).getPyprojectToml(
+          'apps/app1',
+        ).project.dependencies;
+      }
+
+      function actions(
+        bundleLocalDependencies: boolean | undefined,
+      ): PythonVersionActions {
+        return createActions(
+          new UVProvider('.', new Logger(), tree),
+          bundleLocalDependencies,
+        );
+      }
+
+      it('returns an empty array when there are no dependencies to update', async () => {
+        setupWorkspace('"lib1~=1.1"');
+
+        const result = await actions(false).updateProjectDependencies(
+          tree,
+          projectGraph,
+          {},
+        );
+
+        expect(result).toEqual([]);
+        expect(readDependencies()).toEqual(['lib1~=1.1']);
+      });
+
+      it('is a no-op when bundleLocalDependencies defaults to true', async () => {
+        setupWorkspace('"lib1~=1.1"');
+
+        const result = await actions(undefined).updateProjectDependencies(
+          tree,
+          projectGraph,
+          { lib1: '^1.4.0' },
+        );
+
+        expect(result).toEqual([]);
+        expect(readDependencies()).toEqual(['lib1~=1.1']);
+      });
+
+      it('is a no-op when bundleLocalDependencies is explicitly true', async () => {
+        setupWorkspace('"lib1~=1.1"');
+
+        const result = await actions(true).updateProjectDependencies(
+          tree,
+          projectGraph,
+          { lib1: '^1.4.0' },
+        );
+
+        expect(result).toEqual([]);
+        expect(readDependencies()).toEqual(['lib1~=1.1']);
+      });
+
+      it('rewrites ranges and flags the project for lock refresh in publish mode', async () => {
+        setupWorkspace('"lib1~=1.1", "lib2>=1.2,<2.0", "requests>=2.0"');
+
+        const result = await actions(false).updateProjectDependencies(
+          tree,
+          projectGraph,
+          { lib1: '^1.4.0', lib2: '^1.5.2' },
+        );
+
+        expect(readDependencies()).toEqual([
+          'lib1~=1.4',
+          'lib2>=1.5,<2.0',
+          'requests>=2.0',
+        ]);
+        expect(result).toEqual([
+          '✍️  Updated workspace dependency versions in manifest: apps/app1/pyproject.toml',
+          '✍️  Flagged 2 workspace dependencies (lib1, lib2) for lock file refresh in manifest: apps/app1/pyproject.toml',
+        ]);
+      });
+
+      it('uses the dependency version from its manifest, not the prefixed value from Nx', async () => {
+        setupWorkspace('"lib1~=1.1"');
+
+        await actions(false).updateProjectDependencies(tree, projectGraph, {
+          lib1: '^9.9.9',
+        });
+
+        expect(readDependencies()).toEqual(['lib1~=1.4']);
+      });
+    });
+
+    describe('poetry', () => {
+      const app1Manifest = dedent`
+        [tool.poetry]
+        name = "app1"
+        version = "1.3.0"
+
+        [tool.poetry.dependencies]
+        python = ">=3.9,<4"
+        lib1 = { path = "../../libs/lib1", develop = true }
+      `;
+
+      function setupWorkspace(): void {
+        tree.write(
+          'libs/lib1/pyproject.toml',
+          dedent`
+            [tool.poetry]
+            name = "lib1"
+            version = "1.4.0"
+
+            [tool.poetry.dependencies]
+            python = ">=3.9,<4"
+          `,
+        );
+        tree.write('apps/app1/pyproject.toml', app1Manifest);
+      }
+
+      function readManifest(): string {
+        return tree.read('apps/app1/pyproject.toml', 'utf-8');
+      }
+
+      function actions(
+        bundleLocalDependencies: boolean | undefined,
+      ): PythonVersionActions {
+        return createActions(
+          new PoetryProvider('.', new Logger(), tree),
+          bundleLocalDependencies,
+        );
+      }
+
+      it('returns an empty array when there are no dependencies to update', async () => {
+        setupWorkspace();
+
+        const result = await actions(false).updateProjectDependencies(
+          tree,
+          projectGraph,
+          {},
+        );
+
+        expect(result).toEqual([]);
+        expect(readManifest()).toBe(app1Manifest);
+      });
+
+      it('is a no-op when bundleLocalDependencies is true', async () => {
+        setupWorkspace();
+
+        const result = await actions(true).updateProjectDependencies(
+          tree,
+          projectGraph,
+          { lib1: '^1.4.0' },
+        );
+
+        expect(result).toEqual([]);
+        expect(readManifest()).toBe(app1Manifest);
+      });
+
+      it('flags the project for lock refresh without rewriting the manifest in publish mode', async () => {
+        setupWorkspace();
+
+        const result = await actions(false).updateProjectDependencies(
+          tree,
+          projectGraph,
+          { lib1: '^1.4.0' },
+        );
+
+        // Poetry references local dependencies via `path`/`develop`, so there is
+        // no version specifier to rewrite; the project is still flagged so its
+        // lock file is regenerated.
+        expect(result).toEqual([
+          '✍️  Flagged 1 workspace dependency (lib1) for lock file refresh in manifest: apps/app1/pyproject.toml',
+        ]);
+        expect(readManifest()).toBe(app1Manifest);
+      });
+    });
+  });
+});

--- a/packages/nx-python/src/release/version-actions.ts
+++ b/packages/nx-python/src/release/version-actions.ts
@@ -14,6 +14,7 @@ import type {
 import { getProvider } from '../provider';
 import { PluginOptions } from '../types';
 import { BaseProvider } from '../provider/base';
+import { BuildExecutorSchema } from '../executors/build/schema';
 import path from 'node:path';
 import fs from 'node:fs/promises';
 import { checkPathExists } from '../utils/path';
@@ -226,7 +227,9 @@ export default class PythonVersionActions extends VersionActions {
     for (const manifestToUpdate of this.manifestsToUpdate) {
       const projectRoot = path.dirname(manifestToUpdate.manifestPath);
       this.provider.updateVersion(projectRoot, newVersion);
-      updatedProjects.push(projectRoot);
+      if (!updatedProjects.includes(projectRoot)) {
+        updatedProjects.push(projectRoot);
+      }
 
       logMessages.push(
         `✍️  New version ${newVersion} written to manifest: ${manifestToUpdate.manifestPath}`,
@@ -240,30 +243,64 @@ export default class PythonVersionActions extends VersionActions {
     projectGraph: ProjectGraph,
     dependenciesToUpdate: Record<string, string>,
   ): Promise<string[]> {
-    const projects = Object.entries(projectGraph.nodes).reduce<
-      Record<string, ProjectConfiguration>
-    >((acc, [projectName, node]) => {
-      acc[projectName] = node.data;
-      return acc;
-    }, {});
+    const dependencyNames = Object.keys(dependenciesToUpdate);
+    if (dependencyNames.length === 0) {
+      return [];
+    }
 
-    for (const dependency of Object.keys(dependenciesToUpdate)) {
-      const dependencyProject = projects[dependency];
-      if (!updatedProjects.includes(dependencyProject.root)) {
-        updatedProjects.push(dependencyProject.root);
+    // When local dependencies are bundled into the build artifact (the default,
+    // `bundleLocalDependencies: true`), the dependent does not reference its
+    // workspace dependencies by version, so a dependency version bump requires
+    // no action here. Only in publish mode (`bundleLocalDependencies: false`)
+    // does the build pin each local dependency as `dep==<version>`, which means
+    // this (the dependent) project must have its lock file regenerated so the
+    // new pinned versions propagate — even when it was not version-bumped.
+    const buildOptions = this.projectGraphNode.data.targets?.build?.options as
+      | BuildExecutorSchema
+      | undefined;
+    const bundleLocalDependencies =
+      buildOptions?.bundleLocalDependencies ?? true;
+
+    if (bundleLocalDependencies) {
+      return [];
+    }
+
+    // Map each updated workspace dependency (keyed by its Nx project name) to
+    // its package name and freshly written version. `updateProjectVersion` runs
+    // before this, so the dependency's manifest already holds the new version.
+    const packageVersions: Record<string, string> = {};
+    for (const depProjectName of dependencyNames) {
+      const depNode = projectGraph.nodes[depProjectName];
+      if (!depNode) {
+        continue;
       }
 
-      this.updateProjectDependencies(
-        tree,
-        projectGraph,
-        this.provider
-          .getDependencies(dependency, projects, tree.root)
-          .reduce<Record<string, string>>((acc, dependency) => {
-            acc[dependency.name] = dependency.version;
-            return acc;
-          }, {}),
+      const metadata = this.provider.getMetadata(depNode.data.root);
+      if (metadata?.name) {
+        packageVersions[metadata.name] = metadata.version;
+      }
+    }
+
+    const logMessages: string[] = [];
+    for (const manifestToUpdate of this.manifestsToUpdate) {
+      const projectRoot = path.dirname(manifestToUpdate.manifestPath);
+
+      logMessages.push(
+        ...this.provider.updateDependencyVersions(projectRoot, packageVersions),
+      );
+
+      if (!updatedProjects.includes(projectRoot)) {
+        updatedProjects.push(projectRoot);
+      }
+
+      logMessages.push(
+        `✍️  Flagged ${dependencyNames.length} workspace ${
+          dependencyNames.length === 1 ? 'dependency' : 'dependencies'
+        } (${dependencyNames.join(
+          ', ',
+        )}) for lock file refresh in manifest: ${manifestToUpdate.manifestPath}`,
       );
     }
-    return [];
+    return logMessages;
   }
 }

--- a/packages/nx-python/src/utils/mocks/fs.mock.ts
+++ b/packages/nx-python/src/utils/mocks/fs.mock.ts
@@ -37,21 +37,64 @@ const copyRecursiveSync = (
   }
 };
 
+/**
+ * tree-sitter grammars are loaded from `.wasm` files that live on the real
+ * filesystem (inside `node_modules`), not from the in-memory project layout the
+ * tests build with memfs. These helpers let `.wasm` reads fall through to the
+ * real `fs` while every other read keeps hitting memfs.
+ */
+const isWasmPath = (p: unknown): boolean => String(p).endsWith('.wasm');
+
+/**
+ * Build a wrapper that forwards `.wasm` reads to `realFn` (the real `fs`) and
+ * everything else to `memfsFn` (memfs). The wrapper declares its own rest
+ * parameter so the arguments can be spread into the overloaded `fs` methods.
+ */
+const passthrough =
+  (
+    realFn: (...args: unknown[]) => unknown,
+    memfsFn: (...args: unknown[]) => unknown,
+  ) =>
+  (path: unknown, ...args: unknown[]) =>
+    isWasmPath(path) ? realFn(path, ...args) : memfsFn(path, ...args);
+
+const withWasmPassthrough = (
+  memfsFs: typeof import('memfs').fs,
+  realFs: typeof import('node:fs'),
+) => ({
+  readFileSync: passthrough(
+    realFs.readFileSync as never,
+    memfsFs.readFileSync as never,
+  ),
+  readFile: passthrough(realFs.readFile as never, memfsFs.readFile as never),
+  existsSync: passthrough(
+    realFs.existsSync as never,
+    memfsFs.existsSync as never,
+  ),
+});
+
 vi.mock('fs', async () => {
   const memfs = await vi.importActual<typeof import('memfs')>('memfs');
+  const realFs = await vi.importActual<typeof import('node:fs')>('node:fs');
+  const overrides = withWasmPassthrough(memfs.fs, realFs);
 
   return {
-    default: memfs.fs,
+    default: { ...memfs.fs, ...overrides, cpSync: copyRecursiveSync },
     ...memfs.fs,
+    ...overrides,
     cpSync: copyRecursiveSync,
   };
 });
 
 vi.mock('node:fs', async () => {
   const memfs = await vi.importActual<typeof import('memfs')>('memfs');
+  const realFs = await vi.importActual<typeof import('node:fs')>('node:fs');
+  const overrides = withWasmPassthrough(memfs.fs, realFs);
+
   return {
-    default: memfs.fs,
+    default: { ...memfs.fs, ...overrides, cpSync: copyRecursiveSync },
     ...memfs.fs,
+    ...overrides,
     cpSync: copyRecursiveSync,
   };
 });

--- a/packages/nx-python/tsconfig.spec.json
+++ b/packages/nx-python/tsconfig.spec.json
@@ -24,6 +24,7 @@
     "src/**/*.spec.js",
     "src/**/*.test.jsx",
     "src/**/*.spec.jsx",
+    "src/**/*.mock.ts",
     "src/**/*.d.ts"
   ],
   "references": [

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -343,6 +343,9 @@ importers:
       '@nx/devkit':
         specifier: ^22.0.0
         version: 22.3.3(nx@22.3.3(@swc-node/register@1.9.2(@swc/core@1.5.7(@swc/helpers@0.5.12))(@swc/types@0.1.7)(typescript@5.9.3))(@swc/core@1.5.7(@swc/helpers@0.5.12)))
+      '@renovatebot/pep440':
+        specifier: ^5.0.0
+        version: 5.0.0
       archiver:
         specifier: ^7.0.0
         version: 7.0.1
@@ -373,12 +376,18 @@ importers:
       semver:
         specifier: ^7.5.3
         version: 7.7.3
+      tree-sitter-wasms:
+        specifier: ^0.1.13
+        version: 0.1.13
       tslib:
         specifier: ^2.3.0
         version: 2.8.1
       uuid:
         specifier: ^9.0.0
         version: 9.0.1
+      web-tree-sitter:
+        specifier: ^0.20.8
+        version: 0.20.8
 
   packages/util:
     dependencies:
@@ -2217,6 +2226,10 @@ packages:
   '@polka/url@1.0.0-next.29':
     resolution: {integrity: sha512-wwQAWhWSuHaag8c4q/KN/vCoeOJYshAIvMQwD4GpSb3OiZklFfvAgmj0VCBBImRpuF/aFgIRzllXlVX93Jevww==}
 
+  '@renovatebot/pep440@5.0.0':
+    resolution: {integrity: sha512-91cFM32/pnOAvC7W1W1kPPI9QM2y6OrYCeomz7pop4A+3Ksh2XnZXGznUMlzR7YbOQlg7X/MNlF27s9Yt9hhTA==}
+    engines: {node: ^22.11.0 || >=24.10.0, pnpm: '>=10.0.0'}
+
   '@rollup/rollup-android-arm-eabi@4.40.2':
     resolution: {integrity: sha512-JkdNEq+DFxZfUwxvB58tHMHBHVgX23ew41g1OQinthJ+ryhdRk67O31S7sYw8u2lTjHUPFxwar07BBt1KHp/hg==}
     cpu: [arm]
@@ -2466,6 +2479,9 @@ packages:
 
   '@sinonjs/text-encoding@0.7.3':
     resolution: {integrity: sha512-DE427ROAphMQzU4ENbliGYrBSYPXF+TtLg9S8vzeA+OF4ZKzoDdzfL8sxuMUGS/lgRhM6j1URSk9ghf7Xo1tyA==}
+    deprecated: |-
+      Deprecated: no longer maintained and no longer used by Sinon packages. See
+        https://github.com/sinonjs/nise/issues/243 for replacement details.
 
   '@smithy/abort-controller@4.0.2':
     resolution: {integrity: sha512-Sl/78VDtgqKxN2+1qduaVE140XF+Xg+TafkncspwM4jFP/LHr76ZHmIY/y3V1M0mMLNk+Je6IGbzxy23RSToMw==}
@@ -2985,6 +3001,7 @@ packages:
 
   '@ungap/structured-clone@1.3.0':
     resolution: {integrity: sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==}
+    deprecated: Potential CWE-502 - Update to 1.3.1 or higher
 
   '@unrs/resolver-binding-android-arm-eabi@1.11.1':
     resolution: {integrity: sha512-ppLRUgHVaGRWUx0R0Ut06Mjo9gBaBkg3v/8AxusGLhsIotbBLuRk51rAzqLC8gq6NyyAojEXglNjzf6R948DNw==}
@@ -3306,6 +3323,7 @@ packages:
   aws-sdk@2.1692.0:
     resolution: {integrity: sha512-x511uiJ/57FIsbgUe5csJ13k3uzu25uWQE+XqfBis/sB0SFoiElJWXRkgEAUh0U6n40eT3ay5Ue4oPkRMu1LYw==}
     engines: {node: '>= 10.0.0'}
+    deprecated: The AWS SDK for JavaScript (v2) has reached end-of-support, and no longer receives updates. Please migrate your code to use AWS SDK for JavaScript (v3). More info https://a.co/cUPnyil
 
   axios@1.13.2:
     resolution: {integrity: sha512-VPk9ebNqPcy5lRGuSlKx752IlDatOjT9paPlm8A7yOuW2Fbvp4X3JznJtT4f0GzGLLiWE9W8onz51SqLYwzGaA==}
@@ -4234,6 +4252,7 @@ packages:
   git-raw-commits@4.0.0:
     resolution: {integrity: sha512-ICsMM1Wk8xSGMowkOmPrzo2Fgmfo4bMHLNX6ytHjajRJUqvHOw/TFapQ+QG75c3X/tTDDhOSRPGC52dDbNM8FQ==}
     engines: {node: '>=16'}
+    deprecated: This package is no longer maintained. For the JavaScript API, please use @conventional-changelog/git-client instead.
     hasBin: true
 
   glob-parent@5.1.2:
@@ -4255,11 +4274,12 @@ packages:
 
   glob@10.4.5:
     resolution: {integrity: sha512-7Bv8RF0k6xjo7d4A/PxYLbUCfb6c+Vpd2/mB2yRDlew7Jb5hEXiCD9ibfO7wpk8i4sevK6DFny9h7EYbM3/sHg==}
+    deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
     hasBin: true
 
   glob@7.2.3:
     resolution: {integrity: sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==}
-    deprecated: Glob versions prior to v9 are no longer supported
+    deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
 
   global-directory@4.0.1:
     resolution: {integrity: sha512-wHTUcDUoZ1H5/0iVqEudYW4/kAlN5cZ3j/bXn0Dpbizl9iaUVeWSHqiOjsgk6OW2bkLclbBjzewBz6weQ1zA2Q==}
@@ -5651,6 +5671,7 @@ packages:
   tar@6.2.1:
     resolution: {integrity: sha512-DZ4yORTwrbTj/7MZYq2w+/ZFdI6OZ/f9SFHR+71gIVUZhOQPHzVCLpvRnPgyaMpfWxxk/4ONva3GQSyNIKRv6A==}
     engines: {node: '>=10'}
+    deprecated: Old versions of tar are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
 
   test-exclude@6.0.0:
     resolution: {integrity: sha512-cAGWPIyOHU6zlmg88jwm7VRyXnMN7iV68OGAbYDk/Mh/xC/pzVPlQtY6ngoIH/5/tciuhGfvESU8GrHrcxD56w==}
@@ -5737,6 +5758,9 @@ packages:
   tree-kill@1.2.2:
     resolution: {integrity: sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A==}
     hasBin: true
+
+  tree-sitter-wasms@0.1.13:
+    resolution: {integrity: sha512-wT+cR6DwaIz80/vho3AvSF0N4txuNx/5bcRKoXouOfClpxh/qqrF4URNLQXbbt8MaAxeksZcZd1j8gcGjc+QxQ==}
 
   ts-api-utils@2.1.0:
     resolution: {integrity: sha512-CUgTZL1irw8u29bzrOD/nH85jqyc74D6SshFgujOIA7osm2Rz7dYH77agkx7H4FBNxDq7Cjf+IjaX/8zwFW+ZQ==}
@@ -5863,10 +5887,12 @@ packages:
 
   uuid@8.0.0:
     resolution: {integrity: sha512-jOXGuXZAWdsTH7eZLtyXMqUb9EcWMGZNbL9YcGBJl4MH4nrxHmZJhEHvyLFrkxo+28uLb/NYRcStH48fnD0Vzw==}
+    deprecated: uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).
     hasBin: true
 
   uuid@9.0.1:
     resolution: {integrity: sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==}
+    deprecated: uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).
     hasBin: true
 
   v8-compile-cache-lib@3.0.1:
@@ -5986,6 +6012,9 @@ packages:
 
   wcwidth@1.0.1:
     resolution: {integrity: sha512-XHPEwS0q6TaxcvG85+8EYkbiCux2XtWG2mkc47Ng2A77BQu9+DqIOJldST4HgPkuea7dvKSj5VgX3P1d4rW8Tg==}
+
+  web-tree-sitter@0.20.8:
+    resolution: {integrity: sha512-weOVgZ3aAARgdnb220GqYuh7+rZU0Ka9k9yfKtGAzEYMa6GgiCzW9JjQRJyCJakvibQW+dfjJdihjInKuuCAUQ==}
 
   whatwg-encoding@2.0.0:
     resolution: {integrity: sha512-p41ogyeMUrw3jWclHWTQg1k05DSVXPLcVxRTYsXUk+ZooOCZLcoYgPZ/HL/D/N+uQPOtcp1me1WhBEaX02mhWg==}
@@ -8755,6 +8784,8 @@ snapshots:
   '@pkgr/core@0.2.9': {}
 
   '@polka/url@1.0.0-next.29': {}
+
+  '@renovatebot/pep440@5.0.0': {}
 
   '@rollup/rollup-android-arm-eabi@4.40.2':
     optional: true
@@ -12681,6 +12712,8 @@ snapshots:
 
   tree-kill@1.2.2: {}
 
+  tree-sitter-wasms@0.1.13: {}
+
   ts-api-utils@2.1.0(typescript@5.9.3):
     dependencies:
       typescript: 5.9.3
@@ -12920,6 +12953,8 @@ snapshots:
   wcwidth@1.0.1:
     dependencies:
       defaults: 1.0.4
+
+  web-tree-sitter@0.20.8: {}
 
   whatwg-encoding@2.0.0:
     dependencies:


### PR DESCRIPTION
## Current Behavior

`@nxlv/python`'s `inferDependencies` resolved local project edges by scanning raw Python source with a regular expression (`/(?:import|from)\s+([a-zA-Z_][\w]*)/g`). Because it matched text rather than parsing syntax, it produced false-positive edges from non-import occurrences (comments, docstrings, string literals, and arbitrary identifiers such as service names or registry keys). Those phantom edges polluted the Nx project graph and could create circular task graphs that break `nx affected` and CI (e.g. `microservice-b:build -> internal-package-a:build -> python-microservice-a:build -> internal-package-a:build`).

Separately, during `nx release` the `updateProjectDependencies` hook in the version actions was effectively a no-op: it called itself recursively and never updated anything. When a uv project pinned a local workspace dependency with a version range (e.g. `bsb-core~=7.0`), releasing that dependency did not bump the range in the dependent's `pyproject.toml` once the new version crossed the range. On workspaces with cyclic sibling dependencies, that same unbounded recursion overflowed the stack with `RangeError: Maximum call stack size exceeded`. Both were reported in [#328 (comment)](https://github.com/lucasvieirasilva/nx-plugins/issues/328#issuecomment-4557062819).

## Expected Behavior

- **Dependency inference is now syntax-aware.** Python files are parsed with tree-sitter, using the prebuilt `tree-sitter-wasms` WebAssembly grammar instead of the native `tree-sitter` Node bindings, which fail to build on Node.js 24 (see [tree-sitter/node-tree-sitter#268](https://github.com/tree-sitter/node-tree-sitter/issues/268)). Only real `import` / `from ... import` statements create project edges; comments, docstrings, and string literals are ignored, eliminating the false-positive edges and the resulting circular task graphs.
- **Local dependency versions are bumped on release.** When a project builds in publish mode (`bundleLocalDependencies: false`), `updateProjectDependencies` rewrites the uv version specifiers of released local dependencies — preserving the operator and component precision (`bsb-core~=7.0` → `bsb-core~=7.1`, ceilings kept) and preserving `==`/`!=` prefix wildcards (`==1.1.*` → `==1.4.*`). The result is validated with PEP 440 (`@renovatebot/pep440`); a constraint that would exclude the released version throws so the author can fix it. The dependent project is flagged so its lock file is regenerated. Poetry remains a no-op, since it references local dependencies by `path`/`develop` (no version specifier to rewrite). All `BaseProvider` methods are now documented.
- **No more stack overflow on cyclic deps.** The recursive self-call in `updateProjectDependencies` is removed, so the `RangeError: Maximum call stack size exceeded` reported on cyclic sibling dependencies no longer occurs during `nx release`.
- Also included: data-migration test/mock fixes (`aws-sdk-client-mock` matcher typings) and workspace tooling/docs updates.

## Related Issue(s)

Fixes #348

Refs #328 — addresses the local-dependency version-bump gap and the cyclic-dependency `RangeError` raised in [this comment](https://github.com/lucasvieirasilva/nx-plugins/issues/328#issuecomment-4557062819).
