### PR TITLE
fix: declare @nx/devkit as a peer dependency for Nx 23 support

### DIFF
--- a/packages/data-migration/package.json
+++ b/packages/data-migration/package.json
@@ -41,7 +41,6 @@
     "@aws-sdk/client-lambda": "^3.525.0",
     "@aws-sdk/client-ssm": "^3.525.0",
     "@aws-sdk/client-sts": "^3.525.0",
-    "@nx/devkit": "^22.0.0",
     "@nxlv/util": "workspace:*",
     "archiver": "^7.0.0",
     "chalk": "^4.1.1",
@@ -52,6 +51,9 @@
     "lodash": "^4.17.21",
     "prompts": "^2.4.2",
     "tslib": "^2.3.0"
+  },
+  "peerDependencies": {
+    "@nx/devkit": ">=22.0.0"
   },
   "devDependencies": {
     "@types/prompts": "^2.4.9"

--- a/packages/nx-python/package.json
+++ b/packages/nx-python/package.json
@@ -31,7 +31,6 @@
   },
   "dependencies": {
     "@iarna/toml": "^2.2.5",
-    "@nx/devkit": "^22.0.0",
     "@renovatebot/pep440": "^5.0.0",
     "archiver": "^7.0.0",
     "chalk": "^4.1.1",
@@ -47,6 +46,9 @@
     "tslib": "^2.3.0",
     "uuid": "^9.0.0",
     "web-tree-sitter": "^0.20.8"
+  },
+  "peerDependencies": {
+    "@nx/devkit": ">=22.0.0"
   },
   "nx-migrations": {
     "migrations": "./migrations.json"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -274,7 +274,7 @@ importers:
         specifier: ^3.525.0
         version: 3.804.0
       '@nx/devkit':
-        specifier: ^22.0.0
+        specifier: '>=22.0.0'
         version: 22.3.3(nx@22.3.3(@swc-node/register@1.9.2(@swc/core@1.5.7(@swc/helpers@0.5.12))(@swc/types@0.1.7)(typescript@5.9.3))(@swc/core@1.5.7(@swc/helpers@0.5.12)))
       '@nxlv/util':
         specifier: workspace:*
@@ -341,7 +341,7 @@ importers:
         specifier: ^2.2.5
         version: 2.2.5
       '@nx/devkit':
-        specifier: ^22.0.0
+        specifier: '>=22.0.0'
         version: 22.3.3(nx@22.3.3(@swc-node/register@1.9.2(@swc/core@1.5.7(@swc/helpers@0.5.12))(@swc/types@0.1.7)(typescript@5.9.3))(@swc/core@1.5.7(@swc/helpers@0.5.12)))
       '@renovatebot/pep440':
         specifier: ^5.0.0
@@ -4252,7 +4252,7 @@ packages:
   git-raw-commits@4.0.0:
     resolution: {integrity: sha512-ICsMM1Wk8xSGMowkOmPrzo2Fgmfo4bMHLNX6ytHjajRJUqvHOw/TFapQ+QG75c3X/tTDDhOSRPGC52dDbNM8FQ==}
     engines: {node: '>=16'}
-    deprecated: This package is no longer maintained. For the JavaScript API, please use @conventional-changelog/git-client instead.
+    deprecated: Deprecated and no longer maintained. Use @conventional-changelog/git-client instead.
     hasBin: true
 
   glob-parent@5.1.2:


### PR DESCRIPTION
## Current Behavior

`@nxlv/python` and `@nxlv/data-migration` declare `@nx/devkit` under `dependencies`, pinned to `^22.0.0`. In an Nx 23 workspace this version range can't be satisfied: installing the plugin fails with `ERESOLVE` (npm) or peer/version warnings (pnpm), and where the install does proceed it pulls in a second, bundled copy of `@nx/devkit@22` alongside the workspace's own `@nx/devkit@23` — the classic dual-devkit failure that surfaces as runtime errors during project-graph construction.

Because the range is a hard `^22` cap on a regular dependency, there is no install-time path to use these plugins on Nx 23 short of overrides (`--legacy-peer-deps`, pnpm `peerDependencyRules`).

## Expected Behavior

`@nx/devkit` is declared as a `peerDependency` so the plugin always uses the consumer's installed devkit instead of bundling its own, and the range is widened to `>=22.0.0` (no upper bound). A single published plugin version now installs cleanly on both Nx 22 and Nx 23, with exactly one copy of `@nx/devkit` resolved from the workspace.

The plugin code uses only stable public devkit APIs (`createDependencies`, `Tree`, executors, generators) that are unaffected by the Nx 23 breaking changes — notably it does not use `createNodes`/`createNodesV2` — so no code changes are required. An upper bound is intentionally omitted: the `^22` cap is what blocked Nx 23 in the first place, and capping at `<24` would only recreate the same wall on the next major; the lower bound can be raised if a future major is validated to break the plugin.

Verified against an Nx 22 workspace (build, unit tests, and the `@nx/dependency-checks` lint rule all pass) and against a live Nx 23.0.1 workspace, where the packed plugin installs with no `ERESOLVE`/duplicate devkit and the `uv-project` generator, project-graph (`createDependencies`) hook, and `install` executor all run successfully.