### PR TITLE
fix(nx-python): preserve Windows drive letter when reading pyproject.toml

### DIFF
--- a/packages/nx-python/src/provider/base.spec.ts
+++ b/packages/nx-python/src/provider/base.spec.ts
@@ -2,8 +2,9 @@ import { BaseProvider } from './base';
 import { PoetryProvider } from './poetry';
 import { PoetryPyprojectToml } from './poetry/types';
 import { Logger } from '../executors/utils/logger';
+import * as utils from './utils';
 import chalk from 'chalk';
-import { ExecutorContext } from '@nx/devkit';
+import { ExecutorContext, Tree } from '@nx/devkit';
 import { MockInstance } from 'vitest';
 import path from 'path';
 
@@ -99,5 +100,51 @@ describe('Activate Venv', () => {
       ...originalEnv,
     });
     expect(installMock).not.toHaveBeenCalled();
+  });
+});
+
+describe('getPyprojectToml', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('preserves the drive letter when reading an absolute Windows path from the filesystem', () => {
+    const getPyprojectDataSpy = vi
+      .spyOn(utils, 'getPyprojectData')
+      .mockReturnValue({} as PoetryPyprojectToml);
+
+    // Without a `tree`, `projectRoot` may be an absolute OS path — e.g. the
+    // temporary build folder returned by `os.tmpdir()` in an executor. On
+    // Windows `joinPathFragments` would strip the drive letter, so the file
+    // would not be found and the pyproject would parse as empty.
+    const provider = new PoetryProvider('.', new Logger());
+    const projectRoot =
+      'C:\\Users\\me\\AppData\\Local\\Temp\\nx-python\\build\\abc';
+
+    provider.getPyprojectToml(projectRoot);
+
+    expect(getPyprojectDataSpy).toHaveBeenCalledWith(
+      path.join(projectRoot, 'pyproject.toml'),
+    );
+    expect(getPyprojectDataSpy.mock.calls[0][0].startsWith('C:')).toBe(true);
+  });
+
+  it('reads workspace-relative POSIX paths from the tree', () => {
+    const readPyprojectTomlSpy = vi
+      .spyOn(utils, 'readPyprojectToml')
+      .mockReturnValue({} as PoetryPyprojectToml);
+    const tree = {
+      exists: () => false,
+      read: () => null,
+    } as unknown as Tree;
+
+    const provider = new PoetryProvider('apps/app', new Logger(), tree);
+
+    provider.getPyprojectToml('apps/app');
+
+    expect(readPyprojectTomlSpy).toHaveBeenCalledWith(
+      tree,
+      'apps/app/pyproject.toml',
+    );
   });
 });

--- a/packages/nx-python/src/provider/base.ts
+++ b/packages/nx-python/src/provider/base.ts
@@ -96,14 +96,27 @@ export abstract class BaseProvider<TPyprojectToml> {
    * Reads and parses the `pyproject.toml` of a project, using the in-memory
    * {@link Tree} when available and falling back to the real filesystem.
    *
+   * The path is built differently per source: the {@link Tree} expects a
+   * workspace-relative POSIX path, so `joinPathFragments` is correct there.
+   * The real filesystem, however, may receive an absolute OS path — in an
+   * executor context `projectRoot` can be the temporary build folder from
+   * `os.tmpdir()`. On Windows `joinPathFragments` normalizes to POSIX and
+   * strips the drive letter (`C:\...\pyproject.toml` -> `/.../pyproject.toml`),
+   * so the file is never found and the pyproject parses as empty. `path.join`
+   * preserves the drive letter and is used for the filesystem read.
+   *
    * @param projectRoot - Project root containing the `pyproject.toml`.
    * @returns The parsed `pyproject.toml` contents.
    */
   public getPyprojectToml(projectRoot: string): TPyprojectToml {
-    const pyprojectTomlPath = joinPathFragments(projectRoot, 'pyproject.toml');
     return this.tree
-      ? readPyprojectToml<TPyprojectToml>(this.tree, pyprojectTomlPath)
-      : getPyprojectData<TPyprojectToml>(pyprojectTomlPath);
+      ? readPyprojectToml<TPyprojectToml>(
+          this.tree,
+          joinPathFragments(projectRoot, 'pyproject.toml'),
+        )
+      : getPyprojectData<TPyprojectToml>(
+          path.join(projectRoot, 'pyproject.toml'),
+        );
   }
 
   /**


### PR DESCRIPTION
## Summary

On Windows, building any Python project that bundles local dependencies (`bundleLocalDependencies: true`) fails with:

```
Cannot read properties of undefined (reading 'build-backend')
```

## Root cause

`BaseProvider.getPyprojectToml` builds the pyproject path with `joinPathFragments`:

```ts
const pyprojectTomlPath = joinPathFragments(projectRoot, 'pyproject.toml');
```

`joinPathFragments` normalizes to POSIX and strips the drive letter. When there is no `tree` (executor context), `projectRoot` can be an absolute OS path — the build copies the project into a temporary folder from `os.tmpdir()` and re-reads it there. On Windows that folder is `C:\Users\...\AppData\Local\Temp\nx-python\build\<uuid>`, and `joinPathFragments` turns it into `/Users/.../nx-python/build/<uuid>/pyproject.toml` (drive letter gone).

`existsSync` then returns `false`, `getPyprojectData` returns `{}`, and the empty object has no `build-system`, so the build crashes at `buildTomlData['build-system']['build-backend']`.

Linux and macOS are unaffected because there is no drive letter to strip.

## Fix

Use `path.join` for the real-filesystem read (it preserves the drive letter) and keep `joinPathFragments` for the virtual `tree`, which expects workspace-relative POSIX paths. `path.join(os.tmpdir(), ...)` is already the established pattern elsewhere in this package.

## Tests

Added two unit tests to `base.spec.ts`:

- the filesystem branch preserves the drive letter for an absolute Windows path;
- the tree branch still reads a workspace-relative POSIX path.

`nx test nx-python` passes with no new failures.
