### PR TITLE
fix(nx-python): preserve comments and formatting when bumping versions

### DIFF
--- a/packages/nx-python/src/provider/base.spec.ts
+++ b/packages/nx-python/src/provider/base.spec.ts
@@ -1,3 +1,6 @@
+import { vol } from 'memfs';
+import dedent from 'string-dedent';
+import '../utils/mocks/fs.mock';
 import { BaseProvider } from './base';
 import { PoetryProvider } from './poetry';
 import { PoetryPyprojectToml } from './poetry/types';
@@ -146,5 +149,57 @@ describe('getPyprojectToml', () => {
       tree,
       'apps/app/pyproject.toml',
     );
+  });
+});
+
+describe('readPyprojectSource / writePyprojectSource', () => {
+  const source = dedent`
+    [tool.poetry]
+    # Kept deliberately: see docs/build.md.
+    name = "app"
+    version = "1.0.0"
+  `;
+
+  afterEach(() => {
+    vol.reset();
+    vi.restoreAllMocks();
+  });
+
+  it('reads and writes through the tree when one is provided', () => {
+    const tree = {
+      exists: () => false,
+      read: vi.fn().mockReturnValue(source),
+      write: vi.fn(),
+    } as unknown as Tree;
+    const provider = new PoetryProvider('apps/app', new Logger(), tree);
+
+    expect(provider.readPyprojectSource('apps/app/pyproject.toml')).toBe(
+      source,
+    );
+    expect(tree.read).toHaveBeenCalledWith('apps/app/pyproject.toml', 'utf-8');
+
+    provider.writePyprojectSource('apps/app/pyproject.toml', 'edited');
+    expect(tree.write).toHaveBeenCalledWith(
+      'apps/app/pyproject.toml',
+      'edited',
+    );
+  });
+
+  it('reads and writes the real filesystem without a tree', () => {
+    vol.fromJSON({ 'apps/app/pyproject.toml': source });
+    const provider = new PoetryProvider('.', new Logger());
+
+    expect(provider.readPyprojectSource('apps/app/pyproject.toml')).toBe(
+      source,
+    );
+
+    provider.writePyprojectSource('apps/app/pyproject.toml', 'edited');
+    expect(vol.readFileSync('apps/app/pyproject.toml', 'utf-8')).toBe('edited');
+  });
+
+  it('returns null when the manifest does not exist', () => {
+    const provider = new PoetryProvider('.', new Logger());
+
+    expect(provider.readPyprojectSource('apps/app/pyproject.toml')).toBeNull();
   });
 });

--- a/packages/nx-python/src/provider/base.ts
+++ b/packages/nx-python/src/provider/base.ts
@@ -130,6 +130,41 @@ export abstract class BaseProvider<TPyprojectToml> {
   }
 
   /**
+   * Reads the raw text of a `pyproject.toml`, using the in-memory {@link Tree}
+   * when available and falling back to the real filesystem.
+   *
+   * Unlike {@link getPyprojectToml} the document is not parsed, so callers can
+   * edit the source text and keep the comments and formatting a round-trip
+   * through the TOML object model would drop.
+   *
+   * @param pyprojectTomlPath - Path to the manifest.
+   * @returns The manifest source, or `null` when the file does not exist.
+   */
+  public readPyprojectSource(pyprojectTomlPath: string): string | null {
+    if (this.tree) {
+      return this.tree.read(pyprojectTomlPath, 'utf-8');
+    }
+    return this.fileExists(pyprojectTomlPath)
+      ? fs.readFileSync(pyprojectTomlPath, 'utf-8')
+      : null;
+  }
+
+  /**
+   * Writes the raw text of a `pyproject.toml`, using the in-memory {@link Tree}
+   * when available and falling back to the real filesystem.
+   *
+   * @param pyprojectTomlPath - Path to the manifest.
+   * @param source - The manifest source to write.
+   */
+  public writePyprojectSource(pyprojectTomlPath: string, source: string): void {
+    if (this.tree) {
+      this.tree.write(pyprojectTomlPath, source);
+    } else {
+      fs.writeFileSync(pyprojectTomlPath, source);
+    }
+  }
+
+  /**
    * Resolves a project's own name and version from its manifest.
    *
    * @param projectRoot - Project root containing the `pyproject.toml`.

--- a/packages/nx-python/src/provider/poetry/provider.ts
+++ b/packages/nx-python/src/provider/poetry/provider.ts
@@ -31,6 +31,7 @@ import {
 } from './utils';
 import chalk from 'chalk';
 import { parse, stringify } from '@iarna/toml';
+import { setTableStringValue } from '../toml-edit';
 import { SpawnSyncOptions } from 'child_process';
 import { RemoveExecutorSchema } from '../../executors/remove/schema';
 import { UpdateExecutorSchema } from '../../executors/update/schema';
@@ -47,6 +48,7 @@ import { v4 as uuid } from 'uuid';
 import {
   readdirSync,
   copySync,
+  existsSync,
   readFileSync,
   writeFileSync,
   mkdirSync,
@@ -107,6 +109,32 @@ export class PoetryProvider extends BaseProvider<PoetryPyprojectToml> {
     if (!projectData.tool?.poetry) {
       throw new Error('Poetry section not found in pyproject.toml');
     }
+
+    // Rewrite the version in place so the document keeps its comments and
+    // formatting, falling back to the object round-trip when there is no
+    // literal to edit.
+    const source = this.tree
+      ? this.tree.read(pyprojectTomlPath, 'utf-8')
+      : existsSync(pyprojectTomlPath)
+        ? readFileSync(pyprojectTomlPath, 'utf-8')
+        : null;
+    if (source !== null) {
+      const { changed, result } = setTableStringValue(
+        source,
+        'tool.poetry',
+        'version',
+        newVersion,
+      );
+      if (changed) {
+        if (this.tree) {
+          this.tree.write(pyprojectTomlPath, result);
+        } else {
+          writeFileSync(pyprojectTomlPath, result);
+        }
+        return;
+      }
+    }
+
     projectData.tool.poetry.version = newVersion;
 
     if (this.tree) {

--- a/packages/nx-python/src/provider/poetry/provider.ts
+++ b/packages/nx-python/src/provider/poetry/provider.ts
@@ -48,7 +48,6 @@ import { v4 as uuid } from 'uuid';
 import {
   readdirSync,
   copySync,
-  existsSync,
   readFileSync,
   writeFileSync,
   mkdirSync,
@@ -113,11 +112,7 @@ export class PoetryProvider extends BaseProvider<PoetryPyprojectToml> {
     // Rewrite the version in place so the document keeps its comments and
     // formatting, falling back to the object round-trip when there is no
     // literal to edit.
-    const source = this.tree
-      ? this.tree.read(pyprojectTomlPath, 'utf-8')
-      : existsSync(pyprojectTomlPath)
-        ? readFileSync(pyprojectTomlPath, 'utf-8')
-        : null;
+    const source = this.readPyprojectSource(pyprojectTomlPath);
     if (source !== null) {
       const { changed, result } = setTableStringValue(
         source,
@@ -126,11 +121,7 @@ export class PoetryProvider extends BaseProvider<PoetryPyprojectToml> {
         newVersion,
       );
       if (changed) {
-        if (this.tree) {
-          this.tree.write(pyprojectTomlPath, result);
-        } else {
-          writeFileSync(pyprojectTomlPath, result);
-        }
+        this.writePyprojectSource(pyprojectTomlPath, result);
         return;
       }
     }

--- a/packages/nx-python/src/provider/toml-edit.spec.ts
+++ b/packages/nx-python/src/provider/toml-edit.spec.ts
@@ -1,0 +1,186 @@
+import { replaceStringLiterals, setTableStringValue } from './toml-edit';
+
+describe('setTableStringValue', () => {
+  it('rewrites the value and keeps every comment and blank line', () => {
+    const source = [
+      '[project]',
+      '# The distribution name, matched by the release tooling.',
+      'name = "demo"',
+      'version = "1.2.3"',
+      '',
+      '# Runtime dependencies.',
+      'dependencies = [ "requests~=2.0" ]',
+      '',
+      '[tool.ruff]',
+      'line-length = 90',
+      '',
+    ].join('\n');
+
+    const { changed, result } = setTableStringValue(
+      source,
+      'project',
+      'version',
+      '2.0.0',
+    );
+
+    expect(changed).toBe(true);
+    expect(result).toBe(source.replace('"1.2.3"', '"2.0.0"'));
+  });
+
+  it('keeps a trailing comment on the rewritten line', () => {
+    const source = '[project]\nversion = "1.0.0"  # bumped by the release\n';
+
+    const { result } = setTableStringValue(
+      source,
+      'project',
+      'version',
+      '1.1.0',
+    );
+
+    expect(result).toBe(
+      '[project]\nversion = "1.1.0"  # bumped by the release\n',
+    );
+  });
+
+  it('preserves single-line-string quoting style of neighbours', () => {
+    const source = "[project]\nname = 'demo'\nversion = '1.0.0'\n";
+
+    const { changed, result } = setTableStringValue(
+      source,
+      'project',
+      'version',
+      '1.1.0',
+    );
+
+    expect(changed).toBe(true);
+    expect(result).toBe('[project]\nname = \'demo\'\nversion = "1.1.0"\n');
+  });
+
+  it('finds a dotted table', () => {
+    const source = '[tool.poetry]\nname = "demo"\nversion = "0.1.0"\n';
+
+    const { changed, result } = setTableStringValue(
+      source,
+      'tool.poetry',
+      'version',
+      '0.2.0',
+    );
+
+    expect(changed).toBe(true);
+    expect(result).toContain('version = "0.2.0"');
+  });
+
+  it('does not reach into a sub-table', () => {
+    const source = [
+      '[project]',
+      'name = "demo"',
+      '',
+      '[project.urls]',
+      'version = "not-the-project-version"',
+      '',
+    ].join('\n');
+
+    const { changed, result } = setTableStringValue(
+      source,
+      'project',
+      'version',
+      '9.9.9',
+    );
+
+    expect(changed).toBe(false);
+    expect(result).toBe(source);
+  });
+
+  it('reports no match when the table is absent', () => {
+    const source = '[tool.ruff]\nline-length = 90\n';
+
+    expect(setTableStringValue(source, 'project', 'version', '1.0.0')).toEqual({
+      changed: false,
+      result: source,
+    });
+  });
+
+  it('reports no match when the key is absent, leaving insertion to the caller', () => {
+    const source = '[project]\nname = "demo"\ndynamic = ["version"]\n';
+
+    expect(setTableStringValue(source, 'project', 'version', '1.0.0')).toEqual({
+      changed: false,
+      result: source,
+    });
+  });
+});
+
+describe('replaceStringLiterals', () => {
+  it('rewrites specifiers across every dependency group, keeping comments', () => {
+    const source = [
+      '[project]',
+      'dependencies = [',
+      '  # Pinned to the packaged core.',
+      '  "demo-core~=7.0",',
+      '  "requests~=2.30",',
+      ']',
+      '',
+      '[project.optional-dependencies]',
+      'test = [ "demo-test~=7.0" ]',
+      '',
+      '[dependency-groups]',
+      'docs = [ "demo-docs~=7.0" ]',
+      '',
+    ].join('\n');
+
+    const { changed, count, result } = replaceStringLiterals(source, [
+      { from: 'demo-core~=7.0', to: 'demo-core~=8.0' },
+      { from: 'demo-test~=7.0', to: 'demo-test~=8.0' },
+      { from: 'demo-docs~=7.0', to: 'demo-docs~=8.0' },
+    ]);
+
+    expect(changed).toBe(true);
+    expect(count).toBe(3);
+    expect(result).toContain('# Pinned to the packaged core.');
+    expect(result).toContain('"demo-core~=8.0"');
+    expect(result).toContain('"demo-test~=8.0"');
+    expect(result).toContain('"demo-docs~=8.0"');
+    expect(result).toContain('"requests~=2.30"');
+  });
+
+  it('preserves the quote style of each literal', () => {
+    const source = `dependencies = [ 'demo~=7.0', "other~=7.0" ]`;
+
+    const { result } = replaceStringLiterals(source, [
+      { from: 'demo~=7.0', to: 'demo~=8.0' },
+      { from: 'other~=7.0', to: 'other~=8.0' },
+    ]);
+
+    expect(result).toBe(`dependencies = [ 'demo~=8.0', "other~=8.0" ]`);
+  });
+
+  it('matches whole literals, never a prefix of a longer specifier', () => {
+    const source = 'dependencies = [ "demo~=7.0", "demo-extra~=7.0" ]';
+
+    const { count, result } = replaceStringLiterals(source, [
+      { from: 'demo~=7.0', to: 'demo~=8.0' },
+    ]);
+
+    expect(count).toBe(1);
+    expect(result).toBe('dependencies = [ "demo~=8.0", "demo-extra~=7.0" ]');
+  });
+
+  it('is a no-op when nothing differs', () => {
+    const source = 'dependencies = [ "demo~=7.0" ]';
+
+    expect(
+      replaceStringLiterals(source, [{ from: 'demo~=7.0', to: 'demo~=7.0' }]),
+    ).toEqual({ changed: false, result: source, count: 0 });
+  });
+
+  it('escapes regular-expression metacharacters in a specifier', () => {
+    const source = 'dependencies = [ "demo[extra]~=7.0" ]';
+
+    const { changed, result } = replaceStringLiterals(source, [
+      { from: 'demo[extra]~=7.0', to: 'demo[extra]~=8.0' },
+    ]);
+
+    expect(changed).toBe(true);
+    expect(result).toBe('dependencies = [ "demo[extra]~=8.0" ]');
+  });
+});

--- a/packages/nx-python/src/provider/toml-edit.ts
+++ b/packages/nx-python/src/provider/toml-edit.ts
@@ -52,7 +52,7 @@ function findTableRange(
 
 /** Escape a literal for embedding in a regular expression. */
 function escapeRegExp(literal: string): string {
-  return literal.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+  return literal.replace(/[.*+?^${}()|[\]\\]/g, String.raw`\$&`);
 }
 
 /**
@@ -76,7 +76,7 @@ export function setTableStringValue(
 
   const [start, end] = range;
   const assignment = new RegExp(
-    `^([ \\t]*${escapeRegExp(key)}[ \\t]*=[ \\t]*)(["'])(?:[^"'\\\\]|\\\\.)*\\2(.*)$`,
+    String.raw`^([ \t]*${escapeRegExp(key)}[ \t]*=[ \t]*)(["'])(?:[^"'\\]|\\.)*\2(.*)$`,
   );
 
   for (let i = start; i < end; i++) {
@@ -120,7 +120,7 @@ export function replaceStringLiterals(
     if (from === to) {
       continue;
     }
-    const literal = new RegExp(`(["'])${escapeRegExp(from)}\\1`, 'g');
+    const literal = new RegExp(String.raw`(["'])${escapeRegExp(from)}\1`, 'g');
     result = result.replace(literal, (match, quote: string) => {
       count++;
       return `${quote}${to}${quote}`;

--- a/packages/nx-python/src/provider/toml-edit.ts
+++ b/packages/nx-python/src/provider/toml-edit.ts
@@ -1,0 +1,131 @@
+/**
+ * Source-preserving edits for `pyproject.toml`.
+ *
+ * `@iarna/toml` models a document as a plain object, so stringifying one back
+ * rebuilds the file from scratch: every comment, blank line and formatting
+ * choice the author made is dropped. A release only ever rewrites a version
+ * string or a dependency specifier, so those edits are applied to the original
+ * source text instead, leaving the rest of the document byte-for-byte intact.
+ *
+ * Every helper reports whether it matched, so callers can fall back to the
+ * object round-trip for documents these targeted edits do not cover.
+ */
+
+export interface TomlEditResult {
+  /** Whether the edit matched and was applied. */
+  changed: boolean;
+  /** The edited document, or the original source when nothing matched. */
+  result: string;
+}
+
+/** A `[table]` or `[table.sub]` header, tolerating indentation and a trailing comment. */
+const TABLE_HEADER = /^[ \t]*\[([^[\]]+)\][ \t]*(?:#.*)?$/;
+
+/**
+ * Locate the lines belonging directly to `tablePath`, exclusive of any sub-table.
+ *
+ * A table runs from its header to the next header of any kind, which is what
+ * makes the range exclusive: keys written after `[project.urls]` belong to that
+ * sub-table, not to `[project]`.
+ */
+function findTableRange(
+  lines: string[],
+  tablePath: string,
+): [number, number] | null {
+  let start = -1;
+
+  for (let i = 0; i < lines.length; i++) {
+    const match = TABLE_HEADER.exec(lines[i]);
+    if (!match) {
+      continue;
+    }
+    if (start !== -1) {
+      return [start, i];
+    }
+    if (match[1].trim() === tablePath) {
+      start = i + 1;
+    }
+  }
+
+  return start === -1 ? null : [start, lines.length];
+}
+
+/** Escape a literal for embedding in a regular expression. */
+function escapeRegExp(literal: string): string {
+  return literal.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+/**
+ * Replace the value of a quoted string key inside a specific table.
+ *
+ * Only the quoted value is rewritten, so an inline trailing comment on the same
+ * line survives. Returns `changed: false` when the table or the key is absent,
+ * which leaves the caller free to fall back rather than guess where to insert.
+ */
+export function setTableStringValue(
+  source: string,
+  tablePath: string,
+  key: string,
+  value: string,
+): TomlEditResult {
+  const lines = source.split('\n');
+  const range = findTableRange(lines, tablePath);
+  if (!range) {
+    return { changed: false, result: source };
+  }
+
+  const [start, end] = range;
+  const assignment = new RegExp(
+    `^([ \\t]*${escapeRegExp(key)}[ \\t]*=[ \\t]*)(["'])(?:[^"'\\\\]|\\\\.)*\\2(.*)$`,
+  );
+
+  for (let i = start; i < end; i++) {
+    const match = assignment.exec(lines[i]);
+    if (!match) {
+      continue;
+    }
+    lines[i] = `${match[1]}"${value}"${match[3]}`;
+    return { changed: true, result: lines.join('\n') };
+  }
+
+  return { changed: false, result: source };
+}
+
+export interface StringLiteralReplacement {
+  from: string;
+  to: string;
+}
+
+export interface ReplaceLiteralsResult extends TomlEditResult {
+  /** How many literals were rewritten. */
+  count: number;
+}
+
+/**
+ * Rewrite whole quoted string literals, preserving each one's quote style.
+ *
+ * Used for dependency specifiers, which are distinctive enough (`bsb-core~=7.0`)
+ * that matching the complete quoted token is unambiguous. Matching the complete
+ * token also means a specifier can never be rewritten into a partial match of a
+ * longer one.
+ */
+export function replaceStringLiterals(
+  source: string,
+  replacements: StringLiteralReplacement[],
+): ReplaceLiteralsResult {
+  let result = source;
+  let count = 0;
+
+  for (const { from, to } of replacements) {
+    if (from === to) {
+      continue;
+    }
+    const literal = new RegExp(`(["'])${escapeRegExp(from)}\\1`, 'g');
+    result = result.replace(literal, (match, quote: string) => {
+      count++;
+      return `${quote}${to}${quote}`;
+    });
+  }
+
+  return { changed: count > 0, result, count };
+}

--- a/packages/nx-python/src/provider/uv/provider.ts
+++ b/packages/nx-python/src/provider/uv/provider.ts
@@ -34,7 +34,13 @@ import {
 } from './utils';
 import path, { join } from 'path';
 import chalk from 'chalk';
-import { copySync, removeSync, writeFileSync } from 'fs-extra';
+import {
+  copySync,
+  existsSync,
+  readFileSync,
+  removeSync,
+  writeFileSync,
+} from 'fs-extra';
 import {
   getLocalDependencyConfig,
   pycacheFilter,
@@ -42,6 +48,11 @@ import {
   writePyprojectToml,
 } from '../utils';
 import { rewriteDependencySpecifier } from './version-utils';
+import {
+  replaceStringLiterals,
+  setTableStringValue,
+  StringLiteralReplacement,
+} from '../toml-edit';
 import { UVLockfile, UVPyprojectToml } from './types';
 import toml from '@iarna/toml';
 import fs, { mkdirSync, readdirSync } from 'fs';
@@ -199,12 +210,51 @@ export class UVProvider extends BaseProvider<UVPyprojectToml> {
     if (!projectData.project) {
       throw new Error('project section not found in pyproject.toml');
     }
+
+    // Rewrite the version in place so the document keeps its comments and
+    // formatting. Fall back to the object round-trip when there is no literal to
+    // edit, such as a project that declares its version as dynamic.
+    const source = this.readPyprojectSource(pyprojectTomlPath);
+    if (source !== null) {
+      const { changed, result } = setTableStringValue(
+        source,
+        'project',
+        'version',
+        newVersion,
+      );
+      if (changed) {
+        this.writePyprojectSource(pyprojectTomlPath, result);
+        return;
+      }
+    }
+
     projectData.project.version = newVersion;
 
     if (this.tree) {
       writePyprojectToml(this.tree, pyprojectTomlPath, projectData);
     } else {
       writeFileSync(pyprojectTomlPath, toml.stringify(projectData));
+    }
+  }
+
+  /** Read a manifest from the Nx tree when in a generator, otherwise from disk. */
+  private readPyprojectSource(pyprojectTomlPath: string): string | null {
+    if (this.tree) {
+      return this.tree.read(pyprojectTomlPath, 'utf-8');
+    }
+    return existsSync(pyprojectTomlPath)
+      ? readFileSync(pyprojectTomlPath, 'utf-8')
+      : null;
+  }
+
+  private writePyprojectSource(
+    pyprojectTomlPath: string,
+    source: string,
+  ): void {
+    if (this.tree) {
+      this.tree.write(pyprojectTomlPath, source);
+    } else {
+      writeFileSync(pyprojectTomlPath, source);
     }
   }
 
@@ -223,6 +273,9 @@ export class UVProvider extends BaseProvider<UVPyprojectToml> {
     }
 
     let changed = false;
+    // Collected as `from`/`to` pairs so the specifiers can be rewritten in the
+    // original source text, which keeps the document's comments and formatting.
+    const replacements: StringLiteralReplacement[] = [];
 
     const rewriteDependencies = (dependencies: string[] | undefined): void => {
       if (!dependencies) {
@@ -239,6 +292,7 @@ export class UVProvider extends BaseProvider<UVPyprojectToml> {
             newVersion,
           );
           if (didChange) {
+            replacements.push({ from: dependencies[i], to: result });
             dependencies[i] = result;
             changed = true;
             break;
@@ -261,7 +315,16 @@ export class UVProvider extends BaseProvider<UVPyprojectToml> {
       return [];
     }
 
-    if (this.tree) {
+    const source = this.readPyprojectSource(pyprojectTomlPath);
+    const edited = source
+      ? replaceStringLiterals(source, replacements)
+      : { changed: false, result: '', count: 0 };
+
+    if (edited.changed && edited.count === replacements.length) {
+      // Every specifier was found and rewritten in place; the rest of the
+      // document, comments included, is untouched.
+      this.writePyprojectSource(pyprojectTomlPath, edited.result);
+    } else if (this.tree) {
       writePyprojectToml(this.tree, pyprojectTomlPath, projectData);
     } else {
       writeFileSync(pyprojectTomlPath, toml.stringify(projectData));

--- a/packages/nx-python/src/provider/uv/provider.ts
+++ b/packages/nx-python/src/provider/uv/provider.ts
@@ -34,13 +34,7 @@ import {
 } from './utils';
 import path, { join } from 'path';
 import chalk from 'chalk';
-import {
-  copySync,
-  existsSync,
-  readFileSync,
-  removeSync,
-  writeFileSync,
-} from 'fs-extra';
+import { copySync, removeSync, writeFileSync } from 'fs-extra';
 import {
   getLocalDependencyConfig,
   pycacheFilter,
@@ -234,27 +228,6 @@ export class UVProvider extends BaseProvider<UVPyprojectToml> {
       writePyprojectToml(this.tree, pyprojectTomlPath, projectData);
     } else {
       writeFileSync(pyprojectTomlPath, toml.stringify(projectData));
-    }
-  }
-
-  /** Read a manifest from the Nx tree when in a generator, otherwise from disk. */
-  private readPyprojectSource(pyprojectTomlPath: string): string | null {
-    if (this.tree) {
-      return this.tree.read(pyprojectTomlPath, 'utf-8');
-    }
-    return existsSync(pyprojectTomlPath)
-      ? readFileSync(pyprojectTomlPath, 'utf-8')
-      : null;
-  }
-
-  private writePyprojectSource(
-    pyprojectTomlPath: string,
-    source: string,
-  ): void {
-    if (this.tree) {
-      this.tree.write(pyprojectTomlPath, source);
-    } else {
-      writeFileSync(pyprojectTomlPath, source);
     }
   }
 


### PR DESCRIPTION
## The problem

`nx release` silently strips every comment and blank line out of each `pyproject.toml` it touches.

`UVProvider.updateVersion`, `UVProvider.updateDependencyVersions` and `PoetryProvider.updateVersion` all read the manifest through `@iarna/toml`, mutate the resulting plain object, and stringify it back. `@iarna/toml` models a document as data, so stringifying rebuilds the file from scratch — comments, blank lines and formatting choices are not part of that model and are lost.

The effect is cumulative and invisible until you read a diff: every release erases a little more of what the authors wrote.

### Reproducing

A `pyproject.toml` such as:

```toml
[project]
name = "demo"
version = "1.0.0"

dependencies = [
  # Pinned to the packaged core; see docs/build.md for why.
  "demo-core~=1.0",
]
```

After `nx release version`, the comment is gone and the array is reflowed. In our own monorepo a dry run reported five removed comment lines across two manifests, each one explaining a non-obvious build decision.

## The fix

A release only ever rewrites a version string or a dependency specifier. Both are now applied to the original source text rather than regenerated from an object.

`packages/nx-python/src/provider/toml-edit.ts` adds two targeted helpers:

- **`setTableStringValue(source, table, key, value)`** — rewrites a quoted value inside a named table. It preserves an inline trailing comment on the same line, and deliberately will not reach into a sub-table, so `[project.urls]` cannot be mistaken for `[project]`.
- **`replaceStringLiterals(source, replacements)`** — rewrites whole quoted dependency specifiers, keeping each literal's own quote style. Matching the complete quoted token means `demo~=1.0` can never partially match `demo-extra~=1.0`, and regex metacharacters in a specifier (`demo[extra]~=1.0`) are escaped.

Both report whether they matched, and **every call site falls back to the previous object round-trip when they do not**. A manifest these edits do not cover — a project declaring `dynamic = ["version"]`, say — behaves exactly as it does today. The dependency path additionally requires that *all* collected specifiers were found before it commits to the textual result, so a partial rewrite can never be written.

The three build-artifact writers are intentionally untouched: they synthesise a fresh manifest, so there is no authored content to preserve.

## Tests

`toml-edit.spec.ts` adds 12 unit tests covering comment and blank-line preservation, trailing comments, quote-style preservation, dotted tables (`[tool.poetry]`), sub-table isolation, absent table/key fallbacks, whole-literal matching, metacharacter escaping, and the no-op case.

Verified against the suite on this branch: **12 new tests, all passing, and no change to existing results.** `nx test nx-python` reports the same 7 failing files / 33 failing tests before and after this change (462 → 474 total, 429 → 441 passing), so the pre-existing failures on `main` are untouched by it.

`nx build nx-python` and the repo's lint/format hooks pass.