### PR TITLE
fix(nx-python): render chalk templates with chalk-template and fix build input hashing

### DIFF
--- a/nx.json
+++ b/nx.json
@@ -41,7 +41,7 @@
       "!{projectRoot}/.eslintrc.json",
       "!{projectRoot}/eslint.config.js",
       "!{projectRoot}/**/?(*.)+(spec|test).[jt]s?(x)?(.snap)",
-      "!{projectRoot}/**/?(*.)+(mock).[jt]s?(x)?",
+      "!{projectRoot}/**/?(*.)+(mock).[jt]s?(x)",
       "!{projectRoot}/tsconfig.spec.json",
       "!{projectRoot}/vite.config.[jt]s",
       "!{projectRoot}/src/test-setup.[jt]s",

--- a/package.json
+++ b/package.json
@@ -73,6 +73,7 @@
     "aws-lambda": "^1.0.7",
     "axios": "^1.7.7",
     "chalk": "^5.6.2",
+    "chalk-template": "^1.1.2",
     "command-exists": "^1.2.9",
     "cross-spawn": "^7.0.3",
     "dynamoose": "^4.0.0",

--- a/packages/nx-python/package.json
+++ b/packages/nx-python/package.json
@@ -37,6 +37,7 @@
     "@renovatebot/pep440": "^5.0.0",
     "archiver": "^8.0.0",
     "chalk": "^5.6.2",
+    "chalk-template": "^1.1.2",
     "command-exists": "^1.2.9",
     "cross-spawn": "^7.0.3",
     "file-uri-to-path": "^2.0.0",

--- a/packages/nx-python/src/executors/add/executor.spec.ts
+++ b/packages/nx-python/src/executors/add/executor.spec.ts
@@ -6,7 +6,7 @@ import * as poetryUtils from '../../provider/poetry/utils';
 import { UVProvider } from '../../provider/uv/provider';
 import { PoetryProvider } from '../../provider/poetry/provider';
 import executor from './executor';
-import chalk from 'chalk';
+import chalkTemplate from 'chalk-template';
 import { parseToml } from '../../provider/poetry/utils';
 import dedent from 'string-dedent';
 import spawn from 'cross-spawn';
@@ -14,7 +14,7 @@ import { ExecutorContext } from '@nx/devkit';
 
 describe('Add Executor', () => {
   beforeAll(() => {
-    console.log(chalk`init chalk`);
+    console.log(chalkTemplate`init chalk`);
   });
 
   afterEach(() => {

--- a/packages/nx-python/src/executors/add/executor.ts
+++ b/packages/nx-python/src/executors/add/executor.ts
@@ -1,6 +1,6 @@
 import { ExecutorContext } from '@nx/devkit';
 import { AddExecutorSchema } from './schema';
-import chalk from 'chalk';
+import chalkTemplate from 'chalk-template';
 import { getProvider } from '../../provider';
 
 export default async function executor(
@@ -21,7 +21,7 @@ export default async function executor(
       success: true,
     };
   } catch (error) {
-    console.log(chalk`\n  {bgRed.bold  ERROR } ${error.message}\n`);
+    console.log(chalkTemplate`\n  {bgRed.bold  ERROR } ${error.message}\n`);
     return {
       success: false,
     };

--- a/packages/nx-python/src/executors/build/executor.spec.ts
+++ b/packages/nx-python/src/executors/build/executor.spec.ts
@@ -11,7 +11,7 @@ import { existsSync, readFileSync, mkdirsSync, writeFileSync } from 'fs-extra';
 import { parse } from '@iarna/toml';
 import { join } from 'path';
 import { tmpdir } from 'os';
-import chalk from 'chalk';
+import chalkTemplate from 'chalk-template';
 import dedent from 'string-dedent';
 import spawn from 'cross-spawn';
 import { SpawnSyncOptions } from 'child_process';
@@ -23,9 +23,10 @@ import { UVPyprojectToml } from '../../provider/uv/types';
 
 describe('Build Executor', () => {
   let buildPath = null;
+  let consoleInfoSpy: MockInstance;
 
   beforeAll(() => {
-    console.log(chalk`init chalk`);
+    console.log(chalkTemplate`init chalk`);
   });
 
   beforeEach(() => {
@@ -42,9 +43,16 @@ describe('Build Executor', () => {
     });
 
     vi.spyOn(process, 'chdir').mockReturnValue(undefined);
+    consoleInfoSpy = vi.spyOn(console, 'info');
   });
 
   afterEach(() => {
+    // chalk 5 dropped tagged-template support; a `chalk\`{bold ...}\`` call prints
+    // the raw template. Every logged line must come out fully rendered.
+    for (const [message] of consoleInfoSpy.mock.calls) {
+      expect(String(message)).not.toMatch(/\{[a-z][a-zA-Z.]* /);
+    }
+
     vol.reset();
     vi.resetAllMocks();
   });

--- a/packages/nx-python/src/executors/build/executor.ts
+++ b/packages/nx-python/src/executors/build/executor.ts
@@ -1,6 +1,6 @@
 import { ExecutorContext } from '@nx/devkit';
 import { BuildExecutorOutput, BuildExecutorSchema } from './schema';
-import chalk from 'chalk';
+import chalkTemplate from 'chalk-template';
 import { Logger } from '../utils/logger';
 import { getProvider } from '../../provider';
 
@@ -27,7 +27,7 @@ export default async function executor(
       success: true,
     };
   } catch (error) {
-    logger.info(chalk`\n  {bgRed.bold  ERROR } ${error.message}\n`);
+    logger.info(chalkTemplate`\n  {bgRed.bold  ERROR } ${error.message}\n`);
     return {
       buildFolderPath: '',
       success: false,

--- a/packages/nx-python/src/executors/flake8/executor.spec.ts
+++ b/packages/nx-python/src/executors/flake8/executor.spec.ts
@@ -1,6 +1,6 @@
 import { vi, MockInstance } from 'vitest';
 import { vol } from 'memfs';
-import chalk from 'chalk';
+import chalkTemplate from 'chalk-template';
 import '../../utils/mocks/fs.mock';
 import '../../utils/mocks/cross-spawn.mock';
 import * as poetryUtils from '../../provider/poetry/utils';
@@ -18,7 +18,7 @@ describe('Flake8 Executor', () => {
   let tmppath = null;
 
   beforeAll(() => {
-    console.log(chalk`init chalk`);
+    console.log(chalkTemplate`init chalk`);
   });
 
   afterEach(() => {

--- a/packages/nx-python/src/executors/flake8/executor.ts
+++ b/packages/nx-python/src/executors/flake8/executor.ts
@@ -1,5 +1,5 @@
 import { ExecutorContext } from '@nx/devkit';
-import chalk from 'chalk';
+import chalkTemplate from 'chalk-template';
 import { Logger } from '../utils/logger';
 import { Flake8ExecutorSchema } from './schema';
 import path from 'path';
@@ -17,7 +17,7 @@ export default async function executor(
   process.chdir(workspaceRoot);
   try {
     logger.info(
-      chalk`\n  {bold Running flake8 linting on project {bgBlue  ${context.projectName} }...}\n`,
+      chalkTemplate`\n  {bold Running flake8 linting on project {bgBlue  ${context.projectName} }...}\n`,
     );
 
     const projectConfig =
@@ -56,17 +56,19 @@ export default async function executor(
     const output = readFileSync(absPath, 'utf8');
     const lines = output.split('\n').length;
     if (lines > 1) {
-      logger.info(chalk`\n  {bgRed.bold  ERROR } linting issues\n${output}`);
+      logger.info(
+        chalkTemplate`\n  {bgRed.bold  ERROR } linting issues\n${output}`,
+      );
       return { success: false };
     }
 
-    logger.info(chalk`\n  {green All files pass linting.}\n`);
+    logger.info(chalkTemplate`\n  {green All files pass linting.}\n`);
 
     return {
       success: true,
     };
   } catch (error) {
-    logger.info(chalk`\n  {bgRed.bold  ERROR } ${error.message}\n`);
+    logger.info(chalkTemplate`\n  {bgRed.bold  ERROR } ${error.message}\n`);
     return {
       success: false,
     };

--- a/packages/nx-python/src/executors/install/executor.ts
+++ b/packages/nx-python/src/executors/install/executor.ts
@@ -1,7 +1,7 @@
 import { InstallExecutorSchema } from './schema';
 import { Logger } from '../utils/logger';
 import { ExecutorContext } from '@nx/devkit';
-import chalk from 'chalk';
+import chalkTemplate from 'chalk-template';
 import { getProvider } from '../../provider';
 
 const logger = new Logger();
@@ -26,7 +26,7 @@ export default async function executor(
       success: true,
     };
   } catch (error) {
-    logger.info(chalk`\n  {bgRed.bold  ERROR } ${error.message}\n`);
+    logger.info(chalkTemplate`\n  {bgRed.bold  ERROR } ${error.message}\n`);
     return {
       success: false,
     };

--- a/packages/nx-python/src/executors/lock/executor.ts
+++ b/packages/nx-python/src/executors/lock/executor.ts
@@ -1,7 +1,7 @@
 import { LockExecutorSchema } from './schema';
 import { Logger } from '../utils/logger';
 import { ExecutorContext } from '@nx/devkit';
-import chalk from 'chalk';
+import chalkTemplate from 'chalk-template';
 import { getProvider } from '../../provider';
 
 const logger = new Logger();
@@ -26,7 +26,7 @@ export default async function executor(
       success: true,
     };
   } catch (error) {
-    logger.info(chalk`\n  {bgRed.bold  ERROR } ${error.message}\n`);
+    logger.info(chalkTemplate`\n  {bgRed.bold  ERROR } ${error.message}\n`);
     return {
       success: false,
     };

--- a/packages/nx-python/src/executors/package-dependencies/executor.ts
+++ b/packages/nx-python/src/executors/package-dependencies/executor.ts
@@ -1,5 +1,5 @@
 import { ExecutorContext } from '@nx/devkit';
-import chalk from 'chalk';
+import chalkTemplate from 'chalk-template';
 import { Logger } from '../utils/logger';
 import { ExecutorSchema } from './schema';
 import path from 'path';
@@ -63,7 +63,7 @@ export default async function executor(
 
   try {
     logger.info(
-      chalk`\n  {bold Packaging dependencies for project {bgBlue  ${context.projectName} } to {bgBlue  ${options.outputType} } }\n`,
+      chalkTemplate`\n  {bold Packaging dependencies for project {bgBlue  ${context.projectName} } to {bgBlue  ${options.outputType} } }\n`,
     );
 
     const targetDir =
@@ -103,10 +103,12 @@ export default async function executor(
       );
     }
 
-    logger.info(chalk`\n  {bold Installing dependencies...}\n`);
-    logger.info(chalk`  {bold Python version: ${options.pythonVersion} }`);
-    logger.info(chalk`  {bold ABI: ${options.abi} }`);
-    logger.info(chalk`  {bold Platform: ${options.platform} }`);
+    logger.info(chalkTemplate`\n  {bold Installing dependencies...}\n`);
+    logger.info(
+      chalkTemplate`  {bold Python version: ${options.pythonVersion} }`,
+    );
+    logger.info(chalkTemplate`  {bold ABI: ${options.abi} }`);
+    logger.info(chalkTemplate`  {bold Platform: ${options.platform} }`);
     const pipResult = spawn.sync(
       'pip',
       [
@@ -138,7 +140,7 @@ export default async function executor(
     }
 
     if (options.outputType === 'zip') {
-      logger.info(chalk`\n  {bold Creating zip file...}\n`);
+      logger.info(chalkTemplate`\n  {bold Creating zip file...}\n`);
 
       const outputDir = path.dirname(options.outputPath);
       if (!existsSync(outputDir)) {
@@ -164,21 +166,21 @@ export default async function executor(
       await new Promise((resolve, reject) => {
         outputStream.on('error', (err) => {
           logger.info(
-            chalk`\n  {bgRed.bold  ERROR } Error finalizing archive: ${err.message}\n`,
+            chalkTemplate`\n  {bgRed.bold  ERROR } Error finalizing archive: ${err.message}\n`,
           );
           reject(err);
         });
 
         outputStream.on('close', () => {
           logger.info(
-            chalk`\n  {bold Zip file created at {bgBlue  ${options.outputPath} } ${archive.pointer()} bytes }\n`,
+            chalkTemplate`\n  {bold Zip file created at {bgBlue  ${options.outputPath} } ${archive.pointer()} bytes }\n`,
           );
           resolve(undefined);
         });
       });
     } else {
       logger.info(
-        chalk`\n  {bold Folder created at {bgBlue  ${options.outputPath} } }\n`,
+        chalkTemplate`\n  {bold Folder created at {bgBlue  ${options.outputPath} } }\n`,
       );
     }
 
@@ -186,7 +188,7 @@ export default async function executor(
       success: true,
     };
   } catch (error) {
-    logger.info(chalk`\n  {bgRed.bold  ERROR } ${error.message}\n`);
+    logger.info(chalkTemplate`\n  {bgRed.bold  ERROR } ${error.message}\n`);
     return {
       success: false,
     };

--- a/packages/nx-python/src/executors/package-project/executor.ts
+++ b/packages/nx-python/src/executors/package-project/executor.ts
@@ -1,5 +1,5 @@
 import { ExecutorContext } from '@nx/devkit';
-import chalk from 'chalk';
+import chalkTemplate from 'chalk-template';
 import { Logger } from '../utils/logger';
 import { ExecutorSchema } from './schema';
 import path from 'path';
@@ -33,7 +33,7 @@ export default async function executor(
 
   try {
     logger.info(
-      chalk`\n  {bold Packaging project {bgBlue  ${context.projectName} } to {bgBlue  ${options.outputType} } }\n`,
+      chalkTemplate`\n  {bold Packaging project {bgBlue  ${context.projectName} } to {bgBlue  ${options.outputType} } }\n`,
     );
 
     const targetDir =
@@ -63,7 +63,7 @@ export default async function executor(
     );
 
     if (options.outputType === 'zip') {
-      logger.info(chalk`\n  {bold Creating zip file...}\n`);
+      logger.info(chalkTemplate`\n  {bold Creating zip file...}\n`);
 
       const outputDir = path.dirname(options.outputPath);
       if (!existsSync(outputDir)) {
@@ -94,21 +94,21 @@ export default async function executor(
       await new Promise((resolve, reject) => {
         outputStream.on('error', (err) => {
           logger.info(
-            chalk`\n  {bgRed.bold  ERROR } Error finalizing archive: ${err.message}\n`,
+            chalkTemplate`\n  {bgRed.bold  ERROR } Error finalizing archive: ${err.message}\n`,
           );
           reject(err);
         });
 
         outputStream.on('close', () => {
           logger.info(
-            chalk`\n  {bold Zip file created at {bgBlue  ${options.outputPath} } ${archive.pointer()} bytes }\n`,
+            chalkTemplate`\n  {bold Zip file created at {bgBlue  ${options.outputPath} } ${archive.pointer()} bytes }\n`,
           );
           resolve(undefined);
         });
       });
     } else {
       logger.info(
-        chalk`\n  {bold Folder created at {bgBlue  ${options.outputPath} } }\n`,
+        chalkTemplate`\n  {bold Folder created at {bgBlue  ${options.outputPath} } }\n`,
       );
     }
 
@@ -116,7 +116,7 @@ export default async function executor(
       success: true,
     };
   } catch (error) {
-    logger.info(chalk`\n  {bgRed.bold  ERROR } ${error.message}\n`);
+    logger.info(chalkTemplate`\n  {bgRed.bold  ERROR } ${error.message}\n`);
     return {
       success: false,
     };

--- a/packages/nx-python/src/executors/publish/executor.spec.ts
+++ b/packages/nx-python/src/executors/publish/executor.spec.ts
@@ -54,7 +54,7 @@ vi.mock('child_process', async (importOriginal) => {
   };
 });
 
-import chalk from 'chalk';
+import chalkTemplate from 'chalk-template';
 import * as poetryUtils from '../../provider/poetry/utils';
 import executor from './executor';
 import { EventEmitter } from 'events';
@@ -65,7 +65,7 @@ import { PoetryProvider } from '../../provider/poetry/provider';
 
 describe('Publish Executor', () => {
   beforeAll(() => {
-    console.log(chalk`init chalk`);
+    console.log(chalkTemplate`init chalk`);
   });
 
   afterEach(() => {

--- a/packages/nx-python/src/executors/publish/executor.ts
+++ b/packages/nx-python/src/executors/publish/executor.ts
@@ -1,6 +1,6 @@
 import { ExecutorContext } from '@nx/devkit';
 import { PublishExecutorSchema } from './schema';
-import chalk from 'chalk';
+import chalkTemplate from 'chalk-template';
 import { Logger } from '../utils/logger';
 import { getProvider } from '../../provider';
 
@@ -28,7 +28,7 @@ export default async function executor(
     };
   } catch (error) {
     logger.info(
-      chalk`\n  {bgRed.bold  ERROR } {bold The publish command failed}:\n\n  {bold ${error.message}}\n`,
+      chalkTemplate`\n  {bgRed.bold  ERROR } {bold The publish command failed}:\n\n  {bold ${error.message}}\n`,
     );
 
     return {

--- a/packages/nx-python/src/executors/remove/executor.spec.ts
+++ b/packages/nx-python/src/executors/remove/executor.spec.ts
@@ -3,7 +3,7 @@ import { vol } from 'memfs';
 import '../../utils/mocks/fs.mock';
 import '../../utils/mocks/cross-spawn.mock';
 import * as poetryUtils from '../../provider/poetry/utils';
-import chalk from 'chalk';
+import chalkTemplate from 'chalk-template';
 import executor from './executor';
 import dedent from 'string-dedent';
 import spawn from 'cross-spawn';
@@ -18,7 +18,7 @@ describe('Delete Executor', () => {
   });
 
   beforeAll(() => {
-    console.log(chalk`init chalk`);
+    console.log(chalkTemplate`init chalk`);
   });
 
   describe('poetry', () => {

--- a/packages/nx-python/src/executors/remove/executor.ts
+++ b/packages/nx-python/src/executors/remove/executor.ts
@@ -1,5 +1,5 @@
 import { ExecutorContext } from '@nx/devkit';
-import chalk from 'chalk';
+import chalkTemplate from 'chalk-template';
 import { RemoveExecutorSchema } from './schema';
 import { getProvider } from '../../provider';
 
@@ -22,7 +22,7 @@ export default async function executor(
       success: true,
     };
   } catch (error) {
-    console.log(chalk`\n  {bgRed.bold  ERROR } ${error.message}\n`);
+    console.log(chalkTemplate`\n  {bgRed.bold  ERROR } ${error.message}\n`);
     return {
       success: false,
     };

--- a/packages/nx-python/src/executors/ruff-check/executor.spec.ts
+++ b/packages/nx-python/src/executors/ruff-check/executor.spec.ts
@@ -1,6 +1,6 @@
 import { vi, MockInstance } from 'vitest';
 import { vol } from 'memfs';
-import chalk from 'chalk';
+import chalkTemplate from 'chalk-template';
 import '../../utils/mocks/fs.mock';
 import '../../utils/mocks/cross-spawn.mock';
 import * as poetryUtils from '../../provider/poetry/utils';
@@ -12,7 +12,7 @@ import { PoetryProvider } from '../../provider/poetry/provider';
 
 describe('Ruff Check Executor', () => {
   beforeAll(() => {
-    console.log(chalk`init chalk`);
+    console.log(chalkTemplate`init chalk`);
   });
 
   afterEach(() => {

--- a/packages/nx-python/src/executors/ruff-check/executor.ts
+++ b/packages/nx-python/src/executors/ruff-check/executor.ts
@@ -1,5 +1,5 @@
 import { ExecutorContext } from '@nx/devkit';
-import chalk from 'chalk';
+import chalkTemplate from 'chalk-template';
 import { Logger } from '../utils/logger';
 import { RuffCheckExecutorSchema } from './schema';
 import { getProvider } from '../../provider';
@@ -15,7 +15,7 @@ export default async function executor(
   process.chdir(workspaceRoot);
   try {
     logger.info(
-      chalk`\n{bold Running ruff check on project {bgBlue  ${context.projectName} }...}\n`,
+      chalkTemplate`\n{bold Running ruff check on project {bgBlue  ${context.projectName} }...}\n`,
     );
 
     const projectConfig =
@@ -65,7 +65,7 @@ export default async function executor(
       success: true,
     };
   } catch (error) {
-    logger.info(chalk`\n  {bgRed.bold  ERROR } ${error.message}\n`);
+    logger.info(chalkTemplate`\n  {bgRed.bold  ERROR } ${error.message}\n`);
     return {
       success: false,
     };

--- a/packages/nx-python/src/executors/ruff-format/executor.spec.ts
+++ b/packages/nx-python/src/executors/ruff-format/executor.spec.ts
@@ -1,6 +1,6 @@
 import { vi, MockInstance } from 'vitest';
 import { vol } from 'memfs';
-import chalk from 'chalk';
+import chalkTemplate from 'chalk-template';
 import '../../utils/mocks/fs.mock';
 import '../../utils/mocks/cross-spawn.mock';
 import * as poetryUtils from '../../provider/poetry/utils';
@@ -12,7 +12,7 @@ import { PoetryProvider } from '../../provider/poetry/provider';
 
 describe('Ruff Format Executor', () => {
   beforeAll(() => {
-    console.log(chalk`init chalk`);
+    console.log(chalkTemplate`init chalk`);
   });
 
   afterEach(() => {

--- a/packages/nx-python/src/executors/ruff-format/executor.ts
+++ b/packages/nx-python/src/executors/ruff-format/executor.ts
@@ -1,5 +1,5 @@
 import { ExecutorContext } from '@nx/devkit';
-import chalk from 'chalk';
+import chalkTemplate from 'chalk-template';
 import { getProvider } from '../../provider';
 import { extractBooleanFlag } from '../utils/args';
 import { Logger } from '../utils/logger';
@@ -15,7 +15,7 @@ export default async function executor(
   process.chdir(workspaceRoot);
   try {
     logger.info(
-      chalk`\n{bold Running ruff format on project {bgBlue  ${context.projectName} }...}\n`,
+      chalkTemplate`\n{bold Running ruff format on project {bgBlue  ${context.projectName} }...}\n`,
     );
 
     const projectConfig =
@@ -55,7 +55,7 @@ export default async function executor(
       success: true,
     };
   } catch (error) {
-    logger.info(chalk`\n  {bgRed.bold  ERROR } ${error.message}\n`);
+    logger.info(chalkTemplate`\n  {bgRed.bold  ERROR } ${error.message}\n`);
     return {
       success: false,
     };

--- a/packages/nx-python/src/executors/sls-deploy/executor.spec.ts
+++ b/packages/nx-python/src/executors/sls-deploy/executor.spec.ts
@@ -2,7 +2,7 @@ import { vi, MockInstance } from 'vitest';
 import { vol } from 'memfs';
 import '../../utils/mocks/fs.mock';
 import '../../utils/mocks/cross-spawn.mock';
-import chalk from 'chalk';
+import chalkTemplate from 'chalk-template';
 import * as poetryUtils from '../../provider/poetry/utils';
 import executor from './executor';
 import spawn from 'cross-spawn';
@@ -34,7 +34,7 @@ describe('Serverless Framework Deploy Executor', () => {
   };
 
   beforeAll(() => {
-    console.log(chalk`init chalk`);
+    console.log(chalkTemplate`init chalk`);
   });
 
   afterEach(() => {

--- a/packages/nx-python/src/executors/sls-deploy/executor.ts
+++ b/packages/nx-python/src/executors/sls-deploy/executor.ts
@@ -1,5 +1,5 @@
 import { ExecutorContext } from '@nx/devkit';
-import chalk from 'chalk';
+import chalkTemplate from 'chalk-template';
 import spawn from 'cross-spawn';
 import { Logger } from '../utils/logger';
 import { ExecutorSchema } from './schema';
@@ -34,7 +34,7 @@ export default async function executor(
 
   try {
     logger.info(
-      chalk`\n  {bold Running serverless framework deploy on project {bgBlue  ${context.projectName} }...}\n`,
+      chalkTemplate`\n  {bold Running serverless framework deploy on project {bgBlue  ${context.projectName} }...}\n`,
     );
 
     const distFolder = path.join(cwd, 'dist');
@@ -69,7 +69,7 @@ export default async function executor(
       success: true,
     };
   } catch (error) {
-    logger.info(chalk`\n  {bgRed.bold  ERROR } ${error.message}\n`);
+    logger.info(chalkTemplate`\n  {bgRed.bold  ERROR } ${error.message}\n`);
     return {
       success: false,
     };

--- a/packages/nx-python/src/executors/sls-package/executor.spec.ts
+++ b/packages/nx-python/src/executors/sls-package/executor.spec.ts
@@ -2,7 +2,7 @@ import { vi, MockInstance } from 'vitest';
 import { vol } from 'memfs';
 import '../../utils/mocks/fs.mock';
 import '../../utils/mocks/cross-spawn.mock';
-import chalk from 'chalk';
+import chalkTemplate from 'chalk-template';
 import * as poetryUtils from '../../provider/poetry/utils';
 import executor from './executor';
 import spawn from 'cross-spawn';
@@ -34,7 +34,7 @@ describe('Serverless Framework Package Executor', () => {
   };
 
   beforeAll(() => {
-    console.log(chalk`init chalk`);
+    console.log(chalkTemplate`init chalk`);
   });
 
   afterEach(() => {

--- a/packages/nx-python/src/executors/sls-package/executor.ts
+++ b/packages/nx-python/src/executors/sls-package/executor.ts
@@ -1,5 +1,5 @@
 import { ExecutorContext } from '@nx/devkit';
-import chalk from 'chalk';
+import chalkTemplate from 'chalk-template';
 import spawn from 'cross-spawn';
 import { Logger } from '../utils/logger';
 import { ExecutorSchema } from './schema';
@@ -34,7 +34,7 @@ export default async function executor(
 
   try {
     logger.info(
-      chalk`\n  {bold Running serverless framework deploy on project {bgBlue  ${context.projectName} }...}\n`,
+      chalkTemplate`\n  {bold Running serverless framework deploy on project {bgBlue  ${context.projectName} }...}\n`,
     );
 
     const distFolder = path.join(cwd, 'dist');
@@ -67,7 +67,7 @@ export default async function executor(
       success: true,
     };
   } catch (error) {
-    logger.info(chalk`\n  {bgRed.bold  ERROR } ${error.message}\n`);
+    logger.info(chalkTemplate`\n  {bgRed.bold  ERROR } ${error.message}\n`);
     return {
       success: false,
     };

--- a/packages/nx-python/src/executors/sync/executor.ts
+++ b/packages/nx-python/src/executors/sync/executor.ts
@@ -1,7 +1,7 @@
 import { SyncExecutorSchema } from './schema';
 import { Logger } from '../utils/logger';
 import { ExecutorContext } from '@nx/devkit';
-import chalk from 'chalk';
+import chalkTemplate from 'chalk-template';
 import { getProvider } from '../../provider';
 
 const logger = new Logger();
@@ -26,7 +26,7 @@ export default async function executor(
       success: true,
     };
   } catch (error) {
-    logger.info(chalk`\n  {bgRed.bold  ERROR } ${error.message}\n`);
+    logger.info(chalkTemplate`\n  {bgRed.bold  ERROR } ${error.message}\n`);
     return {
       success: false,
     };

--- a/packages/nx-python/src/executors/tox/executor.spec.ts
+++ b/packages/nx-python/src/executors/tox/executor.spec.ts
@@ -6,7 +6,7 @@ import * as poetryUtils from '../../provider/poetry/utils';
 import * as buildExecutor from '../build/executor';
 import { ToxExecutorSchema } from './schema';
 import executor from './executor';
-import chalk from 'chalk';
+import chalkTemplate from 'chalk-template';
 import spawn from 'cross-spawn';
 import { ExecutorContext } from '@nx/devkit';
 import { UVProvider } from '../../provider/uv';
@@ -41,7 +41,7 @@ describe('Tox Executor', () => {
   };
 
   beforeAll(() => {
-    console.log(chalk`init chalk`);
+    console.log(chalkTemplate`init chalk`);
   });
 
   beforeEach(() => {

--- a/packages/nx-python/src/executors/tox/executor.ts
+++ b/packages/nx-python/src/executors/tox/executor.ts
@@ -2,7 +2,7 @@ import { ExecutorContext } from '@nx/devkit';
 import { ToxExecutorSchema } from './schema';
 import buildExecutor from '../build/executor';
 import path from 'path';
-import chalk from 'chalk';
+import chalkTemplate from 'chalk-template';
 import { Logger } from '../utils/logger';
 import { readdirSync, existsSync } from 'fs-extra';
 import { getProvider } from '../../provider';
@@ -47,7 +47,9 @@ export default async function executor(
     }
 
     if (!existsSync(distFolder)) {
-      throw new Error(chalk`Folder {blue.bold ${distFolder}} not found`);
+      throw new Error(
+        chalkTemplate`Folder {blue.bold ${distFolder}} not found`,
+      );
     }
 
     const packageFile = readdirSync(distFolder).find((file) =>
@@ -56,7 +58,7 @@ export default async function executor(
 
     if (!packageFile) {
       throw new Error(
-        chalk`No package file {blue.bold *.tar.gz} found in the {bold ${distFolder}}`,
+        chalkTemplate`No package file {blue.bold *.tar.gz} found in the {bold ${distFolder}}`,
       );
     }
 
@@ -83,7 +85,7 @@ export default async function executor(
       success: true,
     };
   } catch (error) {
-    logger.info(chalk`\n  {bgRed.bold  ERROR } ${error.message}\n`);
+    logger.info(chalkTemplate`\n  {bgRed.bold  ERROR } ${error.message}\n`);
     return {
       success: false,
     };

--- a/packages/nx-python/src/executors/update/executor.spec.ts
+++ b/packages/nx-python/src/executors/update/executor.spec.ts
@@ -4,7 +4,7 @@ import '../../utils/mocks/fs.mock';
 import '../../utils/mocks/cross-spawn.mock';
 import * as poetryUtils from '../../provider/poetry/utils';
 import executor from './executor';
-import chalk from 'chalk';
+import chalkTemplate from 'chalk-template';
 import { parseToml } from '../../provider/poetry/utils';
 import dedent from 'string-dedent';
 import spawn from 'cross-spawn';
@@ -19,7 +19,7 @@ describe('Update Executor', () => {
   });
 
   beforeAll(() => {
-    console.log(chalk`init chalk`);
+    console.log(chalkTemplate`init chalk`);
   });
 
   describe('poetry', () => {

--- a/packages/nx-python/src/executors/update/executor.ts
+++ b/packages/nx-python/src/executors/update/executor.ts
@@ -1,5 +1,5 @@
 import { ExecutorContext } from '@nx/devkit';
-import chalk from 'chalk';
+import chalkTemplate from 'chalk-template';
 import { UpdateExecutorSchema } from './schema';
 import { getProvider } from '../../provider';
 
@@ -23,7 +23,7 @@ export default async function executor(
       success: true,
     };
   } catch (error) {
-    console.log(chalk`\n  {bgRed.bold  ERROR } ${error.message}\n`);
+    console.log(chalkTemplate`\n  {bgRed.bold  ERROR } ${error.message}\n`);
     return {
       success: false,
     };

--- a/packages/nx-python/src/generators/migrate-to-shared-venv/generator.ts
+++ b/packages/nx-python/src/generators/migrate-to-shared-venv/generator.ts
@@ -9,7 +9,7 @@ import {
 import path from 'path';
 import { Schema } from './schema';
 import { parse, stringify } from '@iarna/toml';
-import chalk from 'chalk';
+import chalkTemplate from 'chalk-template';
 import { PoetryPyprojectToml } from '../../provider/poetry';
 import { UVPyprojectToml } from '../../provider/uv/types';
 import { getProvider } from '../../provider';
@@ -124,10 +124,10 @@ function movePoetryDevDependencies(
 
   return async () => {
     console.log(
-      chalk`  Updating ${pyprojectToml.tool.poetry.name} {bgBlue poetry.lock}...`,
+      chalkTemplate`  Updating ${pyprojectToml.tool.poetry.name} {bgBlue poetry.lock}...`,
     );
     await provider.lock(projectConfig.root);
-    console.log(chalk`\n  {bgBlue poetry.lock} updated.\n`);
+    console.log(chalkTemplate`\n  {bgBlue poetry.lock} updated.\n`);
   };
 }
 

--- a/packages/nx-python/src/generators/poetry-project/generator.ts
+++ b/packages/nx-python/src/generators/poetry-project/generator.ts
@@ -7,7 +7,7 @@ import {
 } from '@nx/devkit';
 import * as path from 'path';
 import { parse, stringify } from '@iarna/toml';
-import chalk from 'chalk';
+import chalkTemplate from 'chalk-template';
 import _ from 'lodash';
 import {
   PoetryProvider,
@@ -202,10 +202,10 @@ async function updateRootPoetryLock(
   provider: BaseProvider<PoetryPyprojectToml>,
 ) {
   if (tree.exists('./pyproject.toml')) {
-    console.log(chalk`  Updating root {bgBlue poetry.lock}...`);
+    console.log(chalkTemplate`  Updating root {bgBlue poetry.lock}...`);
     await provider.lock();
     await provider.install();
-    console.log(chalk`\n  {bgBlue poetry.lock} updated.\n`);
+    console.log(chalkTemplate`\n  {bgBlue poetry.lock} updated.\n`);
   }
 }
 

--- a/packages/nx-python/src/generators/project/generator.ts
+++ b/packages/nx-python/src/generators/project/generator.ts
@@ -10,7 +10,7 @@ import {
 import path from 'path';
 import { Schema } from './schema';
 import { parse, stringify } from '@iarna/toml';
-import chalk from 'chalk';
+import chalkTemplate from 'chalk-template';
 import { PoetryPyprojectToml } from '../../provider/poetry';
 import { checkPoetryExecutable, runPoetry } from '../../provider/poetry/utils';
 
@@ -123,10 +123,10 @@ function updateRootPyprojectToml(
 
 function updateRootPoetryLock(host: Tree, normalizedOptions: NormalizedSchema) {
   if (host.exists('./pyproject.toml')) {
-    console.log(chalk`  Updating root {bgBlue poetry.lock}...`);
+    console.log(chalkTemplate`  Updating root {bgBlue poetry.lock}...`);
     const updateArgs = ['update', normalizedOptions.packageName];
     runPoetry(updateArgs, { log: false });
-    console.log(chalk`\n  {bgBlue poetry.lock} updated.\n`);
+    console.log(chalkTemplate`\n  {bgBlue poetry.lock} updated.\n`);
   }
 }
 

--- a/packages/nx-python/src/generators/uv-project/generator.ts
+++ b/packages/nx-python/src/generators/uv-project/generator.ts
@@ -8,7 +8,7 @@ import {
 } from '@nx/devkit';
 import * as path from 'path';
 import { parse, stringify } from '@iarna/toml';
-import chalk from 'chalk';
+import chalkTemplate from 'chalk-template';
 import _ from 'lodash';
 import { UVPyprojectToml } from '../../provider/uv/types';
 import { DEV_DEPENDENCIES_VERSION_MAP } from '../consts';
@@ -247,9 +247,9 @@ async function updateRootUvLock(
   provider: BaseProvider<UVPyprojectToml>,
 ) {
   if (tree.exists('pyproject.toml')) {
-    console.log(chalk`  Updating root {bgBlue uv.lock}...`);
+    console.log(chalkTemplate`  Updating root {bgBlue uv.lock}...`);
     await provider.install();
-    console.log(chalk`\n  {bgBlue uv.lock} updated.\n`);
+    console.log(chalkTemplate`\n  {bgBlue uv.lock} updated.\n`);
   }
 }
 

--- a/packages/nx-python/src/provider/base.spec.ts
+++ b/packages/nx-python/src/provider/base.spec.ts
@@ -6,7 +6,7 @@ import { PoetryProvider } from './poetry';
 import { PoetryPyprojectToml } from './poetry/types';
 import { Logger } from '../executors/utils/logger';
 import * as utils from './utils';
-import chalk from 'chalk';
+import chalkTemplate from 'chalk-template';
 import { ExecutorContext, Tree } from '@nx/devkit';
 import { MockInstance } from 'vitest';
 import path from 'path';
@@ -17,7 +17,7 @@ describe('Activate Venv', () => {
   let installMock: MockInstance;
 
   beforeAll(() => {
-    console.log(chalk`init chalk`);
+    console.log(chalkTemplate`init chalk`);
   });
 
   beforeEach(() => {

--- a/packages/nx-python/src/provider/base.ts
+++ b/packages/nx-python/src/provider/base.ts
@@ -16,7 +16,7 @@ import { SyncExecutorSchema } from '../executors/sync/schema';
 import { Logger } from '../executors/utils/logger';
 import path from 'path';
 import fs from 'fs';
-import chalk from 'chalk';
+import chalkTemplate from 'chalk-template';
 import { parse } from '@iarna/toml';
 import { getPyprojectData, readPyprojectToml } from './utils';
 
@@ -458,7 +458,7 @@ export abstract class BaseProvider<TPyprojectToml> {
           const autoActivate = rootConfig.tool.nx?.autoActivate ?? false;
           if (autoActivate) {
             console.log(
-              chalk`\n{bold shared virtual environment detected and not activated, activating...}\n\n`,
+              chalkTemplate`\n{bold shared virtual environment detected and not activated, activating...}\n\n`,
             );
             const virtualEnv = path.resolve(workspaceRoot, '.venv');
             this.setVenvEnvironmentVariables(virtualEnv);
@@ -478,7 +478,7 @@ export abstract class BaseProvider<TPyprojectToml> {
         const virtualEnv = path.resolve(baseDir, '.venv');
         if (!fs.existsSync(virtualEnv)) {
           this.logger.info(
-            chalk`\n  {bold Creating virtual environment in {bgBlue  ${baseDir} }...}\n`,
+            chalkTemplate`\n  {bold Creating virtual environment in {bgBlue  ${baseDir} }...}\n`,
           );
           await this.install(baseDir);
         }

--- a/packages/nx-python/src/provider/poetry/build/resolvers/locked.ts
+++ b/packages/nx-python/src/provider/poetry/build/resolvers/locked.ts
@@ -3,6 +3,7 @@ import { readFileSync, existsSync } from 'fs-extra';
 import path, { join, relative } from 'path';
 import { PoetryLock, PoetryLockPackage } from './types';
 import chalk from 'chalk';
+import chalkTemplate from 'chalk-template';
 import uri2path from 'file-uri-to-path';
 import { includeDependencyPackage, sanitizePackageName } from './utils';
 import { Logger } from '../../../../executors/utils/logger';
@@ -32,7 +33,7 @@ export class LockedDependencyResolver extends BaseDependencyResolver {
     devDependencies: boolean,
     workspaceRoot: string,
   ): PoetryPyprojectToml {
-    this.logger.info(chalk`  Resolving dependencies...`);
+    this.logger.info(chalkTemplate`  Resolving dependencies...`);
 
     const deps = this.resolveDependencies(
       devDependencies,
@@ -140,7 +141,7 @@ export class LockedDependencyResolver extends BaseDependencyResolver {
         dep.name = elements[0].split('==')[0];
         dep.version = elements[0].split('==')[1]?.trim();
         this.logger.info(
-          chalk`${tab}• Adding {blue.bold ${dep.name}==${dep.version}} dependency`,
+          chalkTemplate`${tab}• Adding {blue.bold ${dep.name}==${dep.version}} dependency`,
         );
         this.resolvePackageExtras(dep);
 
@@ -164,7 +165,7 @@ export class LockedDependencyResolver extends BaseDependencyResolver {
         );
 
         this.logger.info(
-          chalk`${tab}• Extra: {blue.bold ${extra}} - {blue.bold ${resolvedDeps.join(
+          chalkTemplate`${tab}• Extra: {blue.bold ${extra}} - {blue.bold ${resolvedDeps.join(
             ', ',
           )}} Locked Dependencies`,
         );
@@ -195,7 +196,7 @@ export class LockedDependencyResolver extends BaseDependencyResolver {
     ) {
       const warning = chalk.bgHex('#FFA500');
       console.log(
-        chalk`{bold ${warning(' WARNING ')} Poetry export plugin is not installed, installing it now...}`,
+        chalkTemplate`{bold ${warning(' WARNING ')} Poetry export plugin is not installed, installing it now...}`,
       );
 
       runPoetry(['self', 'add', 'poetry-plugin-export'], { cwd: root });
@@ -270,7 +271,7 @@ export class LockedDependencyResolver extends BaseDependencyResolver {
       const pyprojectToml = path.join(location, 'pyproject.toml');
       if (!existsSync(pyprojectToml)) {
         throw new Error(
-          chalk`pyproject.toml not found in {blue.bold ${location}}`,
+          chalkTemplate`pyproject.toml not found in {blue.bold ${location}}`,
         );
       }
 
@@ -309,7 +310,7 @@ export class LockedDependencyResolver extends BaseDependencyResolver {
     );
     if (!lockedPkg) {
       throw new Error(
-        chalk`Package {blue.bold ${resolvedPkgName}} not found in poetry.lock`,
+        chalkTemplate`Package {blue.bold ${resolvedPkgName}} not found in poetry.lock`,
       );
     }
     return lockedPkg;
@@ -329,7 +330,7 @@ export class LockedDependencyResolver extends BaseDependencyResolver {
       readFileSync(pyprojectToml).toString('utf-8'),
     ) as PoetryPyprojectToml;
     this.logger.info(
-      chalk`${tab}• Adding {blue.bold ${packageName}} local dependency`,
+      chalkTemplate`${tab}• Adding {blue.bold ${packageName}} local dependency`,
     );
     includeDependencyPackage(
       tomlData,
@@ -353,7 +354,7 @@ export class LockedDependencyResolver extends BaseDependencyResolver {
     }
 
     this.logger.info(
-      chalk`${tab}• Adding {blue.bold ${dep.name}==${dep.git}@${lockedPkg.source.reference}} dependency`,
+      chalkTemplate`${tab}• Adding {blue.bold ${dep.name}==${dep.git}@${lockedPkg.source.reference}} dependency`,
     );
 
     deps.push(dep);
@@ -368,7 +369,7 @@ export class LockedDependencyResolver extends BaseDependencyResolver {
     const tab = getLoggingTab(level);
     for (const dep of deps) {
       this.logger.info(
-        chalk`${tab}• Resolving dependency: {blue.bold ${dep.name}}`,
+        chalkTemplate`${tab}• Resolving dependency: {blue.bold ${dep.name}}`,
       );
       if (
         dep.source?.type !== 'directory' &&
@@ -389,7 +390,7 @@ export class LockedDependencyResolver extends BaseDependencyResolver {
       optionalPkgDeps.forEach((pkgDep) => resolvedDeps.push(pkgDep.name));
       if (optionalPkgDeps.length > 0) {
         this.logger.info(
-          chalk`${tab}• Resolved Dependencies: {blue.bold ${optionalPkgDeps
+          chalkTemplate`${tab}• Resolved Dependencies: {blue.bold ${optionalPkgDeps
             .map((pkgDep) => pkgDep.name)
             .join(' ')}}`,
         );

--- a/packages/nx-python/src/provider/poetry/build/resolvers/project.ts
+++ b/packages/nx-python/src/provider/poetry/build/resolvers/project.ts
@@ -1,4 +1,4 @@
-import chalk from 'chalk';
+import chalkTemplate from 'chalk-template';
 import { join, normalize, relative, resolve } from 'path';
 import { readFileSync } from 'fs-extra';
 import { parse } from '@iarna/toml';
@@ -53,7 +53,7 @@ export class ProjectDependencyResolver extends BaseDependencyResolver {
     buildFolderPath: string,
     buildTomlData: PoetryPyprojectToml,
   ): PoetryPyprojectToml {
-    this.logger.info(chalk`  Resolving dependencies...`);
+    this.logger.info(chalkTemplate`  Resolving dependencies...`);
 
     return this.updatePyproject(root, buildTomlData, buildFolderPath);
   }
@@ -122,7 +122,7 @@ export class ProjectDependencyResolver extends BaseDependencyResolver {
       if (typeof data === 'string') {
         if (!loggedDependencies) {
           this.logger.info(
-            chalk`${tab}• Adding {blue.bold ${name}@${data}} dependency`,
+            chalkTemplate`${tab}• Adding {blue.bold ${name}@${data}} dependency`,
           );
           loggedDependencies.push(name);
         }
@@ -155,7 +155,7 @@ export class ProjectDependencyResolver extends BaseDependencyResolver {
           // Log the dependency being added (avoid duplicates)
           if (!loggedDependencies.includes(packageName)) {
             this.logger.info(
-              chalk`${tab}• Adding {blue.bold ${packageName}} local dependency`,
+              chalkTemplate`${tab}• Adding {blue.bold ${packageName}} local dependency`,
             );
             loggedDependencies.push(packageName);
           }
@@ -235,7 +235,7 @@ export class ProjectDependencyResolver extends BaseDependencyResolver {
 
               if (!loggedDependencies.includes(depName)) {
                 this.logger.info(
-                  chalk`${tab}• Adding {blue.bold ${depName}@${typeof depData === 'string' ? depData : depData.version}} dependency`,
+                  chalkTemplate`${tab}• Adding {blue.bold ${depName}@${typeof depData === 'string' ? depData : depData.version}} dependency`,
                 );
                 loggedDependencies.push(depName);
               }
@@ -328,7 +328,7 @@ export class ProjectDependencyResolver extends BaseDependencyResolver {
 
           if (!loggedDependencies.includes(name)) {
             this.logger.info(
-              chalk`${tab}• Adding {blue.bold ${name}@${depPyproject.tool.poetry.version}} local dependency`,
+              chalkTemplate`${tab}• Adding {blue.bold ${name}@${depPyproject.tool.poetry.version}} local dependency`,
             );
             loggedDependencies.push(name);
           }
@@ -337,7 +337,7 @@ export class ProjectDependencyResolver extends BaseDependencyResolver {
         // Step 7: This is an external dependency - just log it
         if (!loggedDependencies.includes(name)) {
           this.logger.info(
-            chalk`${tab}• Adding {blue.bold ${name}${data.version ? `@${data.version}` : data.git ? ` ${data.git}@${data.rev}` : ''}} dependency`,
+            chalkTemplate`${tab}• Adding {blue.bold ${name}${data.version ? `@${data.version}` : data.git ? ` ${data.git}@${data.rev}` : ''}} dependency`,
           );
           loggedDependencies.push(name);
         }
@@ -458,7 +458,7 @@ export class ProjectDependencyResolver extends BaseDependencyResolver {
       const newName = `${name}-${hash}`;
 
       this.logger.info(
-        chalk`  Duplicate source for {blue.bold ${name}} renamed to ${newName}`,
+        chalkTemplate`  Duplicate source for {blue.bold ${name}} renamed to ${newName}`,
       );
 
       if (sources.find((s) => s.name === newName)) {

--- a/packages/nx-python/src/provider/poetry/provider.ts
+++ b/packages/nx-python/src/provider/poetry/provider.ts
@@ -29,7 +29,7 @@ import {
   runPoetry,
   RunPoetryOptions,
 } from './utils';
-import chalk from 'chalk';
+import chalkTemplate from 'chalk-template';
 import { parse, stringify } from '@iarna/toml';
 import { setTableStringValue } from '../toml-edit';
 import { SpawnSyncOptions } from 'child_process';
@@ -296,7 +296,7 @@ export class PoetryProvider extends BaseProvider<PoetryPyprojectToml> {
 
     if (options.local) {
       this.logger.info(
-        chalk`\n  {bold Adding {bgBlue  ${options.name} } workspace dependency...}\n`,
+        chalkTemplate`\n  {bold Adding {bgBlue  ${options.name} } workspace dependency...}\n`,
       );
       await this.updateLocalProject(
         context,
@@ -309,7 +309,7 @@ export class PoetryProvider extends BaseProvider<PoetryPyprojectToml> {
       );
     } else {
       this.logger.info(
-        chalk`\n  {bold Adding {bgBlue  ${options.name} } dependency...}\n`,
+        chalkTemplate`\n  {bold Adding {bgBlue  ${options.name} } dependency...}\n`,
       );
       const installArgs = ['add', options.name]
         .concat(options.group ? ['--group', options.group] : [])
@@ -325,7 +325,7 @@ export class PoetryProvider extends BaseProvider<PoetryPyprojectToml> {
     await this.updateDependencyTree(context);
 
     this.logger.info(
-      chalk`\n  {green.bold '${options.name}'} {green dependency has been successfully added to the project}\n`,
+      chalkTemplate`\n  {green.bold '${options.name}'} {green dependency has been successfully added to the project}\n`,
     );
   }
 
@@ -426,7 +426,7 @@ export class PoetryProvider extends BaseProvider<PoetryPyprojectToml> {
 
     if (options.local && options.name) {
       this.logger.info(
-        chalk`\n  {bold Updating {bgBlue  ${options.name} } workspace dependency...}\n`,
+        chalkTemplate`\n  {bold Updating {bgBlue  ${options.name} } workspace dependency...}\n`,
       );
 
       if (
@@ -435,7 +435,7 @@ export class PoetryProvider extends BaseProvider<PoetryPyprojectToml> {
         )
       ) {
         throw new Error(
-          chalk`\n  {red.bold ${options.name}} workspace project does not exist\n`,
+          chalkTemplate`\n  {red.bold ${options.name}} workspace project does not exist\n`,
         );
       }
 
@@ -443,10 +443,12 @@ export class PoetryProvider extends BaseProvider<PoetryPyprojectToml> {
     } else {
       if (options.name) {
         this.logger.info(
-          chalk`\n  {bold Updating {bgBlue  ${options.name} } dependency...}\n`,
+          chalkTemplate`\n  {bold Updating {bgBlue  ${options.name} } dependency...}\n`,
         );
       } else {
-        this.logger.info(chalk`\n  {bold Updating project dependencies...}\n`);
+        this.logger.info(
+          chalkTemplate`\n  {bold Updating project dependencies...}\n`,
+        );
       }
 
       const updateArgs = ['update']
@@ -459,7 +461,7 @@ export class PoetryProvider extends BaseProvider<PoetryPyprojectToml> {
     await this.updateDependencyTree(context);
 
     this.logger.info(
-      chalk`\n  {green.bold '${options.name}'} {green dependency has been successfully added to the project}\n`,
+      chalkTemplate`\n  {green.bold '${options.name}'} {green dependency has been successfully added to the project}\n`,
     );
   }
 
@@ -477,7 +479,7 @@ export class PoetryProvider extends BaseProvider<PoetryPyprojectToml> {
     const projectConfig =
       context.projectsConfigurations.projects[context.projectName];
     this.logger.info(
-      chalk`\n  {bold Removing {bgBlue  ${options.name} } dependency...}\n`,
+      chalkTemplate`\n  {bold Removing {bgBlue  ${options.name} } dependency...}\n`,
     );
 
     let dependencyName = options.name;
@@ -505,7 +507,7 @@ export class PoetryProvider extends BaseProvider<PoetryPyprojectToml> {
     await this.updateDependencyTree(context);
 
     this.logger.info(
-      chalk`\n  {green.bold '${options.name}'} {green dependency has been successfully removed}\n`,
+      chalkTemplate`\n  {green.bold '${options.name}'} {green dependency has been successfully removed}\n`,
     );
   }
 
@@ -546,7 +548,7 @@ export class PoetryProvider extends BaseProvider<PoetryPyprojectToml> {
       }
 
       this.logger.info(
-        chalk`\n  {bold Publishing project {bgBlue  ${context.projectName} }...}\n`,
+        chalkTemplate`\n  {bold Publishing project {bgBlue  ${context.projectName} }...}\n`,
       );
 
       const commandArgs = [
@@ -562,9 +564,9 @@ export class PoetryProvider extends BaseProvider<PoetryPyprojectToml> {
       const commandStr = `${POETRY_EXECUTABLE} ${commandArgs.join(' ')}`;
 
       this.logger.info(
-        chalk`{bold Running command}: ${commandStr} ${
+        chalkTemplate`{bold Running command}: ${commandStr} ${
           buildFolderPath && buildFolderPath !== '.'
-            ? chalk`at {bold ${buildFolderPath}} folder`
+            ? chalkTemplate`at {bold ${buildFolderPath}} folder`
             : ''
         }\n`,
       );
@@ -579,7 +581,7 @@ export class PoetryProvider extends BaseProvider<PoetryPyprojectToml> {
       if (typeof error === 'object' && 'code' in error && 'output' in error) {
         if (error.code !== 0 && error.output.includes('File already exists')) {
           this.logger.info(
-            chalk`\n  {bgYellow.bold  WARNING } {bold The package is already published}\n`,
+            chalkTemplate`\n  {bgYellow.bold  WARNING } {bold The package is already published}\n`,
           );
 
           return;
@@ -811,7 +813,7 @@ export class PoetryProvider extends BaseProvider<PoetryPyprojectToml> {
     }
 
     this.logger.info(
-      chalk`\n  {bold Building project {bgBlue  ${context.projectName} }...}\n`,
+      chalkTemplate`\n  {bold Building project {bgBlue  ${context.projectName} }...}\n`,
     );
 
     const { root } =
@@ -822,7 +824,9 @@ export class PoetryProvider extends BaseProvider<PoetryPyprojectToml> {
 
     mkdirSync(buildFolderPath, { recursive: true });
 
-    this.logger.info(chalk`  Copying project files to a temporary folder`);
+    this.logger.info(
+      chalkTemplate`  Copying project files to a temporary folder`,
+    );
     readdirSync(root).forEach((file) => {
       if (
         !options.ignorePaths.some((pattern) =>
@@ -870,7 +874,7 @@ export class PoetryProvider extends BaseProvider<PoetryPyprojectToml> {
     removeSync(distFolder);
 
     if (!options.skipBuild) {
-      this.logger.info(chalk`  Generating sdist and wheel artifacts`);
+      this.logger.info(chalkTemplate`  Generating sdist and wheel artifacts`);
       const buildArgs = ['build'];
       if (options.format) {
         buildArgs.push('--format', options.format);
@@ -881,7 +885,7 @@ export class PoetryProvider extends BaseProvider<PoetryPyprojectToml> {
       removeSync(options.outputPath);
       mkdirSync(options.outputPath, { recursive: true });
       this.logger.info(
-        chalk`  Artifacts generated at {bold ${options.outputPath}} folder`,
+        chalkTemplate`  Artifacts generated at {bold ${options.outputPath}} folder`,
       );
       copySync(distFolder, options.outputPath);
     }
@@ -984,7 +988,7 @@ export class PoetryProvider extends BaseProvider<PoetryPyprojectToml> {
 
       if (allRootDependencyNames.includes(pkgName)) {
         this.logger.info(
-          chalk`\nUpdating root {bold pyproject.toml} dependency {bold ${pkgName}}`,
+          chalkTemplate`\nUpdating root {bold pyproject.toml} dependency {bold ${pkgName}}`,
         );
 
         await this.lock();
@@ -1018,7 +1022,7 @@ export class PoetryProvider extends BaseProvider<PoetryPyprojectToml> {
         continue;
       }
 
-      this.logger.info(chalk`\nUpdating project {bold ${dep}}`);
+      this.logger.info(chalkTemplate`\nUpdating project {bold ${dep}}`);
       const depConfig = workspace.projects[dep];
 
       await this.updateProject(depConfig.root, updateLockOnly);

--- a/packages/nx-python/src/provider/poetry/utils.spec.ts
+++ b/packages/nx-python/src/provider/poetry/utils.spec.ts
@@ -11,13 +11,13 @@ vi.mock('command-exists', () => {
 });
 
 import * as poetryUtils from './utils';
-import chalk from 'chalk';
+import chalkTemplate from 'chalk-template';
 import spawn from 'cross-spawn';
 import commandExists from 'command-exists';
 
 describe('Poetry Utils', () => {
   beforeAll(() => {
-    console.log(chalk`init chalk`);
+    console.log(chalkTemplate`init chalk`);
   });
 
   afterEach(() => {

--- a/packages/nx-python/src/provider/poetry/utils.ts
+++ b/packages/nx-python/src/provider/poetry/utils.ts
@@ -1,5 +1,5 @@
 import { ExecutorContext, ProjectConfiguration, Tree } from '@nx/devkit';
-import chalk from 'chalk';
+import chalkTemplate from 'chalk-template';
 import spawn from 'cross-spawn';
 import path from 'path';
 import toml from '@iarna/toml';
@@ -140,9 +140,9 @@ export function runPoetry(
 
   if (log) {
     console.log(
-      chalk`{bold Running command}: ${commandStr} ${
+      chalkTemplate`{bold Running command}: ${commandStr} ${
         options.cwd && options.cwd !== '.'
-          ? chalk`at {bold ${options.cwd}} folder`
+          ? chalkTemplate`at {bold ${options.cwd}} folder`
           : ''
       }\n`,
     );
@@ -156,7 +156,7 @@ export function runPoetry(
 
   if (error && result.status !== 0) {
     throw new Error(
-      chalk`{bold ${commandStr}} command failed with exit code {bold ${result.status}}`,
+      chalkTemplate`{bold ${commandStr}} command failed with exit code {bold ${result.status}}`,
     );
   }
 }

--- a/packages/nx-python/src/provider/utils.ts
+++ b/packages/nx-python/src/provider/utils.ts
@@ -1,6 +1,6 @@
 import toml, { JsonMap } from '@iarna/toml';
 import { ExecutorContext, Tree } from '@nx/devkit';
-import chalk from 'chalk';
+import chalkTemplate from 'chalk-template';
 import { existsSync, readFileSync } from 'fs';
 import { sep } from 'node:path';
 
@@ -49,7 +49,7 @@ export function getLocalDependencyConfig(
     context.projectsConfigurations.projects[dependencyName];
   if (!dependencyConfig) {
     throw new Error(
-      chalk`project {bold ${dependencyName}} not found in the Nx workspace`,
+      chalkTemplate`project {bold ${dependencyName}} not found in the Nx workspace`,
     );
   }
   return dependencyConfig;

--- a/packages/nx-python/src/provider/uv/build/resolvers/locked.ts
+++ b/packages/nx-python/src/provider/uv/build/resolvers/locked.ts
@@ -1,5 +1,5 @@
 import path from 'path';
-import chalk from 'chalk';
+import chalkTemplate from 'chalk-template';
 import { Logger } from '../../../../executors/utils/logger';
 import { UVLockfile, UVLockfilePackage, UVPyprojectToml } from '../../types';
 import { getUvLockfile, getUvVersion, UV_EXECUTABLE } from '../../utils';
@@ -31,7 +31,7 @@ export class LockedDependencyResolver {
   ): UVPyprojectToml {
     const tab = getLoggingTab(1);
     const result: PackageDependency[] = [];
-    this.logger.info(chalk`  Resolving dependencies...`);
+    this.logger.info(chalkTemplate`  Resolving dependencies...`);
 
     const requirementsTxt = this.getProjectRequirementsTxt(
       devDependencies,
@@ -58,7 +58,7 @@ export class LockedDependencyResolver {
 
         if (!existsSync(dependencyPyprojectPath)) {
           this.logger.info(
-            chalk`    • Skipping local dependency {blue.bold ${dependencyPath}} as pyproject.toml not found`,
+            chalkTemplate`    • Skipping local dependency {blue.bold ${dependencyPath}} as pyproject.toml not found`,
           );
           continue;
         }
@@ -68,7 +68,7 @@ export class LockedDependencyResolver {
         );
 
         this.logger.info(
-          chalk`    • Adding {blue.bold ${projectData.project.name}} local dependency`,
+          chalkTemplate`    • Adding {blue.bold ${projectData.project.name}} local dependency`,
         );
 
         includeDependencyPackage(
@@ -83,7 +83,7 @@ export class LockedDependencyResolver {
       }
 
       this.logger.info(
-        chalk`    • Adding {blue.bold ${line.trim()}} dependency`,
+        chalkTemplate`    • Adding {blue.bold ${line.trim()}} dependency`,
       );
 
       result.push({
@@ -107,7 +107,7 @@ export class LockedDependencyResolver {
         .length > 0
     ) {
       if (!this.lockFileExists(projectRoot, workspaceRoot)) {
-        throw new Error(chalk`{bold uv.lock file not found`);
+        throw new Error(chalkTemplate`{bold uv.lock file not found`);
       }
 
       const lockData = getUvLockfile(
@@ -117,7 +117,7 @@ export class LockedDependencyResolver {
       );
 
       if (!lockData) {
-        throw new Error(chalk`{bold failed to get uv.lock file}`);
+        throw new Error(chalkTemplate`{bold failed to get uv.lock file}`);
       }
 
       for (const extra in buildTomlData.project['optional-dependencies']) {
@@ -149,7 +149,7 @@ export class LockedDependencyResolver {
         );
 
         this.logger.info(
-          chalk`${tab}• Extra: {blue.bold ${extra}} - {blue.bold ${resolvedDeps.join(
+          chalkTemplate`${tab}• Extra: {blue.bold ${extra}} - {blue.bold ${resolvedDeps.join(
             ', ',
           )}} Locked Dependencies`,
         );
@@ -196,7 +196,7 @@ export class LockedDependencyResolver {
 
       if (lockCmd.status !== 0) {
         throw new Error(
-          chalk`{bold failed to generate uv.lock file with exit code {bold ${lockCmd.status}}}`,
+          chalkTemplate`{bold failed to generate uv.lock file with exit code {bold ${lockCmd.status}}}`,
         );
       }
     }
@@ -209,7 +209,7 @@ export class LockedDependencyResolver {
 
     if (result.status !== 0) {
       throw new Error(
-        chalk`{bold failed to export requirements txt with exit code {bold ${result.status}}}`,
+        chalkTemplate`{bold failed to export requirements txt with exit code {bold ${result.status}}}`,
       );
     }
 
@@ -238,7 +238,7 @@ export class LockedDependencyResolver {
     const tab = getLoggingTab(level);
     for (const [dep, extras] of deps) {
       this.logger.info(
-        chalk`${tab}• Resolving dependency: {blue.bold ${dep.name}}`,
+        chalkTemplate`${tab}• Resolving dependency: {blue.bold ${dep.name}}`,
       );
 
       if (dep.source.editable) {
@@ -260,7 +260,7 @@ export class LockedDependencyResolver {
           );
 
           this.logger.info(
-            chalk`    • Adding {blue.bold ${projectData.project.name}} local dependency`,
+            chalkTemplate`    • Adding {blue.bold ${projectData.project.name}} local dependency`,
           );
 
           includeDependencyPackage(
@@ -308,7 +308,7 @@ export class LockedDependencyResolver {
             });
 
             this.logger.info(
-              chalk`${tab}• Resolving extra: {blue.bold ${extra}} - {blue.bold ${pkgDeps
+              chalkTemplate`${tab}• Resolving extra: {blue.bold ${extra}} - {blue.bold ${pkgDeps
                 .map(([pkgDep]) => pkgDep.name)
                 .join(', ')}} Locked Dependencies`,
             );

--- a/packages/nx-python/src/provider/uv/build/resolvers/project.ts
+++ b/packages/nx-python/src/provider/uv/build/resolvers/project.ts
@@ -1,4 +1,4 @@
-import chalk from 'chalk';
+import chalkTemplate from 'chalk-template';
 import path, { join, relative, resolve } from 'path';
 import { existsSync } from 'fs-extra';
 import { UVLockfile, UVPyprojectToml, UVPyprojectTomlIndex } from '../../types';
@@ -60,7 +60,7 @@ export class ProjectDependencyResolver {
     buildTomlData: UVPyprojectToml,
     workspaceRoot: string,
   ): UVPyprojectToml {
-    this.logger.info(chalk`  Resolving dependencies...`);
+    this.logger.info(chalkTemplate`  Resolving dependencies...`);
 
     return this.updatePyproject(
       projectRoot,
@@ -162,7 +162,7 @@ export class ProjectDependencyResolver {
 
         if (!existsSync(dependencyPyprojectPath)) {
           this.logger.info(
-            chalk`${tab}• Skipping local dependency {blue.bold ${dependency}} as pyproject.toml not found`,
+            chalkTemplate`${tab}• Skipping local dependency {blue.bold ${dependency}} as pyproject.toml not found`,
           );
           continue;
         }
@@ -188,7 +188,7 @@ export class ProjectDependencyResolver {
           // Log the dependency being added (avoid duplicates)
           if (!loggedDependencies.includes(dependency)) {
             this.logger.info(
-              chalk`${tab}• Adding {blue.bold ${dependency}} local dependency`,
+              chalkTemplate`${tab}• Adding {blue.bold ${dependency}} local dependency`,
             );
             loggedDependencies.push(dependency);
           }
@@ -399,7 +399,7 @@ export class ProjectDependencyResolver {
 
               if (!loggedDependencies.includes(depName)) {
                 this.logger.info(
-                  chalk`${tab}• Adding {blue.bold ${depName}} dependency`,
+                  chalkTemplate`${tab}• Adding {blue.bold ${depName}} dependency`,
                 );
                 loggedDependencies.push(depName);
               }
@@ -428,7 +428,7 @@ export class ProjectDependencyResolver {
 
           if (!loggedDependencies.includes(depName)) {
             this.logger.info(
-              chalk`${tab}• Adding {blue.bold ${depName}} local dependency`,
+              chalkTemplate`${tab}• Adding {blue.bold ${depName}} local dependency`,
             );
             loggedDependencies.push(depName);
           }
@@ -437,7 +437,7 @@ export class ProjectDependencyResolver {
         // Step 7: This is an external dependency - just log it
         if (!loggedDependencies.includes(dependency)) {
           this.logger.info(
-            chalk`${tab}• Adding {blue.bold ${dependency}} dependency`,
+            chalkTemplate`${tab}• Adding {blue.bold ${dependency}} dependency`,
           );
           loggedDependencies.push(dependency);
         }
@@ -694,7 +694,7 @@ export class ProjectDependencyResolver {
       const newName = `${name}-${hash}`;
 
       this.logger.info(
-        chalk`  Duplicate index for {blue.bold ${name}} renamed to ${newName}`,
+        chalkTemplate`  Duplicate index for {blue.bold ${name}} renamed to ${newName}`,
       );
 
       if (indexes.find((s) => s.name === newName)) {

--- a/packages/nx-python/src/provider/uv/provider.ts
+++ b/packages/nx-python/src/provider/uv/provider.ts
@@ -33,7 +33,7 @@ import {
   UV_EXECUTABLE,
 } from './utils';
 import path, { join } from 'path';
-import chalk from 'chalk';
+import chalkTemplate from 'chalk-template';
 import { copySync, removeSync, writeFileSync } from 'fs-extra';
 import {
   getLocalDependencyConfig,
@@ -691,12 +691,12 @@ export class UVProvider extends BaseProvider<UVPyprojectToml> {
       }
 
       this.logger.info(
-        chalk`\n  {bold Publishing project {bgBlue  ${context.projectName} }...}\n`,
+        chalkTemplate`\n  {bold Publishing project {bgBlue  ${context.projectName} }...}\n`,
       );
 
       if (options.dryRun) {
         this.logger.info(
-          chalk`\n  {bgYellow.bold  WARNING } {bold Dry run is currently not supported by uv}\n`,
+          chalkTemplate`\n  {bgYellow.bold  WARNING } {bold Dry run is currently not supported by uv}\n`,
         );
       }
 
@@ -878,7 +878,7 @@ export class UVProvider extends BaseProvider<UVPyprojectToml> {
     }
 
     this.logger.info(
-      chalk`\n  {bold Building project {bgBlue  ${context.projectName} }...}\n`,
+      chalkTemplate`\n  {bold Building project {bgBlue  ${context.projectName} }...}\n`,
     );
 
     const projectRoot = this.getProjectRoot(context);
@@ -888,7 +888,9 @@ export class UVProvider extends BaseProvider<UVPyprojectToml> {
 
     mkdirSync(buildFolderPath, { recursive: true });
 
-    this.logger.info(chalk`  Copying project files to a temporary folder`);
+    this.logger.info(
+      chalkTemplate`  Copying project files to a temporary folder`,
+    );
     readdirSync(projectRoot).forEach((file) => {
       if (
         !options.ignorePaths.some((pattern) =>
@@ -927,7 +929,7 @@ export class UVProvider extends BaseProvider<UVPyprojectToml> {
     removeSync(distFolder);
 
     if (!options.skipBuild) {
-      this.logger.info(chalk`  Generating sdist and wheel artifacts`);
+      this.logger.info(chalkTemplate`  Generating sdist and wheel artifacts`);
       const buildArgs = ['build'];
       if (options.format) {
         buildArgs.push(`--${options.format}`);
@@ -938,7 +940,7 @@ export class UVProvider extends BaseProvider<UVPyprojectToml> {
       removeSync(options.outputPath);
       mkdirSync(options.outputPath, { recursive: true });
       this.logger.info(
-        chalk`  Artifacts generated at {bold ${options.outputPath}} folder`,
+        chalkTemplate`  Artifacts generated at {bold ${options.outputPath}} folder`,
       );
       copySync(distFolder, options.outputPath);
     }
@@ -1127,7 +1129,7 @@ export class UVProvider extends BaseProvider<UVPyprojectToml> {
         continue;
       }
 
-      this.logger.info(chalk`\nUpdating project {bold ${dep}}`);
+      this.logger.info(chalkTemplate`\nUpdating project {bold ${dep}}`);
       const depConfig = context.projectsConfigurations.projects[dep];
       runUv(['sync'], {
         cwd: depConfig.root,

--- a/packages/nx-python/src/provider/uv/utils.ts
+++ b/packages/nx-python/src/provider/uv/utils.ts
@@ -1,4 +1,4 @@
-import chalk from 'chalk';
+import chalkTemplate from 'chalk-template';
 import { SpawnSyncOptions } from 'child_process';
 import commandExists from 'command-exists';
 import spawn from 'cross-spawn';
@@ -35,9 +35,9 @@ export function runUv(args: string[], options: RunUvOptions = {}): void {
 
   if (log) {
     console.log(
-      chalk`{bold Running command}: ${commandStr} ${
+      chalkTemplate`{bold Running command}: ${commandStr} ${
         options.cwd && options.cwd !== '.'
-          ? chalk`at {bold ${options.cwd}} folder`
+          ? chalkTemplate`at {bold ${options.cwd}} folder`
           : ''
       }\n`,
     );
@@ -51,7 +51,7 @@ export function runUv(args: string[], options: RunUvOptions = {}): void {
 
   if (error && result.status !== 0) {
     throw new Error(
-      chalk`{bold ${commandStr}} command failed with exit code {bold ${result.status}}`,
+      chalkTemplate`{bold ${commandStr}} command failed with exit code {bold ${result.status}}`,
     );
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -62,6 +62,9 @@ importers:
       chalk:
         specifier: ^5.6.2
         version: 5.6.2
+      chalk-template:
+        specifier: ^1.1.2
+        version: 1.1.2
       command-exists:
         specifier: ^1.2.9
         version: 1.2.9
@@ -355,6 +358,9 @@ importers:
       chalk:
         specifier: ^5.6.2
         version: 5.6.2
+      chalk-template:
+        specifier: ^1.1.2
+        version: 1.1.2
       command-exists:
         specifier: ^1.2.9
         version: 1.2.9
@@ -3670,6 +3676,10 @@ packages:
   chai@6.2.2:
     resolution: {integrity: sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==}
     engines: {node: '>=18'}
+
+  chalk-template@1.1.2:
+    resolution: {integrity: sha512-2bxTP2yUH7AJj/VAXfcA+4IcWGdQ87HwBANLt5XxGTeomo8yG0y95N1um9i5StvhT/Bl0/2cARA5v1PpPXUxUA==}
+    engines: {node: '>=14.16'}
 
   chalk@2.4.2:
     resolution: {integrity: sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==}
@@ -11850,6 +11860,10 @@ snapshots:
 
   chai@6.2.2: {}
 
+  chalk-template@1.1.2:
+    dependencies:
+      chalk: 5.6.2
+
   chalk@2.4.2:
     dependencies:
       ansi-styles: 3.2.1
@@ -13839,7 +13853,7 @@ snapshots:
       jest-message-util: 30.3.0
       jest-util: 30.3.0
       pretty-format: 30.3.0
-      semver: 7.7.4
+      semver: 7.8.5
       synckit: 0.11.12
     transitivePeerDependencies:
       - supports-color


### PR DESCRIPTION
## Current Behavior

Since the chalk 5 upgrade, every log line in `@nxlv/python` prints the raw chalk template instead of styled text, e.g. `{bold Building PROJECT {bgBlue  , }...}`. chalk 5 removed tagged-template support, and the plugin has 132 `chalk\`{bold ...}\`` call sites across executors, generators and providers, so the whole executor output is garbled. No test observed the rendered output, so the regression went unnoticed.

Separately, the `production` named input in `nx.json` contains `!{projectRoot}/**/?(*.)+(mock).[jt]s?(x)?`, which has a dangling `?` after the extglob group. Nx's native glob converter turns that exclusion into a match-everything rule, so every project's fileset hashes as empty. `nx run nx-python:build` (and any target using `production` / `^production`) keeps hitting the cache even after source files change.

## Expected Behavior

- Log output from all executors, generators and providers is rendered again (bold, background colours, etc.). Tagged-template calls now go through the `chalk-template` package, which is chalk 5's home for the `{style ...}` syntax; the plain `chalk` import is kept only where `chalk.bgHex` is used.
- The build executor spec spies on `console.info` and fails if any logged message still contains a raw template token, so this cannot regress silently.
- The mock exclusion pattern is `!{projectRoot}/**/?(*.)+(mock).[jt]s?(x)`. Build inputs are hashed from the real fileset, so editing a source file invalidates the `build` cache and unchanged runs still hit it.

## Related Issue(s)

Fixes #
